### PR TITLE
Remove empty sets from managers

### DIFF
--- a/internal/fixture/state.go
+++ b/internal/fixture/state.go
@@ -259,5 +259,12 @@ func (tc TestCase) Test(parser *typed.ParseableType) error {
 		}
 	}
 
+	// Fail if any empty sets are present in the managers
+	for manager, set := range state.Managers {
+		if set.Empty() {
+			return fmt.Errorf("expected Managers to have no empty sets, but found one managed by %v", manager)
+		}
+	}
+
 	return nil
 }

--- a/merge/leaf_test.go
+++ b/merge/leaf_test.go
@@ -221,6 +221,55 @@ func TestUpdateLeaf(t *testing.T) {
 				},
 			},
 		},
+		"update_remove_empty_set": {
+			Ops: []Operation{
+				Apply{
+					Manager:    "default",
+					APIVersion: "v1",
+					Object: `
+						string: "string"
+					`,
+				},
+				Update{
+					Manager:    "controller",
+					APIVersion: "v1",
+					Object: `
+						string: "new string"
+					`,
+				},
+			},
+			Object: `
+				string: "new string"
+			`,
+			Managed: fieldpath.ManagedFields{
+				"controller": &fieldpath.VersionedSet{
+					Set: _NS(
+						_P("string"),
+					),
+					APIVersion: "v1",
+				},
+			},
+		},
+		"apply_remove_empty_set": {
+			Ops: []Operation{
+				Apply{
+					Manager:    "default",
+					APIVersion: "v1",
+					Object: `
+						string: "string"
+					`,
+				},
+				Apply{
+					Manager:    "default",
+					APIVersion: "v1",
+					Object: "",
+				},
+			},
+			Object: `
+				string: "string"
+			`,
+			Managed: fieldpath.ManagedFields{},
+		},
 	}
 
 	for name, test := range tests {

--- a/merge/update.go
+++ b/merge/update.go
@@ -85,6 +85,9 @@ func (s *Updater) update(oldObject, newObject typed.TypedValue, version fieldpat
 
 	for manager, conflictSet := range conflicts {
 		managers[manager].Set = managers[manager].Set.Difference(conflictSet.Set)
+		if managers[manager].Set.Empty() {
+			delete(managers, manager)
+		}
 	}
 
 	return managers, nil
@@ -112,6 +115,9 @@ func (s *Updater) Update(liveObject, newObject typed.TypedValue, version fieldpa
 	}
 	managers[manager].Set = managers[manager].Set.Union(compare.Modified).Union(compare.Added).Difference(compare.Removed)
 	managers[manager].APIVersion = version
+	if managers[manager].Set.Empty() {
+		delete(managers, manager)
+	}
 	return managers, nil
 }
 
@@ -137,6 +143,9 @@ func (s *Updater) Apply(liveObject, configObject typed.TypedValue, version field
 	managers[manager] = &fieldpath.VersionedSet{
 		Set:        set,
 		APIVersion: version,
+	}
+	if managers[manager].Set.Empty() {
+		delete(managers, manager)
 	}
 	return newObject, managers, nil
 }


### PR DESCRIPTION
The three codepaths added are tested by:
- ```TestUpdateLeaf/update_remove_empty_set``` tests that when all fields are removed from existing owner (either by an Update or forced Apply), their entry is removed from managers
- ```TestUpdateSet/apply_update_apply_reorder``` is an existing test, that now also tests that when updating an object, if the caller would own nothing after the own update, their entry is removed from managers
- ```TestUpdateLeaf/apply_remove_empty_set``` tests that when applying to an object, if the caller provides an empty PSO, their entry is removed from managers

/assign @apelisse 
/assign @kwiesmueller 