### PR TITLE
Integrate union in Apply/Update path

### DIFF
--- a/internal/fixture/state.go
+++ b/internal/fixture/state.go
@@ -92,11 +92,11 @@ func (s *State) Update(obj typed.YAMLObject, version fieldpath.APIVersion, manag
 	if err != nil {
 		return err
 	}
-	managers, err := s.Updater.Update(s.Live, tv, version, s.Managers, manager)
+	newObj, managers, err := s.Updater.Update(s.Live, tv, version, s.Managers, manager)
 	if err != nil {
 		return err
 	}
-	s.Live = tv
+	s.Live = newObj
 	s.Managers = managers
 
 	return nil

--- a/merge/union_test.go
+++ b/merge/union_test.go
@@ -1,0 +1,185 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package merge_test
+
+import (
+	"testing"
+
+	"sigs.k8s.io/structured-merge-diff/fieldpath"
+	. "sigs.k8s.io/structured-merge-diff/internal/fixture"
+	"sigs.k8s.io/structured-merge-diff/merge"
+	"sigs.k8s.io/structured-merge-diff/typed"
+)
+
+var unionFieldsParser = func() typed.ParseableType {
+	parser, err := typed.NewParser(`types:
+- name: unionFields
+  struct:
+    fields:
+    - name: numeric
+      type:
+        scalar: numeric
+    - name: string
+      type:
+        scalar: string
+    - name: type
+      type:
+        scalar: string
+    union:
+      discriminator: type
+      fields:
+      - fieldName: numeric
+        discriminatedBy: Numeric
+      - fieldName: string
+        discriminatedBy: String`)
+	if err != nil {
+		panic(err)
+	}
+	return parser.Type("unionFields")
+}()
+
+func TestUnion(t *testing.T) {
+	tests := map[string]TestCase{
+		"union_apply_owns_discriminator": {
+			Ops: []Operation{
+				Apply{
+					Manager:    "default",
+					APIVersion: "v1",
+					Object: `
+						numeric: 1
+					`,
+				},
+			},
+			Object: `
+				numeric: 1
+				type: Numeric
+			`,
+			Managed: fieldpath.ManagedFields{
+				"default": &fieldpath.VersionedSet{
+					Set: _NS(
+						_P("numeric"), _P("type"),
+					),
+					APIVersion: "v1",
+				},
+			},
+		},
+		"union_apply_without_discriminator_conflict": {
+			Ops: []Operation{
+				Update{
+					Manager:    "controller",
+					APIVersion: "v1",
+					Object: `
+						string: "some string"
+					`,
+				},
+				Apply{
+					Manager:    "default",
+					APIVersion: "v1",
+					Object: `
+						numeric: 1
+					`,
+					Conflicts: merge.Conflicts{
+						merge.Conflict{Manager: "controller", Path: _P("type")},
+					},
+				},
+			},
+			Object: `
+				string: "some string"
+				type: String
+			`,
+			Managed: fieldpath.ManagedFields{
+				"controller": &fieldpath.VersionedSet{
+					Set: _NS(
+						_P("string"), _P("type"),
+					),
+					APIVersion: "v1",
+				},
+			},
+		},
+		"union_apply_with_null_value": {
+			Ops: []Operation{
+				Apply{
+					Manager:    "default",
+					APIVersion: "v1",
+					Object: `
+						type: Numeric
+						string: null
+						numeric: 1
+					`,
+				},
+			},
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			if err := test.Test(unionFieldsParser); err != nil {
+				t.Fatal(err)
+			}
+		})
+	}
+}
+
+func TestUnionErrors(t *testing.T) {
+	tests := map[string]TestCase{
+		"union_apply_two": {
+			Ops: []Operation{
+				Apply{
+					Manager:    "default",
+					APIVersion: "v1",
+					Object: `
+						numeric: 1
+						string: "some string"
+					`,
+				},
+			},
+		},
+		"union_apply_two_and_discriminator": {
+			Ops: []Operation{
+				Apply{
+					Manager:    "default",
+					APIVersion: "v1",
+					Object: `
+						type: Numeric
+						string: "some string"
+						numeric: 1
+					`,
+				},
+			},
+		},
+		"union_apply_wrong_discriminator": {
+			Ops: []Operation{
+				Apply{
+					Manager:    "default",
+					APIVersion: "v1",
+					Object: `
+						type: Numeric
+						string: "some string"
+					`,
+				},
+			},
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			if test.Test(unionFieldsParser) == nil {
+				t.Fatal("Should fail")
+			}
+		})
+	}
+}

--- a/typed/typed.go
+++ b/typed/typed.go
@@ -159,16 +159,15 @@ func (tv TypedValue) RemoveItems(items *fieldpath.Set) *TypedValue {
 func (tv TypedValue) NormalizeUnions(new *TypedValue) (*TypedValue, error) {
 	var errs ValidationErrors
 	var normalizeFn = func(w *mergingWalker) {
-		if err := normalizeUnion(w); err != nil {
-			errs = append(errs, w.error(err)...)
-		}
-	}
-	out, mergeErrs := merge(&tv, new, func(w *mergingWalker) {
 		if w.rhs != nil {
 			v := *w.rhs
 			w.out = &v
 		}
-	}, normalizeFn)
+		if err := normalizeUnion(w); err != nil {
+			errs = append(errs, w.error(err)...)
+		}
+	}
+	out, mergeErrs := merge(&tv, new, func(w *mergingWalker) {}, normalizeFn)
 	if mergeErrs != nil {
 		errs = append(errs, mergeErrs.(ValidationErrors)...)
 	}

--- a/typed/typed.go
+++ b/typed/typed.go
@@ -177,6 +177,11 @@ func (tv TypedValue) NormalizeUnions(new *TypedValue) (*TypedValue, error) {
 	return out, nil
 }
 
+func (tv TypedValue) Empty() *TypedValue {
+	tv.value = value.Value{Null: true}
+	return &tv
+}
+
 func merge(lhs, rhs *TypedValue, rule, postRule mergeRule) (*TypedValue, error) {
 	if lhs.schema != rhs.schema {
 		return nil, errorFormatter{}.

--- a/typed/union_test.go
+++ b/typed/union_test.go
@@ -198,6 +198,12 @@ func TestNormalizeUnions(t *testing.T) {
 			new:  `{"one": 1}`,
 			out:  `{"one": 1, "discriminator": "One"}`,
 		},
+		{
+			name: "new object has three of same union set but one is null",
+			old:  `{"one": 1}`,
+			new:  `{"one": 2, "two": 1, "three": null}`,
+			out:  `{"two": 1, "discriminator": "TWO"}`,
+		},
 		// These use-cases shouldn't happen:
 		{
 			name: "one field removed, discriminator unchanged",


### PR DESCRIPTION
Fix a few bugs, change the interface a little, and call unions. Once this gets integrated, kubernetes should be able to support union, as long as the schema properly defines it (which misses a couple of steps).