### PR TITLE
 Implement list item and map key removal for multiple appliers

### DIFF
--- a/fieldpath/managers.go
+++ b/fieldpath/managers.go
@@ -20,6 +20,7 @@ type APIVersion string
 type VersionedSet struct {
 	*Set
 	APIVersion APIVersion
+	Applied    bool
 }
 
 // ManagedFields is a map from manager to VersionedSet (what they own in

--- a/fieldpath/set.go
+++ b/fieldpath/set.go
@@ -80,7 +80,6 @@ func (s *Set) Intersection(s2 *Set) *Set {
 // Difference returns a Set containing elements which:
 // * appear in s
 // * do not appear in s2
-// * and are not children of elements that appear in s2.
 //
 // In other words, for leaf fields, this acts like a regular set difference
 // operation. When non leaf fields are compared with leaf fields ("parents"
@@ -284,9 +283,6 @@ func (s *SetNodeMap) Difference(s2 *Set) *SetNodeMap {
 	out := &SetNodeMap{}
 	for k, sn := range s.members {
 		pe := sn.pathElement
-		if s2.Members.Has(pe) {
-			continue
-		}
 		if sn2, ok := s2.Children.members[k]; ok {
 			diff := *sn.set.Difference(sn2.set)
 			// We aren't permitted to add nodes with no elements.

--- a/fieldpath/set.go
+++ b/fieldpath/set.go
@@ -159,10 +159,7 @@ func (s *Set) iteratePrefix(prefix Path, f func(Path)) {
 func (s *Set) WithPrefix(pe PathElement) *Set {
 	subset, ok := s.Children.Get(pe)
 	if !ok {
-		subset = NewSet()
-	}
-	if s.Members.Has(pe) {
-		subset.Insert(MakePathOrDie(""))
+		return NewSet()
 	}
 	return subset
 }

--- a/fieldpath/set_test.go
+++ b/fieldpath/set_test.go
@@ -292,6 +292,7 @@ func TestSetIntersectionDifference(t *testing.T) {
 			MakePathOrDie("foo", 0),
 			MakePathOrDie("b0", nameFirst),
 			MakePathOrDie("bar", "c0"),
+			MakePathOrDie("cp", nameFirst, "child"),
 		)
 
 		got := s1.Difference(s2)

--- a/merge/key_test.go
+++ b/merge/key_test.go
@@ -86,6 +86,7 @@ func TestUpdateAssociativeLists(t *testing.T) {
 			Managed: fieldpath.ManagedFields{
 				"default": &fieldpath.VersionedSet{
 					Set: _NS(
+						_P("list", _KBF("name", _SV("b"))),
 						_P("list", _KBF("name", _SV("b")), "name"),
 						_P("list", _KBF("name", _SV("b")), "value"),
 					),

--- a/merge/multiple_appliers_test.go
+++ b/merge/multiple_appliers_test.go
@@ -17,11 +17,15 @@ limitations under the License.
 package merge_test
 
 import (
+	"fmt"
+	"strconv"
+	"strings"
 	"testing"
 
 	"sigs.k8s.io/structured-merge-diff/fieldpath"
 	. "sigs.k8s.io/structured-merge-diff/internal/fixture"
 	"sigs.k8s.io/structured-merge-diff/merge"
+	"sigs.k8s.io/structured-merge-diff/typed"
 )
 
 func TestMultipleAppliersSet(t *testing.T) {
@@ -62,12 +66,14 @@ func TestMultipleAppliersSet(t *testing.T) {
 			Managed: fieldpath.ManagedFields{
 				"apply-one": &fieldpath.VersionedSet{
 					Set: _NS(
+						_P("list", _KBF("name", _SV("a"))),
 						_P("list", _KBF("name", _SV("a")), "name"),
 					),
 					APIVersion: "v3",
 				},
 				"apply-two": &fieldpath.VersionedSet{
 					Set: _NS(
+						_P("list", _KBF("name", _SV("c"))),
 						_P("list", _KBF("name", _SV("c")), "name"),
 					),
 					APIVersion: "v2",
@@ -103,6 +109,7 @@ func TestMultipleAppliersSet(t *testing.T) {
 			Managed: fieldpath.ManagedFields{
 				"apply-one": &fieldpath.VersionedSet{
 					Set: _NS(
+						_P("list", _KBF("name", _SV("a"))),
 						_P("list", _KBF("name", _SV("a")), "name"),
 						_P("list", _KBF("name", _SV("a")), "value"),
 					),
@@ -110,6 +117,7 @@ func TestMultipleAppliersSet(t *testing.T) {
 				},
 				"apply-two": &fieldpath.VersionedSet{
 					Set: _NS(
+						_P("list", _KBF("name", _SV("a"))),
 						_P("list", _KBF("name", _SV("a")), "name"),
 						_P("list", _KBF("name", _SV("a")), "value"),
 					),
@@ -149,6 +157,7 @@ func TestMultipleAppliersSet(t *testing.T) {
 			Managed: fieldpath.ManagedFields{
 				"apply-one": &fieldpath.VersionedSet{
 					Set: _NS(
+						_P("list", _KBF("name", _SV("a"))),
 						_P("list", _KBF("name", _SV("a")), "name"),
 						_P("list", _KBF("name", _SV("a")), "value"),
 					),
@@ -156,19 +165,6 @@ func TestMultipleAppliersSet(t *testing.T) {
 				},
 			},
 		},
-	}
-
-	for name, test := range tests {
-		t.Run(name, func(t *testing.T) {
-			if err := test.Test(associativeListParser); err != nil {
-				t.Fatal(err)
-			}
-		})
-	}
-}
-
-func TestMultipleAppliersSetBroken(t *testing.T) {
-	tests := map[string]TestCase{
 		"remove_one_keep_one": {
 			Ops: []Operation{
 				Apply{
@@ -208,12 +204,15 @@ func TestMultipleAppliersSetBroken(t *testing.T) {
 			Managed: fieldpath.ManagedFields{
 				"apply-one": &fieldpath.VersionedSet{
 					Set: _NS(
+						_P("list", _KBF("name", _SV("a"))),
 						_P("list", _KBF("name", _SV("a")), "name"),
 					),
 					APIVersion: "v3",
 				},
 				"apply-two": &fieldpath.VersionedSet{
 					Set: _NS(
+						_P("list", _KBF("name", _SV("c"))),
+						_P("list", _KBF("name", _SV("d"))),
 						_P("list", _KBF("name", _SV("c")), "name"),
 						_P("list", _KBF("name", _SV("d")), "name"),
 					),
@@ -225,9 +224,663 @@ func TestMultipleAppliersSetBroken(t *testing.T) {
 
 	for name, test := range tests {
 		t.Run(name, func(t *testing.T) {
-			if test.Test(associativeListParser) == nil {
-				t.Fatal("Broken test passed")
+			if err := test.Test(associativeListParser); err != nil {
+				t.Fatal(err)
 			}
 		})
 	}
+}
+
+func TestMultipleAppliersNestedType(t *testing.T) {
+	tests := map[string]TestCase{
+		"remove_one_keep_one_with_two_sub_items": {
+			Ops: []Operation{
+				Apply{
+					Manager: "apply-one",
+					Object: `
+						listOfLists:
+						- name: a
+						- name: b
+						  value:
+						  - c
+					`,
+					APIVersion: "v1",
+				},
+				Apply{
+					Manager: "apply-two",
+					Object: `
+						listOfLists:
+						- name: b
+						  value:
+						  - d
+					`,
+					APIVersion: "v2",
+				},
+				Apply{
+					Manager: "apply-one",
+					Object: `
+						listOfLists:
+						- name: a
+					`,
+					APIVersion: "v3",
+				},
+			},
+			Object: `
+				listOfLists:
+				- name: a
+				- name: b
+				  value:
+				  - d
+			`,
+			Managed: fieldpath.ManagedFields{
+				"apply-one": &fieldpath.VersionedSet{
+					Set: _NS(
+						_P("listOfLists", _KBF("name", _SV("a"))),
+						_P("listOfLists", _KBF("name", _SV("a")), "name"),
+					),
+					APIVersion: "v3",
+				},
+				"apply-two": &fieldpath.VersionedSet{
+					Set: _NS(
+						_P("listOfLists", _KBF("name", _SV("b"))),
+						_P("listOfLists", _KBF("name", _SV("b")), "name"),
+						_P("listOfLists", _KBF("name", _SV("b")), "value", _SV("d")),
+					),
+					APIVersion: "v2",
+				},
+			},
+		},
+		"remove_one_keep_one_with_dangling_subitem": {
+			Ops: []Operation{
+				Apply{
+					Manager: "apply-one",
+					Object: `
+						listOfLists:
+						- name: a
+						- name: b
+						  value:
+						  - c
+					`,
+					APIVersion: "v1",
+				},
+				Apply{
+					Manager: "apply-two",
+					Object: `
+						listOfLists:
+						- name: b
+						  value:
+						  - d
+					`,
+					APIVersion: "v2",
+				},
+				Update{
+					Manager: "controller",
+					Object: `
+						listOfLists:
+						- name: a
+						- name: b
+						  value:
+						  - c
+						  - d
+						  - e
+					`,
+					APIVersion: "v2",
+				},
+				Apply{
+					Manager: "apply-one",
+					Object: `
+						listOfLists:
+						- name: a
+					`,
+					APIVersion: "v3",
+				},
+			},
+			Object: `
+				listOfLists:
+				- name: a
+				- name: b
+				  value:
+				  - d
+				  - e
+			`,
+			Managed: fieldpath.ManagedFields{
+				"apply-one": &fieldpath.VersionedSet{
+					Set: _NS(
+						_P("listOfLists", _KBF("name", _SV("a"))),
+						_P("listOfLists", _KBF("name", _SV("a")), "name"),
+					),
+					APIVersion: "v3",
+				},
+				"apply-two": &fieldpath.VersionedSet{
+					Set: _NS(
+						_P("listOfLists", _KBF("name", _SV("b"))),
+						_P("listOfLists", _KBF("name", _SV("b")), "name"),
+						_P("listOfLists", _KBF("name", _SV("b")), "value", _SV("d")),
+					),
+					APIVersion: "v2",
+				},
+				"controller": &fieldpath.VersionedSet{
+					Set: _NS(
+						_P("listOfLists", _KBF("name", _SV("b")), "value", _SV("e")),
+					),
+					APIVersion: "v2",
+				},
+			},
+		},
+		"remove_one_with_dangling_subitem_keep_one": {
+			Ops: []Operation{
+				Apply{
+					Manager: "apply-one",
+					Object: `
+						listOfLists:
+						- name: a
+						- name: b
+						  value:
+						  - c
+					`,
+					APIVersion: "v1",
+				},
+				Apply{
+					Manager: "apply-two",
+					Object: `
+						listOfLists:
+						- name: a
+						  value:
+						  - b
+					`,
+					APIVersion: "v2",
+				},
+				Update{
+					Manager: "controller",
+					Object: `
+						listOfLists:
+						- name: a
+						  value:
+						  - b
+						- name: b
+						  value:
+						  - c
+						  - d
+					`,
+					APIVersion: "v2",
+				},
+				Apply{
+					Manager: "apply-one",
+					Object: `
+						listOfLists:
+						- name: a
+					`,
+					APIVersion: "v3",
+				},
+			},
+			Object: `
+				listOfLists:
+				- name: a
+				  value:
+				  - b
+			`,
+			Managed: fieldpath.ManagedFields{
+				"apply-one": &fieldpath.VersionedSet{
+					Set: _NS(
+						_P("listOfLists", _KBF("name", _SV("a"))),
+						_P("listOfLists", _KBF("name", _SV("a")), "name"),
+					),
+					APIVersion: "v3",
+				},
+				"apply-two": &fieldpath.VersionedSet{
+					Set: _NS(
+						_P("listOfLists", _KBF("name", _SV("a"))),
+						_P("listOfLists", _KBF("name", _SV("a")), "name"),
+						_P("listOfLists", _KBF("name", _SV("a")), "value", _SV("b")),
+					),
+					APIVersion: "v2",
+				},
+			},
+		},
+		"remove_one_with_managed_subitem_keep_one": {
+			Ops: []Operation{
+				Apply{
+					Manager: "apply-one",
+					Object: `
+						listOfLists:
+						- name: a
+						- name: b
+						  value:
+						  - c
+					`,
+					APIVersion: "v1",
+				},
+				Apply{
+					Manager: "apply-two",
+					Object: `
+						listOfLists:
+						- name: a
+						  value:
+						  - b
+					`,
+					APIVersion: "v2",
+				},
+				Update{
+					Manager: "controller",
+					Object: `
+						listOfLists:
+						- name: a
+						  value:
+						  - b
+						- name: b
+						  value:
+						  - c
+						  - d
+					`,
+					APIVersion: "v2",
+				},
+				Apply{
+					Manager: "apply-one",
+					Object: `
+						listOfLists:
+						- name: a
+					`,
+					APIVersion: "v3",
+				},
+			},
+			Object: `
+				listOfLists:
+				- name: a
+				  value:
+				  - b
+			`,
+			Managed: fieldpath.ManagedFields{
+				"apply-one": &fieldpath.VersionedSet{
+					Set: _NS(
+						_P("listOfLists", _KBF("name", _SV("a"))),
+						_P("listOfLists", _KBF("name", _SV("a")), "name"),
+					),
+					APIVersion: "v3",
+				},
+				"apply-two": &fieldpath.VersionedSet{
+					Set: _NS(
+						_P("listOfLists", _KBF("name", _SV("a"))),
+						_P("listOfLists", _KBF("name", _SV("a")), "name"),
+						_P("listOfLists", _KBF("name", _SV("a")), "value", _SV("b")),
+					),
+					APIVersion: "v2",
+				},
+			},
+		},
+		"remove_one_keep_one_with_sub_item": {
+			Ops: []Operation{
+				Apply{
+					Manager: "apply-one",
+					Object: `
+						listOfLists:
+						- name: a
+						- name: b
+						  value:
+						  - c
+					`,
+					APIVersion: "v1",
+				},
+				Apply{
+					Manager: "apply-two",
+					Object: `
+						listOfLists:
+						- name: b
+						  value:
+						  - d
+					`,
+					APIVersion: "v2",
+				},
+				Apply{
+					Manager: "apply-one",
+					Object: `
+						listOfLists:
+						- name: a
+					`,
+					APIVersion: "v3",
+				},
+			},
+			Object: `
+				listOfLists:
+				- name: a
+				- name: b
+				  value:
+				  - d
+			`,
+			Managed: fieldpath.ManagedFields{
+				"apply-one": &fieldpath.VersionedSet{
+					Set: _NS(
+						_P("listOfLists", _KBF("name", _SV("a"))),
+						_P("listOfLists", _KBF("name", _SV("a")), "name"),
+					),
+					APIVersion: "v3",
+				},
+				"apply-two": &fieldpath.VersionedSet{
+					Set: _NS(
+						_P("listOfLists", _KBF("name", _SV("b"))),
+						_P("listOfLists", _KBF("name", _SV("b")), "name"),
+						_P("listOfLists", _KBF("name", _SV("b")), "value", _SV("d")),
+					),
+					APIVersion: "v2",
+				},
+			},
+		},
+		"multiple_appliers_recursive_map": {
+			Ops: []Operation{
+				Apply{
+					Manager: "apply-one",
+					Object: `
+						mapOfMapsRecursive:
+						  a:
+						    b:
+						  c:
+						    d:
+					`,
+					APIVersion: "v1",
+				},
+				Apply{
+					Manager: "apply-two",
+					Object: `
+						mapOfMapsRecursive:
+						  a:
+						  c:
+						    d:
+					`,
+					APIVersion: "v2",
+				},
+				Update{
+					Manager: "controller-one",
+					Object: `
+						mapOfMapsRecursive:
+						  a:
+						    b:
+						      c:
+						  c:
+						    d:
+						      e:
+					`,
+					APIVersion: "v3",
+				},
+				Update{
+					Manager: "controller-two",
+					Object: `
+						mapOfMapsRecursive:
+						  a:
+						    b:
+						      c:
+						        d:
+						  c:
+						    d:
+						      e:
+						        f:
+					`,
+					APIVersion: "v2",
+				},
+				Update{
+					Manager: "controller-one",
+					Object: `
+						mapOfMapsRecursive:
+						  a:
+						    b:
+						      c:
+						        d:
+						          e:
+						  c:
+						    d:
+						      e:
+						        f:
+						          g:
+					`,
+					APIVersion: "v3",
+				},
+				Apply{
+					Manager: "apply-one",
+					Object: `
+						mapOfMapsRecursive:
+					`,
+					APIVersion: "v4",
+				},
+			},
+			Object: `
+				mapOfMapsRecursive:
+				  a:
+				  c:
+				    d:
+				      e:
+				        f:
+				          g:
+			`,
+			Managed: fieldpath.ManagedFields{
+				"apply-two": &fieldpath.VersionedSet{
+					Set: _NS(
+						_P("mapOfMapsRecursive", "a"),
+						_P("mapOfMapsRecursive", "c"),
+						_P("mapOfMapsRecursive", "c", "d"),
+					),
+					APIVersion: "v2",
+				},
+				"controller-one": &fieldpath.VersionedSet{
+					Set: _NS(
+						_P("mapOfMapsRecursive", "c", "d", "e"),
+						_P("mapOfMapsRecursive", "c", "d", "e", "f", "g"),
+					),
+					APIVersion: "v3",
+				},
+				"controller-two": &fieldpath.VersionedSet{
+					Set: _NS(
+						_P("mapOfMapsRecursive", "c", "d", "e", "f"),
+					),
+					APIVersion: "v2",
+				},
+			},
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			if err := test.Test(nestedTypeParser); err != nil {
+				t.Fatal(err)
+			}
+		})
+	}
+}
+
+func TestMultipleAppliersRealConversion(t *testing.T) {
+	tests := map[string]TestCase{
+		"multiple_appliers_recursive_map_real_conversion": {
+			Ops: []Operation{
+				Apply{
+					Manager: "apply-one",
+					Object: `
+						mapOfMapsRecursive:
+						  a:
+						    b:
+						  c:
+						    d:
+					`,
+					APIVersion: "v1",
+				},
+				Apply{
+					Manager: "apply-two",
+					Object: `
+						mapOfMapsRecursive:
+						  aa:
+						  cc:
+						    dd:
+					`,
+					APIVersion: "v2",
+				},
+				Update{
+					Manager: "controller",
+					Object: `
+						mapOfMapsRecursive:
+						  aaa:
+						    bbb:
+						      ccc:
+						        ddd:
+						  ccc:
+						    ddd:
+						      eee:
+						        fff:
+					`,
+					APIVersion: "v3",
+				},
+				Apply{
+					Manager: "apply-one",
+					Object: `
+						mapOfMapsRecursive:
+					`,
+					APIVersion: "v4",
+				},
+			},
+			Object: `
+				mapOfMapsRecursive:
+				  aaaa:
+				  cccc:
+				    dddd:
+				      eeee:
+				        ffff:
+			`,
+			Managed: fieldpath.ManagedFields{
+				"apply-two": &fieldpath.VersionedSet{
+					Set: _NS(
+						_P("mapOfMapsRecursive", "aa"),
+						_P("mapOfMapsRecursive", "cc"),
+						_P("mapOfMapsRecursive", "cc", "dd"),
+					),
+					APIVersion: "v2",
+				},
+				"controller": &fieldpath.VersionedSet{
+					Set: _NS(
+						_P("mapOfMapsRecursive", "ccc", "ddd", "eee"),
+						_P("mapOfMapsRecursive", "ccc", "ddd", "eee", "fff"),
+					),
+					APIVersion: "v3",
+				},
+			},
+		},
+		"appliers_remove_from_controller_real_conversion": {
+			Ops: []Operation{
+				Update{
+					Manager: "controller",
+					Object: `
+						mapOfMapsRecursive:
+						  a:
+						    b:
+						      c:
+					`,
+					APIVersion: "v1",
+				},
+				Apply{
+					Manager: "apply",
+					Object: `
+						mapOfMapsRecursive:
+						  aa:
+						    bb:
+						  cc:
+						    dd:
+					`,
+					APIVersion: "v2",
+				},
+				Apply{
+					Manager: "apply",
+					Object: `
+						mapOfMapsRecursive:
+						  aaa:
+						  ccc:
+					`,
+					APIVersion: "v3",
+				},
+			},
+			Object: `
+				mapOfMapsRecursive:
+				  aaa:
+				  ccc:
+			`,
+			Managed: fieldpath.ManagedFields{
+				"controller": &fieldpath.VersionedSet{
+					Set: _NS(
+						_P("mapOfMapsRecursive"),
+						_P("mapOfMapsRecursive", "a"),
+					),
+					APIVersion: "v1",
+				},
+				"apply": &fieldpath.VersionedSet{
+					Set: _NS(
+						_P("mapOfMapsRecursive", "aaa"),
+						_P("mapOfMapsRecursive", "ccc"),
+					),
+					APIVersion: "v3",
+				},
+			},
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			if err := test.TestWithConverter(nestedTypeParser, repeatingConverter{nestedTypeParser}); err != nil {
+				t.Fatal(err)
+			}
+		})
+	}
+}
+
+// repeatingConverter repeats a single letterkey v times, where v is the version.
+type repeatingConverter struct{
+	typed.ParseableType
+}
+
+var _ merge.Converter = repeatingConverter{}
+
+var missingVersionError error = fmt.Errorf("cannot convert to invalid version")
+
+// Convert implements merge.Converter
+func (r repeatingConverter) Convert(v typed.TypedValue, version fieldpath.APIVersion) (typed.TypedValue, error) {
+	if len(version) < 2 || string(version)[0] != 'v' {
+		return nil, missingVersionError
+	}
+	versionNumber, err := strconv.Atoi(string(version)[1:len(version)])
+	if err != nil {
+		return nil, missingVersionError
+	}
+	y, err := v.AsValue().ToYAML()
+	if err != nil {
+		return nil, err
+	}
+	str := string(y)
+	var str2 string
+	for i, line := range strings.Split(str, "\n") {
+		if i == 0 {
+			str2 = line
+		} else {
+			spaces := strings.Repeat(" ", countLeadingSpace(line))
+			if len(spaces) == 0 {
+				break
+			}
+			c := line[len(spaces):len(spaces)+1]
+			c = strings.Repeat(c, versionNumber)
+			str2 = fmt.Sprintf("%v\n%v%v:", str2, spaces, c)
+		}
+	}
+	v2, err := r.ParseableType.FromYAML(typed.YAMLObject(str2))
+	if err != nil {
+		return nil, err
+	}
+	return v2, nil
+}
+
+func countLeadingSpace(line string) int {
+        spaces := 0
+        for _, letter := range line {
+                if letter == ' ' {
+                        spaces++
+                } else {
+                        break
+                }
+        }
+        return spaces
+}
+
+// Convert implements merge.Converter
+func (r repeatingConverter) IsMissingVersionError(err error) bool {
+	return err == missingVersionError
 }

--- a/merge/nested_test.go
+++ b/merge/nested_test.go
@@ -41,6 +41,9 @@ var nestedTypeParser = func() typed.ParseableType {
       - name: mapOfMaps
         type:
           namedType: mapOfMaps
+      - name: mapOfMapsRecursive
+        type:
+          namedType: mapOfMapsRecursive
 - name: listOfLists
   list:
     elementType:
@@ -89,6 +92,11 @@ var nestedTypeParser = func() typed.ParseableType {
     elementType:
       namedType: map
     elementRelationship: associative
+- name: mapOfMapsRecursive
+  map:
+    elementType:
+      namedType: mapOfMapsRecursive
+    elementRelationship: associative
 `)
 	if err != nil {
 		panic(err)
@@ -133,6 +141,7 @@ func TestUpdateNestedType(t *testing.T) {
 			Managed: fieldpath.ManagedFields{
 				"default": &fieldpath.VersionedSet{
 					Set: _NS(
+						_P("listOfLists", _KBF("name", _SV("a"))),
 						_P("listOfLists", _KBF("name", _SV("a")), "name"),
 						_P("listOfLists", _KBF("name", _SV("a")), "value", _SV("a")),
 						_P("listOfLists", _KBF("name", _SV("a")), "value", _SV("c")),
@@ -176,6 +185,7 @@ func TestUpdateNestedType(t *testing.T) {
 			Managed: fieldpath.ManagedFields{
 				"default": &fieldpath.VersionedSet{
 					Set: _NS(
+						_P("listOfLists", _KBF("name", _SV("b"))),
 						_P("listOfLists", _KBF("name", _SV("b")), "name"),
 						_P("listOfLists", _KBF("name", _SV("b")), "value", _SV("a")),
 						_P("listOfLists", _KBF("name", _SV("b")), "value", _SV("c")),
@@ -219,6 +229,7 @@ func TestUpdateNestedType(t *testing.T) {
 			Managed: fieldpath.ManagedFields{
 				"default": &fieldpath.VersionedSet{
 					Set: _NS(
+						_P("listOfMaps", _KBF("name", _SV("a"))),
 						_P("listOfMaps", _KBF("name", _SV("a")), "name"),
 						_P("listOfMaps", _KBF("name", _SV("a")), "value", "a"),
 						_P("listOfMaps", _KBF("name", _SV("a")), "value", "c"),
@@ -262,6 +273,7 @@ func TestUpdateNestedType(t *testing.T) {
 			Managed: fieldpath.ManagedFields{
 				"default": &fieldpath.VersionedSet{
 					Set: _NS(
+						_P("listOfMaps", _KBF("name", _SV("b"))),
 						_P("listOfMaps", _KBF("name", _SV("b")), "name"),
 						_P("listOfMaps", _KBF("name", _SV("b")), "value", "a"),
 						_P("listOfMaps", _KBF("name", _SV("b")), "value", "c"),
@@ -302,6 +314,7 @@ func TestUpdateNestedType(t *testing.T) {
 			Managed: fieldpath.ManagedFields{
 				"default": &fieldpath.VersionedSet{
 					Set: _NS(
+						_P("mapOfLists", "a"),
 						_P("mapOfLists", "a", _SV("a")),
 						_P("mapOfLists", "a", _SV("c")),
 					),
@@ -341,6 +354,7 @@ func TestUpdateNestedType(t *testing.T) {
 			Managed: fieldpath.ManagedFields{
 				"default": &fieldpath.VersionedSet{
 					Set: _NS(
+						_P("mapOfLists", "b"),
 						_P("mapOfLists", "b", _SV("a")),
 						_P("mapOfLists", "b", _SV("c")),
 					),
@@ -380,6 +394,7 @@ func TestUpdateNestedType(t *testing.T) {
 			Managed: fieldpath.ManagedFields{
 				"default": &fieldpath.VersionedSet{
 					Set: _NS(
+						_P("mapOfMaps", "a"),
 						_P("mapOfMaps", "a", "a"),
 						_P("mapOfMaps", "a", "c"),
 					),
@@ -419,8 +434,49 @@ func TestUpdateNestedType(t *testing.T) {
 			Managed: fieldpath.ManagedFields{
 				"default": &fieldpath.VersionedSet{
 					Set: _NS(
+						_P("mapOfMaps", "b"),
 						_P("mapOfMaps", "b", "a"),
 						_P("mapOfMaps", "b", "c"),
+					),
+					APIVersion: "v1",
+				},
+			},
+		},
+		"mapOfMapsRecursive_change_middle_key": {
+			Ops: []Operation{
+				Apply{
+					Manager: "default",
+					Object: `
+						mapOfMapsRecursive:
+						  a:
+						    b:
+						      c:
+					`,
+					APIVersion: "v1",
+				},
+				Apply{
+					Manager: "default",
+					Object: `
+						mapOfMapsRecursive:
+						  a:
+						    d:
+						      c:
+					`,
+					APIVersion: "v1",
+				},
+			},
+			Object: `
+				mapOfMapsRecursive:
+				  a:
+				    d:
+				      c:
+			`,
+			Managed: fieldpath.ManagedFields{
+				"default": &fieldpath.VersionedSet{
+					Set: _NS(
+						_P("mapOfMapsRecursive", "a"),
+						_P("mapOfMapsRecursive", "a", "d"),
+						_P("mapOfMapsRecursive", "a", "d", "c"),
 					),
 					APIVersion: "v1",
 				},

--- a/merge/update.go
+++ b/merge/update.go
@@ -181,6 +181,10 @@ func shallowCopyManagers(managers fieldpath.ManagedFields) fieldpath.ManagedFiel
 	return newManagers
 }
 
+// prune will remove a list or map item, iff:
+// * applyingManager applied it last time
+// * applyingManager didn't apply it this time
+// * no other applier claims to manage it
 func (s *Updater) prune(merged typed.TypedValue, managers fieldpath.ManagedFields, applyingManager string, lastSet *fieldpath.VersionedSet) (typed.TypedValue, error) {
 	if lastSet == nil || lastSet.Set.Empty() {
 		return merged, nil
@@ -204,6 +208,8 @@ func (s *Updater) prune(merged typed.TypedValue, managers fieldpath.ManagedField
 	return s.Converter.Convert(pruned, managers[applyingManager].APIVersion)
 }
 
+// addBackOwnedItems adds back any list and map items that were removed by prune,
+// but other appliers (or the current applier's new config) claim to own.
 func (s *Updater) addBackOwnedItems(merged, pruned typed.TypedValue, managedFields fieldpath.ManagedFields, applyingManager string) (typed.TypedValue, error) {
 	var err error
 	managedAtVersion := map[fieldpath.APIVersion]*fieldpath.Set{}
@@ -243,6 +249,10 @@ func (s *Updater) addBackOwnedItems(merged, pruned typed.TypedValue, managedFiel
 	return pruned, nil
 }
 
+
+// addBackDanglingItems makes sure that the only items removed by prune are items that were
+// previously owned by the currently applying manager. This will add back unowned items and items
+// which are owned by Updaters that shouldn't be removed.
 func (s *Updater) addBackDanglingItems(merged, pruned typed.TypedValue, lastSet *fieldpath.VersionedSet) (typed.TypedValue, error) {
 	convertedPruned, err := s.Converter.Convert(pruned, lastSet.APIVersion)
 	if err != nil {

--- a/merge/update.go
+++ b/merge/update.go
@@ -176,5 +176,5 @@ func (s *Updater) removeDisownedItems(merged, applied typed.TypedValue, lastSet 
 	if err != nil {
 		return nil, fmt.Errorf("failed to create field set from applied config in last applied version: %v", err)
 	}
-	return merged.RemoveItems(lastSet.Set, appliedSet), nil
+	return merged.RemoveItems(lastSet.Set.Difference(appliedSet)), nil
 }

--- a/typed/deduced.go
+++ b/typed/deduced.go
@@ -173,6 +173,6 @@ func modified(lhs, rhs value.Value, path fieldpath.Path, set *fieldpath.Set) {
 
 // RemoveItems does nothing because all lists in a deducedTypedValue are considered atomic,
 // and there are no maps because it is indistinguishable from a struct.
-func (dv deducedTypedValue) RemoveItems(_ *fieldpath.Set, _ *fieldpath.Set) TypedValue {
+func (dv deducedTypedValue) RemoveItems(_ *fieldpath.Set) TypedValue {
 	return dv
 }

--- a/typed/remove.go
+++ b/typed/remove.go
@@ -86,6 +86,10 @@ func (w *removingWalker) doList(t schema.List) (errs ValidationErrors) {
 		newItems = append(newItems, l.Items[i])
 	}
 	l.Items = newItems
+	if len(l.Items) == 0 {
+		w.value.ListValue = nil
+		w.value.Null = true
+	}
 	return nil
 }
 
@@ -111,6 +115,10 @@ func (w *removingWalker) doMap(t schema.Map) ValidationErrors {
 		newMap.Set(item.Name, m.Items[i].Value)
 	}
 	w.value.MapValue = newMap
+	if len(w.value.MapValue.Items) == 0 {
+		w.value.MapValue = nil
+		w.value.Null = true
+	}
 	return nil
 }
 

--- a/typed/remove.go
+++ b/typed/remove.go
@@ -20,18 +20,16 @@ import (
 )
 
 type removingWalker struct {
-	value  *value.Value
-	schema *schema.Schema
-	lhs    *fieldpath.Set
-	rhs    *fieldpath.Set
+	value    *value.Value
+	schema   *schema.Schema
+	toRemove *fieldpath.Set
 }
 
-func removeItemsWithSchema(value *value.Value, lhs *fieldpath.Set, rhs *fieldpath.Set, schema *schema.Schema, typeRef schema.TypeRef) {
+func removeItemsWithSchema(value *value.Value, toRemove *fieldpath.Set, schema *schema.Schema, typeRef schema.TypeRef) {
 	w := &removingWalker{
-		value:  value,
-		schema: schema,
-		lhs:    lhs,
-		rhs:    rhs,
+		value:    value,
+		schema:   schema,
+		toRemove: toRemove,
 	}
 	resolveSchema(schema, typeRef, w)
 }
@@ -58,10 +56,8 @@ func (w *removingWalker) doStruct(t schema.Struct) ValidationErrors {
 	for i, _ := range s.Items {
 		item := s.Items[i]
 		pe := fieldpath.PathElement{FieldName: &item.Name}
-		subsetLHS := w.lhs.WithPrefix(pe)
-		subsetRHS := w.rhs.WithPrefix(pe)
-		if !subsetLHS.Empty() {
-			removeItemsWithSchema(&s.Items[i].Value, subsetLHS, subsetRHS, w.schema, fieldTypes[item.Name])
+		if subset := w.toRemove.WithPrefix(pe); !subset.Empty() {
+			removeItemsWithSchema(&s.Items[i].Value, subset, w.schema, fieldTypes[item.Name])
 		}
 	}
 	return nil
@@ -80,13 +76,12 @@ func (w *removingWalker) doList(t schema.List) (errs ValidationErrors) {
 		item := l.Items[i]
 		// Ignore error because we have already validated this list
 		pe, _ := listItemToPathElement(t, i, item)
-		subsetLHS := w.lhs.WithPrefix(pe)
-		subsetRHS := w.rhs.WithPrefix(pe)
-		if !subsetLHS.Empty() {
-			if subsetRHS.Empty() {
-				continue
-			}
-			removeItemsWithSchema(&l.Items[i], subsetLHS, subsetRHS, w.schema, t.ElementType)
+		path, _ := fieldpath.MakePath(pe)
+		if w.toRemove.Has(path) {
+			continue
+		}
+		if subset := w.toRemove.WithPrefix(pe); !subset.Empty() {
+			removeItemsWithSchema(&l.Items[i], subset, w.schema, t.ElementType)
 		}
 		newItems = append(newItems, l.Items[i])
 	}
@@ -106,13 +101,12 @@ func (w *removingWalker) doMap(t schema.Map) ValidationErrors {
 	for i, _ := range m.Items {
 		item := m.Items[i]
 		pe := fieldpath.PathElement{FieldName: &item.Name}
-		subsetLHS := w.lhs.WithPrefix(pe)
-		subsetRHS := w.rhs.WithPrefix(pe)
-		if !subsetLHS.Empty() {
-			if subsetRHS.Empty() {
-				continue
-			}
-			removeItemsWithSchema(&m.Items[i].Value, subsetLHS, subsetRHS, w.schema, t.ElementType)
+		path, _ := fieldpath.MakePath(pe)
+		if w.toRemove.Has(path) {
+			continue
+		}
+		if subset := w.toRemove.WithPrefix(pe); !subset.Empty() {
+			removeItemsWithSchema(&m.Items[i].Value, subset, w.schema, t.ElementType)
 		}
 		newMap.Set(item.Name, m.Items[i].Value)
 	}

--- a/typed/toset_test.go
+++ b/typed/toset_test.go
@@ -166,8 +166,8 @@ var fieldsetCases = []fieldsetTestCase{{
 		{`{"arbitraryWavelengthColor":{"IR":255}}`, _NS(_P("arbitraryWavelengthColor"))},
 		{`{"args":[]}`, _NS(_P("args"))},
 		{`{"args":null}`, _NS(_P("args"))},
-		{`{"args":[null]}`, _NS(_P("args"))},
-		{`{"args":[{"key":"a","value":"b"},{"key":"c","value":"d"}]}`, _NS(_P("args"))},
+		{`{"args":[null]}`,_NS(_P("args"))},
+		{`{"args":[{"key":"a","value":"b"},{"key":"c","value":"d"}]}`,_NS(_P("args"))},
 	},
 }, {
 	name:         "associative list",
@@ -221,11 +221,15 @@ var fieldsetCases = []fieldsetTestCase{{
 	pairs: []objSetPair{
 		{`{"list":[]}`, _NS()},
 		{`{"list":[{"key":"a","id":1,"value":{"a":"a"}}]}`, _NS(
+			_P("list", _KBF("key", _SV("a"), "id", _IV(1))),
 			_P("list", _KBF("key", _SV("a"), "id", _IV(1)), "key"),
 			_P("list", _KBF("key", _SV("a"), "id", _IV(1)), "id"),
 			_P("list", _KBF("key", _SV("a"), "id", _IV(1)), "value", "a"),
 		)},
 		{`{"list":[{"key":"a","id":1},{"key":"a","id":2},{"key":"b","id":1}]}`, _NS(
+			_P("list", _KBF("key", _SV("a"), "id", _IV(1))),
+			_P("list", _KBF("key", _SV("a"), "id", _IV(2))),
+			_P("list", _KBF("key", _SV("b"), "id", _IV(1))),
 			_P("list", _KBF("key", _SV("a"), "id", _IV(1)), "key"),
 			_P("list", _KBF("key", _SV("a"), "id", _IV(1)), "id"),
 			_P("list", _KBF("key", _SV("a"), "id", _IV(2)), "key"),

--- a/typed/typed.go
+++ b/typed/typed.go
@@ -53,8 +53,8 @@ type TypedValue interface {
 	// match), or an error will be returned. Validation errors will be returned if
 	// the objects don't conform to the schema.
 	Compare(rhs TypedValue) (c *Comparison, err error)
-	// RemoveItems removes each list or map item from the value that has children in lhs and not in rhs.
-	RemoveItems(lhs *fieldpath.Set, rhs *fieldpath.Set) TypedValue
+	// RemoveItems removes each provided list or map item from the value.
+	RemoveItems(items *fieldpath.Set) TypedValue
 }
 
 // AsTyped accepts a value and a type and returns a TypedValue. 'v' must have
@@ -161,9 +161,9 @@ func (tv typedValue) Compare(rhs TypedValue) (c *Comparison, err error) {
 	return c, nil
 }
 
-// RemoveItems removes each list or map item from the value that has children in lhs and not in rhs.
-func (tv typedValue) RemoveItems(lhs *fieldpath.Set, rhs *fieldpath.Set) TypedValue {
-	removeItemsWithSchema(&tv.value, lhs, rhs, tv.schema, tv.typeRef)
+// RemoveItems removes each provided list or map item from the value.
+func (tv typedValue) RemoveItems(items *fieldpath.Set) TypedValue {
+	removeItemsWithSchema(&tv.value, items, tv.schema, tv.typeRef)
 	return tv
 }
 


### PR DESCRIPTION
The goal of this PR is to define and implement the behavior of apply when it comes to removing list and map items. The strategy implemented here is most simply defined as:
```
Remove an item on apply, iff someone applied with it last time, without it this time,
and no other applier claims to manage it.
```

This solution works without converting any PSOs or fieldsets, and with linear number of conversions wrt the number of versions (so the number of conversions is only getting increased by a constant factor). The downside is that it requires exposing the concept of whether or not a manager is an updater or an applier.

I have tried to include tests for every possible corner case, like multiple appliers and updaters all of different versions, and fields which are dangling without any owner, but shouldn't be removed.

cc @apelisse @kwiesmueller @lavalamp 