### PR TITLE
Export iterator for SetNodeMap

### DIFF
--- a/fieldpath/set.go
+++ b/fieldpath/set.go
@@ -290,6 +290,13 @@ func (s *SetNodeMap) Difference(s2 *Set) *SetNodeMap {
 	return out
 }
 
+// Iterate calls f for each PathElement in the set.
+func (s *SetNodeMap) Iterate(f func(PathElement)) {
+	for _, n := range s.members {
+		f(n.pathElement)
+	}
+}
+
 func (s *SetNodeMap) iteratePrefix(prefix Path, f func(Path)) {
 	for _, n := range s.members {
 		pe := n.pathElement

--- a/fieldpath/set_test.go
+++ b/fieldpath/set_test.go
@@ -334,3 +334,29 @@ func TestSetIntersectionDifference(t *testing.T) {
 		}
 	})
 }
+
+func TestSetNodeMapIterate(t *testing.T) {
+	set := &SetNodeMap{}
+	toAdd := 5
+	addedElements := make([]string, toAdd)
+	for i := 0; i < toAdd; i++ {
+		p := i
+		pe := PathElement{Index: &p}
+		addedElements[i] = pe.String()
+		_ = set.Descend(pe)
+	}
+
+	iteratedElements := make(map[string]bool, toAdd)
+	set.Iterate(func(pe PathElement) {
+		iteratedElements[pe.String()] = true
+	})
+
+	if len(iteratedElements) != toAdd {
+		t.Errorf("expected %v elements to be iterated over, got %v", toAdd, len(iteratedElements))
+	}
+	for _, pe := range addedElements {
+		if _, ok := iteratedElements[pe]; !ok {
+			t.Errorf("expected to have iterated over %v, but never did", pe)
+		}
+	}
+}


### PR DESCRIPTION
Create iterator over the keys of SetNodeMap, mirroring https://github.com/kubernetes-sigs/structured-merge-diff/blob/master/fieldpath/element.go#L179-L184 for the elements of PathElementSet