### PR TITLE
Add a few cross-version tests

### DIFF
--- a/merge/leaf_test.go
+++ b/merge/leaf_test.go
@@ -81,6 +81,40 @@ func TestUpdateLeaf(t *testing.T) {
 				},
 			},
 		},
+		"apply_twice_different_versions": {
+			Ops: []Operation{
+				Apply{
+					Manager: "default",
+					Object: `
+						numeric: 1
+						string: "string"
+					`,
+					APIVersion: "v1",
+				},
+				Apply{
+					Manager: "default",
+					Object: `
+						numeric: 2
+						string: "string"
+						bool: false
+					`,
+					APIVersion: "v2",
+				},
+			},
+			Object: `
+				numeric: 2
+				string: "string"
+				bool: false
+			`,
+			Managed: fieldpath.ManagedFields{
+				"default": &fieldpath.VersionedSet{
+					Set: _NS(
+						_P("numeric"), _P("string"), _P("bool"),
+					),
+					APIVersion: "v2",
+				},
+			},
+		},
 		"apply_update_apply_no_conflict": {
 			Ops: []Operation{
 				Apply{
@@ -126,6 +160,54 @@ func TestUpdateLeaf(t *testing.T) {
 						_P("bool"),
 					),
 					APIVersion: "v1",
+				},
+			},
+		},
+		"apply_update_apply_no_conflict_different_version": {
+			Ops: []Operation{
+				Apply{
+					Manager:    "default",
+					APIVersion: "v1",
+					Object: `
+						numeric: 1
+						string: "string"
+					`,
+				},
+				Update{
+					Manager:    "controller",
+					APIVersion: "v2",
+					Object: `
+						numeric: 1
+						string: "string"
+						bool: true
+					`,
+				},
+				Apply{
+					Manager:    "default",
+					APIVersion: "v1",
+					Object: `
+						numeric: 2
+						string: "string"
+					`,
+				},
+			},
+			Object: `
+				numeric: 2
+				string: "string"
+				bool: true
+			`,
+			Managed: fieldpath.ManagedFields{
+				"default": &fieldpath.VersionedSet{
+					Set: _NS(
+						_P("numeric"), _P("string"),
+					),
+					APIVersion: "v1",
+				},
+				"controller": &fieldpath.VersionedSet{
+					Set: _NS(
+						_P("bool"),
+					),
+					APIVersion: "v2",
 				},
 			},
 		},
@@ -188,6 +270,65 @@ func TestUpdateLeaf(t *testing.T) {
 				},
 			},
 		},
+		"apply_update_apply_with_conflict_across_version": {
+			Ops: []Operation{
+				Apply{
+					Manager:    "default",
+					APIVersion: "v1",
+					Object: `
+						numeric: 1
+						string: "string"
+					`,
+				},
+				Update{
+					Manager:    "controller",
+					APIVersion: "v2",
+					Object: `
+						numeric: 1
+						string: "controller string"
+						bool: true
+					`,
+				},
+				Apply{
+					Manager:    "default",
+					APIVersion: "v1",
+					Object: `
+						numeric: 2
+						string: "user string"
+					`,
+					Conflicts: merge.Conflicts{
+						merge.Conflict{Manager: "controller", Path: _P("string")},
+					},
+				},
+				ForceApply{
+					Manager:    "default",
+					APIVersion: "v1",
+					Object: `
+						numeric: 2
+						string: "user string"
+					`,
+				},
+			},
+			Object: `
+				numeric: 2
+				string: "user string"
+				bool: true
+			`,
+			Managed: fieldpath.ManagedFields{
+				"default": &fieldpath.VersionedSet{
+					Set: _NS(
+						_P("numeric"), _P("string"),
+					),
+					APIVersion: "v1",
+				},
+				"controller": &fieldpath.VersionedSet{
+					Set: _NS(
+						_P("bool"),
+					),
+					APIVersion: "v2",
+				},
+			},
+		},
 		"apply_twice_dangling": {
 			Ops: []Operation{
 				Apply{
@@ -218,6 +359,39 @@ func TestUpdateLeaf(t *testing.T) {
 						_P("string"),
 					),
 					APIVersion: "v1",
+				},
+			},
+		},
+		"apply_twice_dangling_different_version": {
+			Ops: []Operation{
+				Apply{
+					Manager:    "default",
+					APIVersion: "v1",
+					Object: `
+						numeric: 1
+						string: "string"
+						bool: false
+					`,
+				},
+				Apply{
+					Manager:    "default",
+					APIVersion: "v2",
+					Object: `
+						string: "new string"
+					`,
+				},
+			},
+			Object: `
+				numeric: 1
+				string: "new string"
+				bool: false
+			`,
+			Managed: fieldpath.ManagedFields{
+				"default": &fieldpath.VersionedSet{
+					Set: _NS(
+						_P("string"),
+					),
+					APIVersion: "v2",
 				},
 			},
 		},

--- a/merge/set_test.go
+++ b/merge/set_test.go
@@ -147,6 +147,68 @@ func TestUpdateSet(t *testing.T) {
 				},
 			},
 		},
