### PR TITLE
Change union to not "guess" based on difference

### DIFF
--- a/merge/union_test.go
+++ b/merge/union_test.go
@@ -50,14 +50,14 @@ var unionFieldsParser = func() typed.ParseableType {
       deduceInvalidDiscriminator: true
       fields:
       - fieldName: numeric
-        discriminatedBy: Numeric
+        discriminatorValue: Numeric
       - fieldName: string
-        discriminatedBy: String
+        discriminatorValue: String
     - fields:
       - fieldName: fieldA
-        discriminatedBy: FieldA
+        discriminatorValue: FieldA
       - fieldName: fieldB
-        discriminatedBy: FieldB`)
+        discriminatorValue: FieldB`)
 	if err != nil {
 		panic(err)
 	}

--- a/merge/union_test.go
+++ b/merge/union_test.go
@@ -47,6 +47,7 @@ var unionFieldsParser = func() typed.ParseableType {
         scalar: string
     unions:
     - discriminator: type
+      deduceInvalidDiscriminator: true
       fields:
       - fieldName: numeric
         discriminatedBy: Numeric

--- a/merge/update.go
+++ b/merge/update.go
@@ -151,7 +151,7 @@ func (s *Updater) Update(liveObject, newObject *typed.TypedValue, version fieldp
 // and return it.
 func (s *Updater) Apply(liveObject, configObject *typed.TypedValue, version fieldpath.APIVersion, managers fieldpath.ManagedFields, manager string, force bool) (*typed.TypedValue, fieldpath.ManagedFields, error) {
 	managers = shallowCopyManagers(managers)
-	configObject, err := configObject.Empty().NormalizeUnions(configObject)
+	configObject, err := configObject.NormalizeUnionsApply(configObject)
 	if err != nil {
 		return nil, fieldpath.ManagedFields{}, err
 	}
@@ -159,7 +159,7 @@ func (s *Updater) Apply(liveObject, configObject *typed.TypedValue, version fiel
 	if err != nil {
 		return nil, fieldpath.ManagedFields{}, fmt.Errorf("failed to merge config: %v", err)
 	}
-	newObject, err = liveObject.NormalizeUnions(newObject)
+	newObject, err = configObject.NormalizeUnionsApply(newObject)
 	if err != nil {
 		return nil, fieldpath.ManagedFields{}, err
 	}

--- a/schema/elements.go
+++ b/schema/elements.go
@@ -126,10 +126,10 @@ type UnionField struct {
 	// FieldName is the name of the field that is part of the union. This
 	// is the serialized form of the field.
 	FieldName string `yaml:"fieldName"`
-	// DiscriminatedBy is the value of the discriminator to select that
-	// field. If the union doesn't have a discriminator, this field is
-	// ignored.
-	DiscriminatedBy string `yaml:"discriminatedBy"`
+	// Discriminatorvalue is the value of the discriminator to
+	// select that field. If the union doesn't have a discriminator,
+	// this field is ignored.
+	DiscriminatorValue string `yaml:"discriminatorValue"`
 }
 
 // Union, or oneof, means that only one of multiple fields of a structure can be

--- a/schema/schemaschema.go
+++ b/schema/schemaschema.go
@@ -96,7 +96,7 @@ var SchemaSchemaYAML = `types:
     - name: fieldName
       type:
         scalar: string
-    - name: discriminatedBy
+    - name: discriminatorValue
       type:
         scalar: string
 - name: union

--- a/schema/schemaschema.go
+++ b/schema/schemaschema.go
@@ -105,6 +105,9 @@ var SchemaSchemaYAML = `types:
     - name: discriminator
       type:
         scalar: string
+    - name: deduceInvalidDiscriminator
+      type:
+        scalar: bool
     - name: fields
       type:
         list:

--- a/typed/union.go
+++ b/typed/union.go
@@ -203,7 +203,7 @@ func newUnion(su *schema.Union) *union {
 	f2d := map[field]discriminated{}
 	for _, f := range su.Fields {
 		u.f = append(u.f, field(f.FieldName))
-		f2d[field(f.FieldName)] = discriminated(f.DiscriminatedBy)
+		f2d[field(f.FieldName)] = discriminated(f.DiscriminatorValue)
 	}
 	u.dn = newDiscriminatedName(f2d)
 	u.deduceInvalidDiscriminator = su.DeduceInvalidDiscriminator

--- a/typed/union.go
+++ b/typed/union.go
@@ -46,6 +46,28 @@ func normalizeUnions(w *mergingWalker) error {
 	return nil
 }
 
+func normalizeUnionsApply(w *mergingWalker) error {
+	atom, found := w.schema.Resolve(w.typeRef)
+	if !found {
+		panic(fmt.Sprintf("Unable to resolve schema in normalize union: %v/%v", w.schema, w.typeRef))
+	}
+	// Unions can only be in structures, and the struct must not have been removed
+	if atom.Map == nil || w.out == nil {
+		return nil
+	}
+
+	old := &value.Map{}
+	if w.lhs != nil {
+		old = w.lhs.MapValue
+	}
+	for _, union := range atom.Map.Unions {
+		if err := newUnion(&union).NormalizeApply(old, w.rhs.MapValue, w.out.MapValue); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
 type discriminated string
 type field string
 
@@ -167,9 +189,10 @@ func (fs fieldsSet) String() string {
 }
 
 type union struct {
-	d  *discriminator
-	dn discriminatedNames
-	f  []field
+	deduceInvalidDiscriminator bool
+	d                          *discriminator
+	dn                         discriminatedNames
+	f                          []field
 }
 
 func newUnion(su *schema.Union) *union {
@@ -183,6 +206,7 @@ func newUnion(su *schema.Union) *union {
 		f2d[field(f.FieldName)] = discriminated(f.DiscriminatedBy)
 	}
 	u.dn = newDiscriminatedName(f2d)
+	u.deduceInvalidDiscriminator = su.DeduceInvalidDiscriminator
 	return u
 }
 
@@ -201,29 +225,49 @@ func (u *union) Normalize(old, new, out *value.Map) error {
 	ns := newFieldsSet(new, u.f)
 	diff := ns.Difference(os)
 
-	if len(ns) > 1 && len(diff) != 1 {
-		return fmt.Errorf("unable to guess new discriminator amongst new fields: %v", diff)
-	}
-
-	discriminator := field("")
-	if len(ns) == 1 {
-		discriminator = *ns.One()
-	} else if len(diff) == 1 {
-		discriminator = *diff.One()
-	}
-
 	if u.d.Get(old) != u.d.Get(new) && u.d.Get(new) != "" {
-		if len(diff) == 1 && u.d.Get(new) != u.dn.toDiscriminated(discriminator) {
-			return fmt.Errorf("discriminator (%v) and field changed (%v)", u.d.Get(new), discriminator)
+		if len(diff) == 1 && u.d.Get(new) != u.dn.toDiscriminated(*diff.One()) {
+			return fmt.Errorf("discriminator (%v) and field changed (%v) don't match", u.d.Get(new), diff.One())
+		}
+		if len(diff) > 1 {
+			return fmt.Errorf("multiple new fields added: %v", diff)
 		}
 		u.clear(out, u.dn.toField(u.d.Get(new)))
 		return nil
 	}
 
-	if discriminator != "" {
-		u.clear(out, discriminator)
-		u.d.Set(out, u.dn.toDiscriminated(discriminator))
+	if len(ns) > 1 {
+		return fmt.Errorf("multiple fields set without discriminator change: %v", ns)
 	}
+
+	// Update discriminiator if it needs to be deduced.
+	if u.deduceInvalidDiscriminator && len(ns) == 1 {
+		u.d.Set(out, u.dn.toDiscriminated(*ns.One()))
+	}
+
+	return nil
+}
+
+func (u *union) NormalizeApply(applied, merged, out *value.Map) error {
+	as := newFieldsSet(applied, u.f)
+	if len(as) > 1 {
+		return fmt.Errorf("more than one field of union applied: %v", as)
+	}
+	if len(as) == 0 {
+		// None is set, just leave.
+		return nil
+	}
+	// We have exactly one, discriminiator must match if set
+	if u.d.Get(applied) != "" && u.d.Get(applied) != u.dn.toDiscriminated(*as.One()) {
+		return fmt.Errorf("applied discriminator (%v) doesn't match applied field (%v)", u.d.Get(applied), *as.One())
+	}
+
+	// Update discriminiator if needed
+	if u.deduceInvalidDiscriminator {
+		u.d.Set(out, u.dn.toDiscriminated(*as.One()))
+	}
+	// Clear others fields.
+	u.clear(out, *as.One())
 
 	return nil
 }

--- a/typed/union_test.go
+++ b/typed/union_test.go
@@ -53,17 +53,17 @@ var unionParser = func() typed.ParseableType {
       deduceInvalidDiscriminator: true
       fields:
       - fieldName: one
-        discriminatedBy: One
+        discriminatorValue: One
       - fieldName: two
-        discriminatedBy: TWO
+        discriminatorValue: TWO
       - fieldName: three
-        discriminatedBy: three
+        discriminatorValue: three
     - discriminator: letter
       fields:
       - fieldName: a
-        discriminatedBy: A
+        discriminatorValue: A
       - fieldName: b
-        discriminatedBy: b`)
+        discriminatorValue: b`)
 	if err != nil {
 		panic(err)
 	}


### PR DESCRIPTION
We're still using the difference, but only to see if something wrong was sent.
    
The new logic is to only trust the disicriminator, which means that the
behavior for non-discriminated union is now back to before. It also
means that we can't use that process anymore to normalize applied
unions. Applied unions are normalized by trusting the applied fields
exclusively: applying two fields doesn't work, applying a discriminator
and a different value doesn't work.

Also rename `discriminatedBy` into `discriminatorValue`