### PR TITLE
Fix bug with removing non leaf items

### DIFF
--- a/fieldpath/set.go
+++ b/fieldpath/set.go
@@ -159,7 +159,10 @@ func (s *Set) iteratePrefix(prefix Path, f func(Path)) {
 func (s *Set) WithPrefix(pe PathElement) *Set {
 	subset, ok := s.Children.Get(pe)
 	if !ok {
-		return NewSet()
+		subset = NewSet()
+	}
+	if s.Members.Has(pe) {
+		subset.Insert(MakePathOrDie(""))
 	}
 	return subset
 }

--- a/merge/key_test.go
+++ b/merge/key_test.go
@@ -1,0 +1,105 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+ 
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+ 
+    http://www.apache.org/licenses/LICENSE-2.0
+ 
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+ 
+package merge_test
+ 
+import (
+	"testing"
+ 
+	"sigs.k8s.io/structured-merge-diff/fieldpath"
+	. "sigs.k8s.io/structured-merge-diff/internal/fixture"
+	"sigs.k8s.io/structured-merge-diff/typed"
+)
+ 
+var associativeListParser = func() typed.ParseableType {
+	parser, err := typed.NewParser(`types:
+- name: type
+  struct:
+    fields:
+      - name: list
+        type:
+          namedType: associativeList
+- name: associativeList
+  list:
+    elementType:
+      namedType: myElement
+    elementRelationship: associative
+    keys:
+    - name
+- name: myElement
+  struct:
+    fields:
+    - name: name
+      type:
+        scalar: string
+    - name: value
+      type:
+        scalar: numeric
+`)
+	if err != nil {
+		panic(err)
+	}
+	return parser.Type("type")
+}()
+ 
+func TestUpdateAssociativeLists(t *testing.T) {
+	tests := map[string]TestCase{
+		"removing_obsolete_applied_structs": {
+			Ops: []Operation{
+				Apply{
+					Manager: "default",
+					Object: `
+						list:
+						- name: a
+						  value: 1
+					`,
+					APIVersion: "v1",
+				},
+				Apply{
+					Manager: "default",
+					Object: `
+						list:
+						- name: b
+						  value: 2
+					`,
+					APIVersion: "v1",
+				},
+			},
+			Object: `
+				list:
+				- name: b
+				  value: 2
+			`,
+			Managed: fieldpath.ManagedFields{
+				"default": &fieldpath.VersionedSet{
+					Set: _NS(
+						_P("list", _KBF("name", _SV("b")), "name"),
+						_P("list", _KBF("name", _SV("b")), "value"),
+					),
+					APIVersion: "v1",
+				},
+			},
+		},
+	}
+ 
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			if err := test.Test(associativeListParser); err != nil {
+				t.Fatal(err)
+			}
+		})
+	}
+}