+		"apply_update_apply_no_overlap_and_different_version": {
+			Ops: []Operation{
+				Apply{
+					Manager:    "default",
+					APIVersion: "v1",
+					Object: `
+						list:
+						- a
+						- c
+					`,
+				},
+				Update{
+					Manager:    "controller",
+					APIVersion: "v2",
+					Object: `
+						list:
+						- a
+						- b
+						- c
+						- d
+					`,
+				},
+				Apply{
+					Manager:    "default",
+					APIVersion: "v1",
+					Object: `
+						list:
+						- a
+						- aprime
+						- c
+						- cprime
+					`,
+				},
+			},
+			Object: `
+				list:
+				- a
+				- aprime
+				- b
+				- c
+				- cprime
+				- d
+			`,
+			Managed: fieldpath.ManagedFields{
+				"default": &fieldpath.VersionedSet{
+					Set: _NS(
+						_P("list", _SV("a")),
+						_P("list", _SV("aprime")),
+						_P("list", _SV("c")),
+						_P("list", _SV("cprime")),
+					),
+					APIVersion: "v1",
+				},
+				"controller": &fieldpath.VersionedSet{
+					Set: _NS(
+						_P("list", _SV("b")),
+						_P("list", _SV("d")),
+					),
+					APIVersion: "v2",
+				},
+			},
+		},
 		"apply_update_apply_with_overlap": {
 			Ops: []Operation{
 				Apply{
@@ -202,6 +264,64 @@ func TestUpdateSet(t *testing.T) {
 						_P("list", _SV("d")),
 					),
 					APIVersion: "v1",
+				},
+			},
+		},
+		"apply_update_apply_with_overlap_and_different_version": {
+			Ops: []Operation{
+				Apply{
+					Manager:    "default",
+					APIVersion: "v1",
+					Object: `
+						list:
+						- a
+						- c
+					`,
+				},
+				Update{
+					Manager:    "controller",
+					APIVersion: "v2",
+					Object: `
+						list:
+						- a
+						- b
+						- c
+						- d
+					`,
+				},
+				Apply{
+					Manager:    "default",
+					APIVersion: "v1",
+					Object: `
+						list:
+						- a
+						- b
+						- c
+					`,
+				},
+			},
+			Object: `
+				list:
+				- a
+				- b
+				- c
+				- d
+			`,
+			Managed: fieldpath.ManagedFields{
+				"default": &fieldpath.VersionedSet{
+					Set: _NS(
+						_P("list", _SV("a")),
+						_P("list", _SV("b")),
+						_P("list", _SV("c")),
+					),
+					APIVersion: "v1",
+				},
+				"controller": &fieldpath.VersionedSet{
+					Set: _NS(
+						_P("list", _SV("b")),
+						_P("list", _SV("d")),
+					),
+					APIVersion: "v2",
 				},
 			},
 		},
@@ -304,6 +424,61 @@ func TestUpdateSet(t *testing.T) {
 				},
 			},
 		},
+		"apply_update_apply_reorder_across_versions": {
+			Ops: []Operation{
+				Apply{
+					Manager:    "default",
+					APIVersion: "v1",
+					Object: `
+						list:
+						- a
+						- b
+						- c
+						- d
+					`,
+				},
+				Update{
+					Manager:    "controller",
+					APIVersion: "v1",
+					Object: `
+						list:
+						- a
+						- d
+						- c
+						- b
+					`,
+				},
+				Apply{
+					Manager:    "default",
+					APIVersion: "v2",
+					Object: `
+						list:
+						- a
+						- b
+						- c
+						- d
+					`,
+				},
+			},
+			Object: `
+				list:
+				- a
+				- b
+				- c
+				- d
+			`,
+			Managed: fieldpath.ManagedFields{
+				"default": &fieldpath.VersionedSet{
+					Set: _NS(
+						_P("list", _SV("a")),
+						_P("list", _SV("b")),
+						_P("list", _SV("c")),
+						_P("list", _SV("d")),
+					),
+					APIVersion: "v2",
+				},
+			},
+		},
 		"apply_twice_remove": {
 			Ops: []Operation{
 				Apply{
@@ -339,6 +514,47 @@ func TestUpdateSet(t *testing.T) {
 						_P("list", _SV("c")),
 					),
 					APIVersion: "v1",
+				},
+			},
+		},
+		"apply_twice_remove_across_versions": {
+			Ops: []Operation{
+				Apply{
+					Manager:    "default",
+					APIVersion: "v1",
+					Object: `
+						list:
+						- a
+						- b
+						- c
+						- d
+					`,
+				},
+				Apply{
+					Manager:    "default",
+					APIVersion: "v2",
+					Object: `
+						list:
+						- a
+						- c
+						- e
+					`,
+				},
+			},
+			Object: `
+				list:
+				- a
+				- c
+				- e
+			`,
+			Managed: fieldpath.ManagedFields{
+				"default": &fieldpath.VersionedSet{
+					Set: _NS(
+						_P("list", _SV("a")),
+						_P("list", _SV("c")),
+						_P("list", _SV("e")),
+					),
+					APIVersion: "v2",
 				},
 			},
 		},


### PR DESCRIPTION
We don't have any cross-version test yet, and they can be easy to make if we assume that the objects are similar in all versions. This will at least test that we carry the proper version where we need to, and that we still can take ownership of fields across versions, etc.

/assign @jennybuckley @kwiesmueller 