### PR TITLE
ToUnstructured shouldn't return internal types

### DIFF
--- a/value/unstructured.go
+++ b/value/unstructured.go
@@ -183,9 +183,9 @@ func (v *Value) ToUnstructured(preserveOrder bool) interface{} {
 		i := int64(*v.IntValue)
 		return i
 	case v.StringValue != nil:
-		return *v.StringValue
+		return string(*v.StringValue)
 	case v.BooleanValue != nil:
-		return *v.BooleanValue
+		return bool(*v.BooleanValue)
 	case v.ListValue != nil:
 		out := []interface{}{}
 		for _, item := range v.ListValue.Items {

--- a/value/unstructured_test.go
+++ b/value/unstructured_test.go
@@ -18,6 +18,7 @@ package value
 
 import (
 	"fmt"
+	"reflect"
 	"testing"
 
 	"gopkg.in/yaml.v2"
@@ -132,5 +133,23 @@ func runUnstructuredTestUnordered(t *testing.T, input []byte) {
 
 	if string(dcheck) != string(echeck) {
 		t.Fatalf("From/To were not inverse.\n\ndecoded: %#v\n\nencoded: %#v\n\ndecoded:\n%s\n\nencoded:\n%s", decoded, encoded, dcheck, echeck)
+	}
+}
+
+func TestRoundTrip(t *testing.T) {
+	i := map[string]interface{}{
+		"foo": map[string]interface{}{
+			"bar": map[string]interface{}{
+				"qux": []interface{}{true, false, int64(1), float64(1.1), nil, "1"},
+			},
+		},
+	}
+	v, err := FromUnstructured(i)
+	if err != nil {
+		t.Fatalf("failed to interpret (%v):\n%s", err, i)
+	}
+	o := v.ToUnstructured(false)
+	if !reflect.DeepEqual(i, o) {
+		t.Fatalf("Failed to round-trip.\ninput: %#v\noutput: %#v", i, o)
 	}
 }


### PR DESCRIPTION
This is messing up comparison function like DeepEqual because while the
types are absolutely similar, they're not exactly the same, and it's
very hard to debug.