### PR TITLE
FixTabsOrDie doesn't work well with YAML structs

### DIFF
--- a/internal/fixture/state_test.go
+++ b/internal/fixture/state_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package fixture
 
 import (
-	"bytes"
 	"fmt"
 	"testing"
 
@@ -33,16 +32,16 @@ func TestFixTabs(t *testing.T) {
 		out: "a\n  b\n",
 	}, {
 		in:  "\t\ta\n\t\t\tb\n",
-		out: "a\n  b\n",
+		out: "a\n\tb\n",
 	}, {
-		in:  "\n\t\ta\n\t\t\tb\n",
-		out: "a\n  b\n",
+		in:  "\n\t\ta\n\t\tb\n",
+		out: "a\nb\n",
 	}, {
 		in:  "\n\t\ta\n\t\t\tb\n\t",
-		out: "a\n  b\n",
+		out: "a\n\tb\n",
 	}, {
-		in:          "\t\ta\n\t\t  b\n",
-		shouldPanic: true,
+		in:  "\t\ta\n\t\t  b\n",
+		out: "a\n  b\n",
 	}, {
 		in:          "\t\ta\n\tb\n",
 		shouldPanic: true,
@@ -61,9 +60,6 @@ func TestFixTabs(t *testing.T) {
 			got := FixTabsOrDie(tt.in)
 			if e, a := tt.out, got; e != a {
 				t.Errorf("mismatch\n   got %v\nwanted %v", []byte(a), []byte(e))
-			}
-			if bytes.Contains([]byte(got), []byte{'\t'}) {
-				t.Error("contained a tab")
 			}
 		})
 	}


### PR DESCRIPTION
Especially when the struct is in a list because:
```yaml
	- a: 1
	  b: 2
```
panics because of mixed spaces and tabs. A working alternative is to
indent with tabs, but I don't think it's very pleasant:
```yaml
	- a: 1
		b: 2
```

Update the code so that prefixed tabs from the first line are removed
from all consecutive lines, and keep it that simple.

/assign @lavalamp @jennybuckley @kwiesmueller 