--- a/merge/nested_test.go
+++ b/merge/nested_test.go
@@ -1,0 +1,438 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+ 
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+ 
+    http://www.apache.org/licenses/LICENSE-2.0
+ 
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+ 
+package merge_test
+ 
+import (
+	"testing"
+ 
+	"sigs.k8s.io/structured-merge-diff/fieldpath"
+	. "sigs.k8s.io/structured-merge-diff/internal/fixture"
+	"sigs.k8s.io/structured-merge-diff/typed"
+)
+ 
+var nestedTypeParser = func() typed.ParseableType {
+	parser, err := typed.NewParser(`types:
+- name: type
+  struct:
+    fields:
+      - name: listOfLists
+        type:
+          namedType: listOfLists
+      - name: listOfMaps
+        type:
+          namedType: listOfMaps
+      - name: mapOfLists
+        type:
+          namedType: mapOfLists
+      - name: mapOfMaps
+        type:
+          namedType: mapOfMaps
+- name: listOfLists
+  list:
+    elementType:
+      struct:
+        fields:
+        - name: name
+          type:
+            scalar: string
+        - name: value
+          type:
+            namedType: list
+    elementRelationship: associative
+    keys:
+    - name
+- name: list
+  list:
+    elementType:
+      scalar: string
+    elementRelationship: associative
+- name: listOfMaps
+  list:
+    elementType:
+      struct:
+        fields:
+        - name: name
+          type:
+            scalar: string
+        - name: value
+          type:
+            namedType: map
+    elementRelationship: associative
+    keys:
+    - name
+- name: map
+  map:
+    elementType:
+      scalar: string
+    elementRelationship: associative
+- name: mapOfLists
+  map:
+    elementType:
+      namedType: list
+    elementRelationship: associative
+- name: mapOfMaps
+  map:
+    elementType:
+      namedType: map
+    elementRelationship: associative
+`)
+	if err != nil {
+		panic(err)
+	}
+	return parser.Type("type")
+}()
+ 
+func TestUpdateNestedType(t *testing.T) {
+	tests := map[string]TestCase{
+		"listOfLists_change_value": {
+			Ops: []Operation{
+				Apply{
+					Manager: "default",
+					Object: `
+						listOfLists:
+						- name: a
+						  value:
+						  - b
+						  - c
+					`,
+					APIVersion: "v1",
+				},
+				Apply{
+					Manager: "default",
+					Object: `
+						listOfLists:
+						- name: a
+						  value:
+						  - a
+						  - c
+					`,
+					APIVersion: "v1",
+				},
+			},
+			Object: `
+				listOfLists:
+				- name: a
+				  value:
+				  - a
+				  - c
+			`,
+			Managed: fieldpath.ManagedFields{
+				"default": &fieldpath.VersionedSet{
+					Set: _NS(
+						_P("listOfLists", _KBF("name", _SV("a")), "name"),
+						_P("listOfLists", _KBF("name", _SV("a")), "value", _SV("a")),
+						_P("listOfLists", _KBF("name", _SV("a")), "value", _SV("c")),
+					),
+					APIVersion: "v1",
+				},
+			},
+		},
+		"listOfLists_change_key_and_value": {
+			Ops: []Operation{
+				Apply{
+					Manager: "default",
+					Object: `
+						listOfLists:
+						- name: a
+						  value:
+						  - b
+						  - c
+					`,
+					APIVersion: "v1",
+				},
+				Apply{
+					Manager: "default",
+					Object: `
+						listOfLists:
+						- name: b
+						  value:
+						  - a
+						  - c
+					`,
+					APIVersion: "v1",
+				},
+			},
+			Object: `
+				listOfLists:
+				- name: b
+				  value:
+				  - a
+				  - c
+			`,
+			Managed: fieldpath.ManagedFields{
+				"default": &fieldpath.VersionedSet{
+					Set: _NS(
+						_P("listOfLists", _KBF("name", _SV("b")), "name"),
+						_P("listOfLists", _KBF("name", _SV("b")), "value", _SV("a")),
+						_P("listOfLists", _KBF("name", _SV("b")), "value", _SV("c")),
+					),
+					APIVersion: "v1",
+				},
+			},
+		},
+		"listOfMaps_change_value": {
+			Ops: []Operation{
+				Apply{
+					Manager: "default",
+					Object: `
+						listOfMaps:
+						- name: a
+						  value:
+						    b: "x"
+						    c: "y"
+					`,
+					APIVersion: "v1",
+				},
+				Apply{
+					Manager: "default",
+					Object: `
+						listOfMaps:
+						- name: a
+						  value:
+						    a: "x"
+						    c: "z"
+					`,
+					APIVersion: "v1",
+				},
+			},
+			Object: `
+				listOfMaps:
+				- name: a
+				  value:
+				    a: "x"
+				    c: "z"
+			`,
+			Managed: fieldpath.ManagedFields{
+				"default": &fieldpath.VersionedSet{
+					Set: _NS(
+						_P("listOfMaps", _KBF("name", _SV("a")), "name"),
+						_P("listOfMaps", _KBF("name", _SV("a")), "value", "a"),
+						_P("listOfMaps", _KBF("name", _SV("a")), "value", "c"),
+					),
+					APIVersion: "v1",
+				},
+			},
+		},
+		"listOfMaps_change_key_and_value": {
+			Ops: []Operation{
+				Apply{
+					Manager: "default",
+					Object: `
+						listOfMaps:
+						- name: a
+						  value:
+						    b: "x"
+						    c: "y"
+					`,
+					APIVersion: "v1",
+				},
+				Apply{
+					Manager: "default",
+					Object: `
+						listOfMaps:
+						- name: b
+						  value:
+						    a: "x"
+						    c: "z"
+					`,
+					APIVersion: "v1",
+				},
+			},
+			Object: `
+				listOfMaps:
+				- name: b
+				  value:
+				    a: "x"
+				    c: "z"
+			`,
+			Managed: fieldpath.ManagedFields{
+				"default": &fieldpath.VersionedSet{
+					Set: _NS(
+						_P("listOfMaps", _KBF("name", _SV("b")), "name"),
+						_P("listOfMaps", _KBF("name", _SV("b")), "value", "a"),
+						_P("listOfMaps", _KBF("name", _SV("b")), "value", "c"),
+					),
+					APIVersion: "v1",
+				},
+			},
+		},
+		"mapOfLists_change_value": {
+			Ops: []Operation{
+				Apply{
+					Manager: "default",
+					Object: `
+						mapOfLists:
+						  a:
+						  - b
+						  - c
+					`,
+					APIVersion: "v1",
+				},
+				Apply{
+					Manager: "default",
+					Object: `
+						mapOfLists:
+						  a:
+						  - a
+						  - c
+					`,
+					APIVersion: "v1",
+				},
+			},
+			Object: `
+				mapOfLists:
+				  a:
+				  - a
+				  - c
+			`,
+			Managed: fieldpath.ManagedFields{
+				"default": &fieldpath.VersionedSet{
+					Set: _NS(
+						_P("mapOfLists", "a", _SV("a")),
+						_P("mapOfLists", "a", _SV("c")),
+					),
+					APIVersion: "v1",
+				},
+			},
+		},
+		"mapOfLists_change_key_and_value": {
+			Ops: []Operation{
+				Apply{
+					Manager: "default",
+					Object: `
+						mapOfLists:
+						  a:
+						  - b
+						  - c
+					`,
+					APIVersion: "v1",
+				},
+				Apply{
+					Manager: "default",
+					Object: `
+						mapOfLists:
+						  b:
+						  - a
+						  - c
+					`,
+					APIVersion: "v1",
+				},
+			},
+			Object: `
+				mapOfLists:
+				  b:
+				  - a
+				  - c
+			`,
+			Managed: fieldpath.ManagedFields{
+				"default": &fieldpath.VersionedSet{
+					Set: _NS(
+						_P("mapOfLists", "b", _SV("a")),
+						_P("mapOfLists", "b", _SV("c")),
+					),
+					APIVersion: "v1",
+				},
+			},
+		},
+		"mapOfMaps_change_value": {
+			Ops: []Operation{
+				Apply{
+					Manager: "default",
+					Object: `
+						mapOfMaps:
+						  a:
+						    b: "x"
+						    c: "y"
+					`,
+					APIVersion: "v1",
+				},
+				Apply{
+					Manager: "default",
+					Object: `
+						mapOfMaps:
+						  a:
+						    a: "x"
+						    c: "z"
+					`,
+					APIVersion: "v1",
+				},
+			},
+			Object: `
+				mapOfMaps:
+				  a:
+				    a: "x"
+				    c: "z"
+			`,
+			Managed: fieldpath.ManagedFields{
+				"default": &fieldpath.VersionedSet{
+					Set: _NS(
+						_P("mapOfMaps", "a", "a"),
+						_P("mapOfMaps", "a", "c"),
+					),
+					APIVersion: "v1",
+				},
+			},
+		},
+		"mapOfMaps_change_key_and_value": {
+			Ops: []Operation{
+				Apply{
+					Manager: "default",
+					Object: `
+						mapOfMaps:
+						  a:
+						    b: "x"
+						    c: "y"
+					`,
+					APIVersion: "v1",
+				},
+				Apply{
+					Manager: "default",
+					Object: `
+						mapOfMaps:
+						  b:
+						    a: "x"
+						    c: "z"
+					`,
+					APIVersion: "v1",
+				},
+			},
+			Object: `
+				mapOfMaps:
+				  b:
+				    a: "x"
+				    c: "z"
+			`,
+			Managed: fieldpath.ManagedFields{
+				"default": &fieldpath.VersionedSet{
+					Set: _NS(
+						_P("mapOfMaps", "b", "a"),
+						_P("mapOfMaps", "b", "c"),
+					),
+					APIVersion: "v1",
+				},
+			},
+		},
+	}
+ 
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			if err := test.Test(nestedTypeParser); err != nil {
+				t.Fatal(err)
+			}
+		})
+	}
+}

--- a/merge/update.go
+++ b/merge/update.go
@@ -176,5 +176,5 @@ func (s *Updater) removeDisownedItems(merged, applied typed.TypedValue, lastSet 
 	if err != nil {
 		return nil, fmt.Errorf("failed to create field set from applied config in last applied version: %v", err)
 	}
-	return merged.RemoveItems(lastSet.Set.Difference(appliedSet)), nil
+	return merged.RemoveItems(lastSet.Set, appliedSet), nil
 }

--- a/typed/deduced.go
+++ b/typed/deduced.go
@@ -173,6 +173,6 @@ func modified(lhs, rhs value.Value, path fieldpath.Path, set *fieldpath.Set) {
 
 // RemoveItems does nothing because all lists in a deducedTypedValue are considered atomic,
 // and there are no maps because it is indistinguishable from a struct.
-func (dv deducedTypedValue) RemoveItems(_ *fieldpath.Set) TypedValue {
+func (dv deducedTypedValue) RemoveItems(_ *fieldpath.Set, _ *fieldpath.Set) TypedValue {
 	return dv
 }

--- a/typed/typed.go
+++ b/typed/typed.go
@@ -53,8 +53,8 @@ type TypedValue interface {
 	// match), or an error will be returned. Validation errors will be returned if
 	// the objects don't conform to the schema.
 	Compare(rhs TypedValue) (c *Comparison, err error)
-	// RemoveItems removes each provided list or map item from the value.
-	RemoveItems(items *fieldpath.Set) TypedValue
+	// RemoveItems removes each list or map item from the value that has children in lhs and not in rhs.
+	RemoveItems(lhs *fieldpath.Set, rhs *fieldpath.Set) TypedValue
 }
 
 // AsTyped accepts a value and a type and returns a TypedValue. 'v' must have
@@ -161,9 +161,9 @@ func (tv typedValue) Compare(rhs TypedValue) (c *Comparison, err error) {
 	return c, nil
 }
 
-// RemoveItems removes each provided list or map item from the value.
-func (tv typedValue) RemoveItems(items *fieldpath.Set) TypedValue {
-	removeItemsWithSchema(&tv.value, items, tv.schema, tv.typeRef)
+// RemoveItems removes each list or map item from the value that has children in lhs and not in rhs.
+func (tv typedValue) RemoveItems(lhs *fieldpath.Set, rhs *fieldpath.Set) TypedValue {
+	removeItemsWithSchema(&tv.value, lhs, rhs, tv.schema, tv.typeRef)
 	return tv
 }
 


### PR DESCRIPTION
Since ToFieldSet creates a set which only includes leaf nodes, diffing the last applied fieldset and the fieldset generated from the merged object isn't enough to determine which list items to remove, if those items are not scalars (which is why the test we have didn't catch it).