### PR TITLE
Make VersionedSet into an interface

### DIFF
--- a/fieldpath/managers_test.go
+++ b/fieldpath/managers_test.go
@@ -44,98 +44,112 @@ func TestManagersDifference(t *testing.T) {
 		{
 			name: "Empty RHS",
 			lhs: fieldpath.ManagedFields{
-				"default": &fieldpath.VersionedSet{
-					Set:        _NS(_P("numeric"), _P("string"), _P("bool")),
-					APIVersion: "v1",
-				},
+				"default": fieldpath.NewVersionedSet(
+					_NS(_P("numeric"), _P("string"), _P("bool")),
+					"v1",
+					false,
+				),
 			},
 			out: fieldpath.ManagedFields{
-				"default": &fieldpath.VersionedSet{
-					Set:        _NS(_P("numeric"), _P("string"), _P("bool")),
-					APIVersion: "v1",
-				},
+				"default": fieldpath.NewVersionedSet(
+					_NS(_P("numeric"), _P("string"), _P("bool")),
+					"v1",
+					false,
+				),
 			},
 		},
 		{
 			name: "Empty LHS",
 			rhs: fieldpath.ManagedFields{
-				"default": &fieldpath.VersionedSet{
-					Set:        _NS(_P("numeric"), _P("string"), _P("bool")),
-					APIVersion: "v1",
-				},
+				"default": fieldpath.NewVersionedSet(
+					_NS(_P("numeric"), _P("string"), _P("bool")),
+					"v1",
+					false,
+				),
 			},
 			out: fieldpath.ManagedFields{
-				"default": &fieldpath.VersionedSet{
-					Set:        _NS(_P("numeric"), _P("string"), _P("bool")),
-					APIVersion: "v1",
-				},
+				"default": fieldpath.NewVersionedSet(
+					_NS(_P("numeric"), _P("string"), _P("bool")),
+					"v1",
+					false,
+				),
 			},
 		},
 		{
 			name: "Different managers",
 			lhs: fieldpath.ManagedFields{
-				"one": &fieldpath.VersionedSet{
-					Set:        _NS(_P("numeric"), _P("string"), _P("bool")),
-					APIVersion: "v1",
-				},
+				"one": fieldpath.NewVersionedSet(
+					_NS(_P("numeric"), _P("string"), _P("bool")),
+					"v1",
+					false,
+				),
 			},
 			rhs: fieldpath.ManagedFields{
-				"two": &fieldpath.VersionedSet{
-					Set:        _NS(_P("numeric"), _P("string"), _P("bool")),
-					APIVersion: "v1",
-				},
+				"two": fieldpath.NewVersionedSet(
+					_NS(_P("numeric"), _P("string"), _P("bool")),
+					"v1",
+					false,
+				),
 			},
 			out: fieldpath.ManagedFields{
-				"one": &fieldpath.VersionedSet{
-					Set:        _NS(_P("numeric"), _P("string"), _P("bool")),
-					APIVersion: "v1",
-				},
-				"two": &fieldpath.VersionedSet{
-					Set:        _NS(_P("numeric"), _P("string"), _P("bool")),
-					APIVersion: "v1",
-				},
+				"one": fieldpath.NewVersionedSet(
+					_NS(_P("numeric"), _P("string"), _P("bool")),
+					"v1",
+					false,
+				),
+				"two": fieldpath.NewVersionedSet(
+					_NS(_P("numeric"), _P("string"), _P("bool")),
+					"v1",
+					false,
+				),
 			},
 		},
 		{
 			name: "Same manager, different version",
 			lhs: fieldpath.ManagedFields{
-				"one": &fieldpath.VersionedSet{
-					Set:        _NS(_P("numeric"), _P("string"), _P("integer")),
-					APIVersion: "v1",
-				},
+				"one": fieldpath.NewVersionedSet(
+					_NS(_P("numeric"), _P("string"), _P("integer")),
+					"v1",
+					false,
+				),
 			},
 			rhs: fieldpath.ManagedFields{
-				"one": &fieldpath.VersionedSet{
-					Set:        _NS(_P("numeric"), _P("string"), _P("bool")),
-					APIVersion: "v2",
-				},
+				"one": fieldpath.NewVersionedSet(
+					_NS(_P("numeric"), _P("string"), _P("bool")),
+					"v2",
+					false,
+				),
 			},
 			out: fieldpath.ManagedFields{
-				"one": &fieldpath.VersionedSet{
-					Set:        _NS(_P("numeric"), _P("string"), _P("bool")),
-					APIVersion: "v2",
-				},
+				"one": fieldpath.NewVersionedSet(
+					_NS(_P("numeric"), _P("string"), _P("bool")),
+					"v2",
+					false,
+				),
 			},
 		},
 		{
 			name: "Set difference",
 			lhs: fieldpath.ManagedFields{
-				"one": &fieldpath.VersionedSet{
-					Set:        _NS(_P("numeric"), _P("string")),
-					APIVersion: "v1",
-				},
+				"one": fieldpath.NewVersionedSet(
+					_NS(_P("numeric"), _P("string")),
+					"v1",
+					false,
+				),
 			},
 			rhs: fieldpath.ManagedFields{
-				"one": &fieldpath.VersionedSet{
-					Set:        _NS(_P("string"), _P("bool")),
-					APIVersion: "v1",
-				},
+				"one": fieldpath.NewVersionedSet(
+					_NS(_P("string"), _P("bool")),
+					"v1",
+					false,
+				),
 			},
 			out: fieldpath.ManagedFields{
-				"one": &fieldpath.VersionedSet{
-					Set:        _NS(_P("numeric"), _P("bool")),
-					APIVersion: "v1",
-				},
+				"one": fieldpath.NewVersionedSet(
+					_NS(_P("numeric"), _P("bool")),
+					"v1",
+					false,
+				),
 			},
 		},
 	}

--- a/internal/fixture/state.go
+++ b/internal/fixture/state.go
@@ -303,7 +303,7 @@ func (tc TestCase) TestWithConverter(parser typed.ParseableType, converter merge
 
 	// Fail if any empty sets are present in the managers
 	for manager, set := range state.Managers {
-		if set.Empty() {
+		if set.Set().Empty() {
 			return fmt.Errorf("expected Managers to have no empty sets, but found one managed by %v", manager)
 		}
 	}

--- a/merge/conflict.go
+++ b/merge/conflict.go
@@ -79,7 +79,7 @@ func ConflictsFromManagers(sets fieldpath.ManagedFields) Conflicts {
 	conflicts := []Conflict{}
 
 	for manager, set := range sets {
-		set.Iterate(func(p fieldpath.Path) {
+		set.Set().Iterate(func(p fieldpath.Path) {
 			conflicts = append(conflicts, Conflict{
 				Manager: manager,
 				Path:    p,

--- a/merge/conflict_test.go
+++ b/merge/conflict_test.go
@@ -35,20 +35,22 @@ var (
 
 func TestNewFromSets(t *testing.T) {
 	got := merge.ConflictsFromManagers(fieldpath.ManagedFields{
-		"Bob": &fieldpath.VersionedSet{
-			Set: _NS(
+		"Bob": fieldpath.NewVersionedSet(
+			_NS(
 				_P("key"),
 				_P("list", _KBF("key", _SV("a"), "id", _IV(2)), "id"),
 			),
-			APIVersion: "v1",
-		},
-		"Alice": &fieldpath.VersionedSet{
-			Set: _NS(
+			"v1",
+			false,
+		),
+		"Alice": fieldpath.NewVersionedSet(
+			_NS(
 				_P("value"),
 				_P("list", _KBF("key", _SV("a"), "id", _IV(2)), "key"),
 			),
-			APIVersion: "v1",
-		},
+			"v1",
+			false,
+		),
 	})
 	wanted := `conflicts with "Alice":
 - .value

--- a/merge/deduced_test.go
+++ b/merge/deduced_test.go
@@ -53,12 +53,13 @@ func TestDeduced(t *testing.T) {
 				bool: false
 			`,
 			Managed: fieldpath.ManagedFields{
-				"default": &fieldpath.VersionedSet{
-					Set: _NS(
+				"default": fieldpath.NewVersionedSet(
+					_NS(
 						_P("numeric"), _P("string"), _P("bool"),
 					),
-					APIVersion: "v1",
-				},
+					"v1",
+					false,
+				),
 			},
 		},
 		"leaf_apply_update_apply_no_conflict": {
@@ -95,18 +96,20 @@ func TestDeduced(t *testing.T) {
 				bool: true
 			`,
 			Managed: fieldpath.ManagedFields{
-				"default": &fieldpath.VersionedSet{
-					Set: _NS(
+				"default": fieldpath.NewVersionedSet(
+					_NS(
 						_P("numeric"), _P("string"),
 					),
-					APIVersion: "v1",
-				},
-				"controller": &fieldpath.VersionedSet{
-					Set: _NS(
+					"v1",
+					false,
+				),
+				"controller": fieldpath.NewVersionedSet(
+					_NS(
 						_P("bool"),
 					),
-					APIVersion: "v1",
-				},
+					"v1",
+					false,
+				),
 			},
 		},
 		"leaf_apply_update_apply_with_conflict": {
@@ -154,18 +157,20 @@ func TestDeduced(t *testing.T) {
 				bool: true
 			`,
 			Managed: fieldpath.ManagedFields{
-				"default": &fieldpath.VersionedSet{
-					Set: _NS(
+				"default": fieldpath.NewVersionedSet(
+					_NS(
 						_P("numeric"), _P("string"),
 					),
-					APIVersion: "v1",
-				},
-				"controller": &fieldpath.VersionedSet{
-					Set: _NS(
+					"v1",
+					false,
+				),
+				"controller": fieldpath.NewVersionedSet(
+					_NS(
 						_P("bool"),
 					),
-					APIVersion: "v1",
-				},
+					"v1",
+					false,
+				),
 			},
 		},
 		"leaf_apply_twice_remove": {
@@ -191,12 +196,13 @@ func TestDeduced(t *testing.T) {
 				string: "new string"
 			`,
 			Managed: fieldpath.ManagedFields{
-				"default": &fieldpath.VersionedSet{
-					Set: _NS(
+				"default": fieldpath.NewVersionedSet(
+					_NS(
 						_P("string"),
 					),
-					APIVersion: "v1",
-				},
+					"v1",
+					false,
+				),
 			},
 		},
 		"leaf_update_remove_empty_set": {
@@ -220,12 +226,13 @@ func TestDeduced(t *testing.T) {
 				string: "new string"
 			`,
 			Managed: fieldpath.ManagedFields{
-				"controller": &fieldpath.VersionedSet{
-					Set: _NS(
+				"controller": fieldpath.NewVersionedSet(
+					_NS(
 						_P("string"),
 					),
-					APIVersion: "v1",
-				},
+					"v1",
+					false,
+				),
 			},
 		},
 		"apply_twice_list_is_atomic": {
@@ -259,10 +266,11 @@ func TestDeduced(t *testing.T) {
 				- b
 			`,
 			Managed: fieldpath.ManagedFields{
-				"default": &fieldpath.VersionedSet{
-					Set:        _NS(_P("list")),
-					APIVersion: "v1",
-				},
+				"default": fieldpath.NewVersionedSet(
+					_NS(_P("list")),
+					"v1",
+					false,
+				),
 			},
 		},
 		"apply_update_apply_list": {
@@ -305,10 +313,11 @@ func TestDeduced(t *testing.T) {
 				- c
 			`,
 			Managed: fieldpath.ManagedFields{
-				"default": &fieldpath.VersionedSet{
-					Set:        _NS(_P("list")),
-					APIVersion: "v1",
-				},
+				"default": fieldpath.NewVersionedSet(
+					_NS(_P("list")),
+					"v1",
+					false,
+				),
 			},
 		},
 		"leaf_apply_remove_empty_set": {

--- a/merge/key_test.go
+++ b/merge/key_test.go
@@ -84,14 +84,15 @@ func TestUpdateAssociativeLists(t *testing.T) {
 				  value: 2
 			`,
 			Managed: fieldpath.ManagedFields{
-				"default": &fieldpath.VersionedSet{
-					Set: _NS(
+				"default": fieldpath.NewVersionedSet(
+					_NS(
 						_P("list", _KBF("name", _SV("b"))),
 						_P("list", _KBF("name", _SV("b")), "name"),
 						_P("list", _KBF("name", _SV("b")), "value"),
 					),
-					APIVersion: "v1",
-				},
+					"v1",
+					false,
+				),
 			},
 		},
 	}

--- a/merge/leaf_test.go
+++ b/merge/leaf_test.go
@@ -73,12 +73,13 @@ func TestUpdateLeaf(t *testing.T) {
 				bool: false
 			`,
 			Managed: fieldpath.ManagedFields{
-				"default": &fieldpath.VersionedSet{
-					Set: _NS(
+				"default": fieldpath.NewVersionedSet(
+					_NS(
 						_P("numeric"), _P("string"), _P("bool"),
 					),
-					APIVersion: "v1",
-				},
+					"v1",
+					false,
+				),
 			},
 		},
 		"apply_twice_different_versions": {
@@ -107,12 +108,13 @@ func TestUpdateLeaf(t *testing.T) {
 				bool: false
 			`,
 			Managed: fieldpath.ManagedFields{
-				"default": &fieldpath.VersionedSet{
-					Set: _NS(
+				"default": fieldpath.NewVersionedSet(
+					_NS(
 						_P("numeric"), _P("string"), _P("bool"),
 					),
-					APIVersion: "v2",
-				},
+					"v2",
+					false,
+				),
 			},
 		},
 		"apply_update_apply_no_conflict": {
@@ -149,18 +151,20 @@ func TestUpdateLeaf(t *testing.T) {
 				bool: true
 			`,
 			Managed: fieldpath.ManagedFields{
-				"default": &fieldpath.VersionedSet{
-					Set: _NS(
+				"default": fieldpath.NewVersionedSet(
+					_NS(
 						_P("numeric"), _P("string"),
 					),
-					APIVersion: "v1",
-				},
-				"controller": &fieldpath.VersionedSet{
-					Set: _NS(
+					"v1",
+					false,
+				),
+				"controller": fieldpath.NewVersionedSet(
+					_NS(
 						_P("bool"),
 					),
-					APIVersion: "v1",
-				},
+					"v1",
+					false,
+				),
 			},
 		},
 		"apply_update_apply_no_conflict_different_version": {
@@ -197,18 +201,20 @@ func TestUpdateLeaf(t *testing.T) {
 				bool: true
 			`,
 			Managed: fieldpath.ManagedFields{
-				"default": &fieldpath.VersionedSet{
-					Set: _NS(
+				"default": fieldpath.NewVersionedSet(
+					_NS(
 						_P("numeric"), _P("string"),
 					),
-					APIVersion: "v1",
-				},
-				"controller": &fieldpath.VersionedSet{
-					Set: _NS(
+					"v1",
+					false,
+				),
+				"controller": fieldpath.NewVersionedSet(
+					_NS(
 						_P("bool"),
 					),
-					APIVersion: "v2",
-				},
+					"v2",
+					false,
+				),
 			},
 		},
 		"apply_update_apply_with_conflict": {
@@ -256,18 +262,20 @@ func TestUpdateLeaf(t *testing.T) {
 				bool: true
 			`,
 			Managed: fieldpath.ManagedFields{
-				"default": &fieldpath.VersionedSet{
-					Set: _NS(
+				"default": fieldpath.NewVersionedSet(
+					_NS(
 						_P("numeric"), _P("string"),
 					),
-					APIVersion: "v1",
-				},
-				"controller": &fieldpath.VersionedSet{
-					Set: _NS(
+					"v1",
+					false,
+				),
+				"controller": fieldpath.NewVersionedSet(
+					_NS(
 						_P("bool"),
 					),
-					APIVersion: "v1",
-				},
+					"v1",
+					false,
+				),
 			},
 		},
 		"apply_update_apply_with_conflict_across_version": {
@@ -315,18 +323,20 @@ func TestUpdateLeaf(t *testing.T) {
 				bool: true
 			`,
 			Managed: fieldpath.ManagedFields{
-				"default": &fieldpath.VersionedSet{
-					Set: _NS(
+				"default": fieldpath.NewVersionedSet(
+					_NS(
 						_P("numeric"), _P("string"),
 					),
-					APIVersion: "v1",
-				},
-				"controller": &fieldpath.VersionedSet{
-					Set: _NS(
+					"v1",
+					false,
+				),
+				"controller": fieldpath.NewVersionedSet(
+					_NS(
 						_P("bool"),
 					),
-					APIVersion: "v2",
-				},
+					"v2",
+					false,
+				),
 			},
 		},
 		"apply_twice_dangling": {
@@ -354,12 +364,13 @@ func TestUpdateLeaf(t *testing.T) {
 				bool: false
 			`,
 			Managed: fieldpath.ManagedFields{
-				"default": &fieldpath.VersionedSet{
-					Set: _NS(
+				"default": fieldpath.NewVersionedSet(
+					_NS(
 						_P("string"),
 					),
-					APIVersion: "v1",
-				},
+					"v1",
+					false,
+				),
 			},
 		},
 		"apply_twice_dangling_different_version": {
@@ -387,12 +398,13 @@ func TestUpdateLeaf(t *testing.T) {
 				bool: false
 			`,
 			Managed: fieldpath.ManagedFields{
-				"default": &fieldpath.VersionedSet{
-					Set: _NS(
+				"default": fieldpath.NewVersionedSet(
+					_NS(
 						_P("string"),
 					),
-					APIVersion: "v2",
-				},
+					"v2",
+					false,
+				),
 			},
 		},
 		"update_remove_empty_set": {
@@ -416,12 +428,13 @@ func TestUpdateLeaf(t *testing.T) {
 				string: "new string"
 			`,
 			Managed: fieldpath.ManagedFields{
-				"controller": &fieldpath.VersionedSet{
-					Set: _NS(
+				"controller": fieldpath.NewVersionedSet(
+					_NS(
 						_P("string"),
 					),
-					APIVersion: "v1",
-				},
+					"v1",
+					false,
+				),
 			},
 		},
 		"apply_remove_empty_set": {

--- a/merge/multiple_appliers_test.go
+++ b/merge/multiple_appliers_test.go
@@ -64,20 +64,22 @@ func TestMultipleAppliersSet(t *testing.T) {
 				- name: c
 			`,
 			Managed: fieldpath.ManagedFields{
-				"apply-one": &fieldpath.VersionedSet{
-					Set: _NS(
+				"apply-one": fieldpath.NewVersionedSet(
+					_NS(
 						_P("list", _KBF("name", _SV("a"))),
 						_P("list", _KBF("name", _SV("a")), "name"),
 					),
-					APIVersion: "v3",
-				},
-				"apply-two": &fieldpath.VersionedSet{
-					Set: _NS(
+					"v3",
+					false,
+				),
+				"apply-two": fieldpath.NewVersionedSet(
+					_NS(
 						_P("list", _KBF("name", _SV("c"))),
 						_P("list", _KBF("name", _SV("c")), "name"),
 					),
-					APIVersion: "v2",
-				},
+					"v2",
+					false,
+				),
 			},
 		},
 		"same_value_no_conflict": {
@@ -107,22 +109,24 @@ func TestMultipleAppliersSet(t *testing.T) {
 				  value: 0
 			`,
 			Managed: fieldpath.ManagedFields{
-				"apply-one": &fieldpath.VersionedSet{
-					Set: _NS(
+				"apply-one": fieldpath.NewVersionedSet(
+					_NS(
 						_P("list", _KBF("name", _SV("a"))),
 						_P("list", _KBF("name", _SV("a")), "name"),
 						_P("list", _KBF("name", _SV("a")), "value"),
 					),
-					APIVersion: "v1",
-				},
-				"apply-two": &fieldpath.VersionedSet{
-					Set: _NS(
+					"v1",
+					false,
+				),
+				"apply-two": fieldpath.NewVersionedSet(
+					_NS(
 						_P("list", _KBF("name", _SV("a"))),
 						_P("list", _KBF("name", _SV("a")), "name"),
 						_P("list", _KBF("name", _SV("a")), "value"),
 					),
-					APIVersion: "v2",
-				},
+					"v2",
+					false,
+				),
 			},
 		},
 		"change_value_yes_conflict": {
@@ -155,14 +159,15 @@ func TestMultipleAppliersSet(t *testing.T) {
 				  value: 0
 			`,
 			Managed: fieldpath.ManagedFields{
-				"apply-one": &fieldpath.VersionedSet{
-					Set: _NS(
+				"apply-one": fieldpath.NewVersionedSet(
+					_NS(
 						_P("list", _KBF("name", _SV("a"))),
 						_P("list", _KBF("name", _SV("a")), "name"),
 						_P("list", _KBF("name", _SV("a")), "value"),
 					),
-					APIVersion: "v1",
-				},
+					"v1",
+					false,
+				),
 			},
 		},
 		"remove_one_keep_one": {
@@ -202,22 +207,24 @@ func TestMultipleAppliersSet(t *testing.T) {
 				- name: d
 			`,
 			Managed: fieldpath.ManagedFields{
-				"apply-one": &fieldpath.VersionedSet{
-					Set: _NS(
+				"apply-one": fieldpath.NewVersionedSet(
+					_NS(
 						_P("list", _KBF("name", _SV("a"))),
 						_P("list", _KBF("name", _SV("a")), "name"),
 					),
-					APIVersion: "v3",
-				},
-				"apply-two": &fieldpath.VersionedSet{
-					Set: _NS(
+					"v3",
+					false,
+				),
+				"apply-two": fieldpath.NewVersionedSet(
+					_NS(
 						_P("list", _KBF("name", _SV("c"))),
 						_P("list", _KBF("name", _SV("d"))),
 						_P("list", _KBF("name", _SV("c")), "name"),
 						_P("list", _KBF("name", _SV("d")), "name"),
 					),
-					APIVersion: "v2",
-				},
+					"v2",
+					false,
+				),
 			},
 		},
 	}
@@ -273,21 +280,23 @@ func TestMultipleAppliersNestedType(t *testing.T) {
 				  - d
 			`,
 			Managed: fieldpath.ManagedFields{
-				"apply-one": &fieldpath.VersionedSet{
-					Set: _NS(
+				"apply-one": fieldpath.NewVersionedSet(
+					_NS(
 						_P("listOfLists", _KBF("name", _SV("a"))),
 						_P("listOfLists", _KBF("name", _SV("a")), "name"),
 					),
-					APIVersion: "v3",
-				},
-				"apply-two": &fieldpath.VersionedSet{
-					Set: _NS(
+					"v3",
+					false,
+				),
+				"apply-two": fieldpath.NewVersionedSet(
+					_NS(
 						_P("listOfLists", _KBF("name", _SV("b"))),
 						_P("listOfLists", _KBF("name", _SV("b")), "name"),
 						_P("listOfLists", _KBF("name", _SV("b")), "value", _SV("d")),
 					),
-					APIVersion: "v2",
-				},
+					"v2",
+					false,
+				),
 			},
 		},
 		"remove_one_keep_one_with_dangling_subitem": {
@@ -344,27 +353,30 @@ func TestMultipleAppliersNestedType(t *testing.T) {
 				  - e
 			`,
 			Managed: fieldpath.ManagedFields{
-				"apply-one": &fieldpath.VersionedSet{
-					Set: _NS(
+				"apply-one": fieldpath.NewVersionedSet(
+					_NS(
 						_P("listOfLists", _KBF("name", _SV("a"))),
 						_P("listOfLists", _KBF("name", _SV("a")), "name"),
 					),
-					APIVersion: "v3",
-				},
-				"apply-two": &fieldpath.VersionedSet{
-					Set: _NS(
+					"v3",
+					false,
+				),
+				"apply-two": fieldpath.NewVersionedSet(
+					_NS(
 						_P("listOfLists", _KBF("name", _SV("b"))),
 						_P("listOfLists", _KBF("name", _SV("b")), "name"),
 						_P("listOfLists", _KBF("name", _SV("b")), "value", _SV("d")),
 					),
-					APIVersion: "v2",
-				},
-				"controller": &fieldpath.VersionedSet{
-					Set: _NS(
+					"v2",
+					false,
+				),
+				"controller": fieldpath.NewVersionedSet(
+					_NS(
 						_P("listOfLists", _KBF("name", _SV("b")), "value", _SV("e")),
 					),
-					APIVersion: "v2",
-				},
+					"v2",
+					false,
+				),
 			},
 		},
 		"remove_one_with_dangling_subitem_keep_one": {
@@ -420,21 +432,23 @@ func TestMultipleAppliersNestedType(t *testing.T) {
 				  - b
 			`,
 			Managed: fieldpath.ManagedFields{
-				"apply-one": &fieldpath.VersionedSet{
-					Set: _NS(
+				"apply-one": fieldpath.NewVersionedSet(
+					_NS(
 						_P("listOfLists", _KBF("name", _SV("a"))),
 						_P("listOfLists", _KBF("name", _SV("a")), "name"),
 					),
-					APIVersion: "v3",
-				},
-				"apply-two": &fieldpath.VersionedSet{
-					Set: _NS(
+					"v3",
+					false,
+				),
+				"apply-two": fieldpath.NewVersionedSet(
+					_NS(
 						_P("listOfLists", _KBF("name", _SV("a"))),
 						_P("listOfLists", _KBF("name", _SV("a")), "name"),
 						_P("listOfLists", _KBF("name", _SV("a")), "value", _SV("b")),
 					),
-					APIVersion: "v2",
-				},
+					"v2",
+					false,
+				),
 			},
 		},
 		"remove_one_with_managed_subitem_keep_one": {
@@ -490,21 +504,23 @@ func TestMultipleAppliersNestedType(t *testing.T) {
 				  - b
 			`,
 			Managed: fieldpath.ManagedFields{
-				"apply-one": &fieldpath.VersionedSet{
-					Set: _NS(
+				"apply-one": fieldpath.NewVersionedSet(
+					_NS(
 						_P("listOfLists", _KBF("name", _SV("a"))),
 						_P("listOfLists", _KBF("name", _SV("a")), "name"),
 					),
-					APIVersion: "v3",
-				},
-				"apply-two": &fieldpath.VersionedSet{
-					Set: _NS(
+					"v3",
+					false,
+				),
+				"apply-two": fieldpath.NewVersionedSet(
+					_NS(
 						_P("listOfLists", _KBF("name", _SV("a"))),
 						_P("listOfLists", _KBF("name", _SV("a")), "name"),
 						_P("listOfLists", _KBF("name", _SV("a")), "value", _SV("b")),
 					),
-					APIVersion: "v2",
-				},
+					"v2",
+					false,
+				),
 			},
 		},
 		"remove_one_keep_one_with_sub_item": {
@@ -547,21 +563,23 @@ func TestMultipleAppliersNestedType(t *testing.T) {
 				  - d
 			`,
 			Managed: fieldpath.ManagedFields{
-				"apply-one": &fieldpath.VersionedSet{
-					Set: _NS(
+				"apply-one": fieldpath.NewVersionedSet(
+					_NS(
 						_P("listOfLists", _KBF("name", _SV("a"))),
 						_P("listOfLists", _KBF("name", _SV("a")), "name"),
 					),
-					APIVersion: "v3",
-				},
-				"apply-two": &fieldpath.VersionedSet{
-					Set: _NS(
+					"v3",
+					false,
+				),
+				"apply-two": fieldpath.NewVersionedSet(
+					_NS(
 						_P("listOfLists", _KBF("name", _SV("b"))),
 						_P("listOfLists", _KBF("name", _SV("b")), "name"),
 						_P("listOfLists", _KBF("name", _SV("b")), "value", _SV("d")),
 					),
-					APIVersion: "v2",
-				},
+					"v2",
+					false,
+				),
 			},
 		},
 		"multiple_appliers_recursive_map": {
@@ -650,27 +668,30 @@ func TestMultipleAppliersNestedType(t *testing.T) {
 				          g:
 			`,
 			Managed: fieldpath.ManagedFields{
-				"apply-two": &fieldpath.VersionedSet{
-					Set: _NS(
+				"apply-two": fieldpath.NewVersionedSet(
+					_NS(
 						_P("mapOfMapsRecursive", "a"),
 						_P("mapOfMapsRecursive", "c"),
 						_P("mapOfMapsRecursive", "c", "d"),
 					),
-					APIVersion: "v2",
-				},
-				"controller-one": &fieldpath.VersionedSet{
-					Set: _NS(
+					"v2",
+					false,
+				),
+				"controller-one": fieldpath.NewVersionedSet(
+					_NS(
 						_P("mapOfMapsRecursive", "c", "d", "e"),
 						_P("mapOfMapsRecursive", "c", "d", "e", "f", "g"),
 					),
-					APIVersion: "v3",
-				},
-				"controller-two": &fieldpath.VersionedSet{
-					Set: _NS(
+					"v3",
+					false,
+				),
+				"controller-two": fieldpath.NewVersionedSet(
+					_NS(
 						_P("mapOfMapsRecursive", "c", "d", "e", "f"),
 					),
-					APIVersion: "v2",
-				},
+					"v2",
+					false,
+				),
 			},
 		},
 	}
@@ -764,27 +785,30 @@ func TestMultipleAppliersDeducedType(t *testing.T) {
 				        g:
 			`,
 			Managed: fieldpath.ManagedFields{
-				"apply-two": &fieldpath.VersionedSet{
-					Set: _NS(
+				"apply-two": fieldpath.NewVersionedSet(
+					_NS(
 						_P("a"),
 						_P("c"),
 						_P("c", "d"),
 					),
-					APIVersion: "v2",
-				},
-				"controller-one": &fieldpath.VersionedSet{
-					Set: _NS(
+					"v2",
+					false,
+				),
+				"controller-one": fieldpath.NewVersionedSet(
+					_NS(
 						_P("c", "d", "e"),
 						_P("c", "d", "e", "f", "g"),
 					),
-					APIVersion: "v3",
-				},
-				"controller-two": &fieldpath.VersionedSet{
-					Set: _NS(
+					"v3",
+					false,
+				),
+				"controller-two": fieldpath.NewVersionedSet(
+					_NS(
 						_P("c", "d", "e", "f"),
 					),
-					APIVersion: "v2",
-				},
+					"v2",
+					false,
+				),
 			},
 		},
 	}
@@ -855,21 +879,23 @@ func TestMultipleAppliersRealConversion(t *testing.T) {
 				        ffff:
 			`,
 			Managed: fieldpath.ManagedFields{
-				"apply-two": &fieldpath.VersionedSet{
-					Set: _NS(
+				"apply-two": fieldpath.NewVersionedSet(
+					_NS(
 						_P("mapOfMapsRecursive", "aa"),
 						_P("mapOfMapsRecursive", "cc"),
 						_P("mapOfMapsRecursive", "cc", "dd"),
 					),
-					APIVersion: "v2",
-				},
-				"controller": &fieldpath.VersionedSet{
-					Set: _NS(
+					"v2",
+					false,
+				),
+				"controller": fieldpath.NewVersionedSet(
+					_NS(
 						_P("mapOfMapsRecursive", "ccc", "ddd", "eee"),
 						_P("mapOfMapsRecursive", "ccc", "ddd", "eee", "fff"),
 					),
-					APIVersion: "v3",
-				},
+					"v3",
+					false,
+				),
 			},
 		},
 		"appliers_remove_from_controller_real_conversion": {
@@ -911,20 +937,22 @@ func TestMultipleAppliersRealConversion(t *testing.T) {
 				  ccc:
 			`,
 			Managed: fieldpath.ManagedFields{
-				"controller": &fieldpath.VersionedSet{
-					Set: _NS(
+				"controller": fieldpath.NewVersionedSet(
+					_NS(
 						_P("mapOfMapsRecursive"),
 						_P("mapOfMapsRecursive", "a"),
 					),
-					APIVersion: "v1",
-				},
-				"apply": &fieldpath.VersionedSet{
-					Set: _NS(
+					"v1",
+					false,
+				),
+				"apply": fieldpath.NewVersionedSet(
+					_NS(
 						_P("mapOfMapsRecursive", "aaa"),
 						_P("mapOfMapsRecursive", "ccc"),
 					),
-					APIVersion: "v3",
-				},
+					"v3",
+					false,
+				),
 			},
 		},
 	}

--- a/merge/nested_test.go
+++ b/merge/nested_test.go
@@ -139,15 +139,16 @@ func TestUpdateNestedType(t *testing.T) {
 				  - c
 			`,
 			Managed: fieldpath.ManagedFields{
-				"default": &fieldpath.VersionedSet{
-					Set: _NS(
+				"default": fieldpath.NewVersionedSet(
+					_NS(
 						_P("listOfLists", _KBF("name", _SV("a"))),
 						_P("listOfLists", _KBF("name", _SV("a")), "name"),
 						_P("listOfLists", _KBF("name", _SV("a")), "value", _SV("a")),
 						_P("listOfLists", _KBF("name", _SV("a")), "value", _SV("c")),
 					),
-					APIVersion: "v1",
-				},
+					"v1",
+					false,
+				),
 			},
 		},
 		"listOfLists_change_key_and_value": {
@@ -183,15 +184,16 @@ func TestUpdateNestedType(t *testing.T) {
 				  - c
 			`,
 			Managed: fieldpath.ManagedFields{
-				"default": &fieldpath.VersionedSet{
-					Set: _NS(
+				"default": fieldpath.NewVersionedSet(
+					_NS(
 						_P("listOfLists", _KBF("name", _SV("b"))),
 						_P("listOfLists", _KBF("name", _SV("b")), "name"),
 						_P("listOfLists", _KBF("name", _SV("b")), "value", _SV("a")),
 						_P("listOfLists", _KBF("name", _SV("b")), "value", _SV("c")),
 					),
-					APIVersion: "v1",
-				},
+					"v1",
+					false,
+				),
 			},
 		},
 		"listOfMaps_change_value": {
@@ -227,15 +229,16 @@ func TestUpdateNestedType(t *testing.T) {
 				    c: "z"
 			`,
 			Managed: fieldpath.ManagedFields{
-				"default": &fieldpath.VersionedSet{
-					Set: _NS(
+				"default": fieldpath.NewVersionedSet(
+					_NS(
 						_P("listOfMaps", _KBF("name", _SV("a"))),
 						_P("listOfMaps", _KBF("name", _SV("a")), "name"),
 						_P("listOfMaps", _KBF("name", _SV("a")), "value", "a"),
 						_P("listOfMaps", _KBF("name", _SV("a")), "value", "c"),
 					),
-					APIVersion: "v1",
-				},
+					"v1",
+					false,
+				),
 			},
 		},
 		"listOfMaps_change_key_and_value": {
@@ -271,15 +274,16 @@ func TestUpdateNestedType(t *testing.T) {
 				    c: "z"
 			`,
 			Managed: fieldpath.ManagedFields{
-				"default": &fieldpath.VersionedSet{
-					Set: _NS(
+				"default": fieldpath.NewVersionedSet(
+					_NS(
 						_P("listOfMaps", _KBF("name", _SV("b"))),
 						_P("listOfMaps", _KBF("name", _SV("b")), "name"),
 						_P("listOfMaps", _KBF("name", _SV("b")), "value", "a"),
 						_P("listOfMaps", _KBF("name", _SV("b")), "value", "c"),
 					),
-					APIVersion: "v1",
-				},
+					"v1",
+					false,
+				),
 			},
 		},
 		"mapOfLists_change_value": {
@@ -312,14 +316,15 @@ func TestUpdateNestedType(t *testing.T) {
 				  - c
 			`,
 			Managed: fieldpath.ManagedFields{
-				"default": &fieldpath.VersionedSet{
-					Set: _NS(
+				"default": fieldpath.NewVersionedSet(
+					_NS(
 						_P("mapOfLists", "a"),
 						_P("mapOfLists", "a", _SV("a")),
 						_P("mapOfLists", "a", _SV("c")),
 					),
-					APIVersion: "v1",
-				},
+					"v1",
+					false,
+				),
 			},
 		},
 		"mapOfLists_change_key_and_value": {
@@ -352,14 +357,15 @@ func TestUpdateNestedType(t *testing.T) {
 				  - c
 			`,
 			Managed: fieldpath.ManagedFields{
-				"default": &fieldpath.VersionedSet{
-					Set: _NS(
+				"default": fieldpath.NewVersionedSet(
+					_NS(
 						_P("mapOfLists", "b"),
 						_P("mapOfLists", "b", _SV("a")),
 						_P("mapOfLists", "b", _SV("c")),
 					),
-					APIVersion: "v1",
-				},
+					"v1",
+					false,
+				),
 			},
 		},
 		"mapOfMaps_change_value": {
@@ -392,14 +398,15 @@ func TestUpdateNestedType(t *testing.T) {
 				    c: "z"
 			`,
 			Managed: fieldpath.ManagedFields{
-				"default": &fieldpath.VersionedSet{
-					Set: _NS(
+				"default": fieldpath.NewVersionedSet(
+					_NS(
 						_P("mapOfMaps", "a"),
 						_P("mapOfMaps", "a", "a"),
 						_P("mapOfMaps", "a", "c"),
 					),
-					APIVersion: "v1",
-				},
+					"v1",
+					false,
+				),
 			},
 		},
 		"mapOfMaps_change_key_and_value": {
@@ -432,14 +439,15 @@ func TestUpdateNestedType(t *testing.T) {
 				    c: "z"
 			`,
 			Managed: fieldpath.ManagedFields{
-				"default": &fieldpath.VersionedSet{
-					Set: _NS(
+				"default": fieldpath.NewVersionedSet(
+					_NS(
 						_P("mapOfMaps", "b"),
 						_P("mapOfMaps", "b", "a"),
 						_P("mapOfMaps", "b", "c"),
 					),
-					APIVersion: "v1",
-				},
+					"v1",
+					false,
+				),
 			},
 		},
 		"mapOfMapsRecursive_change_middle_key": {
@@ -472,14 +480,15 @@ func TestUpdateNestedType(t *testing.T) {
 				      c:
 			`,
 			Managed: fieldpath.ManagedFields{
-				"default": &fieldpath.VersionedSet{
-					Set: _NS(
+				"default": fieldpath.NewVersionedSet(
+					_NS(
 						_P("mapOfMapsRecursive", "a"),
 						_P("mapOfMapsRecursive", "a", "d"),
 						_P("mapOfMapsRecursive", "a", "d", "c"),
 					),
-					APIVersion: "v1",
-				},
+					"v1",
+					false,
+				),
 			},
 		},
 	}

--- a/merge/obsolete_versions_test.go
+++ b/merge/obsolete_versions_test.go
@@ -70,18 +70,20 @@ func TestObsoleteVersions(t *testing.T) {
 	}
 
 	managers := fieldpath.ManagedFields{
-		"v2": &fieldpath.VersionedSet{
-			Set: _NS(
+		"v2": fieldpath.NewVersionedSet(
+			_NS(
 				_P("v2"),
 			),
-			APIVersion: "v2",
-		},
-		"v3": &fieldpath.VersionedSet{
-			Set: _NS(
+			"v2",
+			false,
+		),
+		"v3": fieldpath.NewVersionedSet(
+			_NS(
 				_P("v3"),
 			),
-			APIVersion: "v3",
-		},
+			"v3",
+			false,
+		),
 	}
 	if diff := state.Managers.Difference(managers); len(diff) != 0 {
 		t.Fatalf("expected Managers to be %v, got %v", managers, state.Managers)

--- a/merge/preserve_unknown_test.go
+++ b/merge/preserve_unknown_test.go
@@ -67,13 +67,14 @@ func TestPreserveUnknownFields(t *testing.T) {
 				unknown: new
 			`,
 			Managed: fieldpath.ManagedFields{
-				"default": &fieldpath.VersionedSet{
-					Set: _NS(
+				"default": fieldpath.NewVersionedSet(
+					_NS(
 						_P("num"),
 						_P("unknown"),
 					),
-					APIVersion: "v1",
-				},
+					"v1",
+					false,
+				),
 			},
 		},
 	}

--- a/merge/set_test.go
+++ b/merge/set_test.go
@@ -74,15 +74,16 @@ func TestUpdateSet(t *testing.T) {
 				- d
 			`,
 			Managed: fieldpath.ManagedFields{
-				"default": &fieldpath.VersionedSet{
-					Set: _NS(
+				"default": fieldpath.NewVersionedSet(
+					_NS(
 						_P("list", _SV("a")),
 						_P("list", _SV("b")),
 						_P("list", _SV("c")),
 						_P("list", _SV("d")),
 					),
-					APIVersion: "v1",
-				},
+					"v1",
+					false,
+				),
 			},
 		},
 		"apply_update_apply_no_overlap": {
@@ -129,22 +130,24 @@ func TestUpdateSet(t *testing.T) {
 				- d
 			`,
 			Managed: fieldpath.ManagedFields{
-				"default": &fieldpath.VersionedSet{
-					Set: _NS(
+				"default": fieldpath.NewVersionedSet(
+					_NS(
 						_P("list", _SV("a")),
 						_P("list", _SV("aprime")),
 						_P("list", _SV("c")),
 						_P("list", _SV("cprime")),
 					),
-					APIVersion: "v1",
-				},
-				"controller": &fieldpath.VersionedSet{
-					Set: _NS(
+					"v1",
+					false,
+				),
+				"controller": fieldpath.NewVersionedSet(
+					_NS(
 						_P("list", _SV("b")),
 						_P("list", _SV("d")),
 					),
-					APIVersion: "v1",
-				},
+					"v1",
+					false,
+				),
 			},
 		},
 		"apply_update_apply_no_overlap_and_different_version": {
@@ -191,22 +194,24 @@ func TestUpdateSet(t *testing.T) {
 				- d
 			`,
 			Managed: fieldpath.ManagedFields{
-				"default": &fieldpath.VersionedSet{
-					Set: _NS(
+				"default": fieldpath.NewVersionedSet(
+					_NS(
 						_P("list", _SV("a")),
 						_P("list", _SV("aprime")),
 						_P("list", _SV("c")),
 						_P("list", _SV("cprime")),
 					),
-					APIVersion: "v1",
-				},
-				"controller": &fieldpath.VersionedSet{
-					Set: _NS(
+					"v1",
+					false,
+				),
+				"controller": fieldpath.NewVersionedSet(
+					_NS(
 						_P("list", _SV("b")),
 						_P("list", _SV("d")),
 					),
-					APIVersion: "v2",
-				},
+					"v2",
+					false,
+				),
 			},
 		},
 		"apply_update_apply_with_overlap": {
@@ -250,21 +255,23 @@ func TestUpdateSet(t *testing.T) {
 				- d
 			`,
 			Managed: fieldpath.ManagedFields{
-				"default": &fieldpath.VersionedSet{
-					Set: _NS(
+				"default": fieldpath.NewVersionedSet(
+					_NS(
 						_P("list", _SV("a")),
 						_P("list", _SV("b")),
 						_P("list", _SV("c")),
 					),
-					APIVersion: "v1",
-				},
-				"controller": &fieldpath.VersionedSet{
-					Set: _NS(
+					"v1",
+					false,
+				),
+				"controller": fieldpath.NewVersionedSet(
+					_NS(
 						_P("list", _SV("b")),
 						_P("list", _SV("d")),
 					),
-					APIVersion: "v1",
-				},
+					"v1",
+					false,
+				),
 			},
 		},
 		"apply_update_apply_with_overlap_and_different_version": {
@@ -308,21 +315,23 @@ func TestUpdateSet(t *testing.T) {
 				- d
 			`,
 			Managed: fieldpath.ManagedFields{
-				"default": &fieldpath.VersionedSet{
-					Set: _NS(
+				"default": fieldpath.NewVersionedSet(
+					_NS(
 						_P("list", _SV("a")),
 						_P("list", _SV("b")),
 						_P("list", _SV("c")),
 					),
-					APIVersion: "v1",
-				},
-				"controller": &fieldpath.VersionedSet{
-					Set: _NS(
+					"v1",
+					false,
+				),
+				"controller": fieldpath.NewVersionedSet(
+					_NS(
 						_P("list", _SV("b")),
 						_P("list", _SV("d")),
 					),
-					APIVersion: "v2",
-				},
+					"v2",
+					false,
+				),
 			},
 		},
 		"apply_twice_reorder": {
@@ -358,15 +367,16 @@ func TestUpdateSet(t *testing.T) {
 				- b
 			`,
 			Managed: fieldpath.ManagedFields{
-				"default": &fieldpath.VersionedSet{
-					Set: _NS(
+				"default": fieldpath.NewVersionedSet(
+					_NS(
 						_P("list", _SV("a")),
 						_P("list", _SV("b")),
 						_P("list", _SV("c")),
 						_P("list", _SV("d")),
 					),
-					APIVersion: "v1",
-				},
+					"v1",
+					false,
+				),
 			},
 		},
 		"apply_update_apply_reorder": {
@@ -413,15 +423,16 @@ func TestUpdateSet(t *testing.T) {
 				- d
 			`,
 			Managed: fieldpath.ManagedFields{
-				"default": &fieldpath.VersionedSet{
-					Set: _NS(
+				"default": fieldpath.NewVersionedSet(
+					_NS(
 						_P("list", _SV("a")),
 						_P("list", _SV("b")),
 						_P("list", _SV("c")),
 						_P("list", _SV("d")),
 					),
-					APIVersion: "v1",
-				},
+					"v1",
+					false,
+				),
 			},
 		},
 		"apply_update_apply_reorder_across_versions": {
@@ -468,15 +479,16 @@ func TestUpdateSet(t *testing.T) {
 				- d
 			`,
 			Managed: fieldpath.ManagedFields{
-				"default": &fieldpath.VersionedSet{
-					Set: _NS(
+				"default": fieldpath.NewVersionedSet(
+					_NS(
 						_P("list", _SV("a")),
 						_P("list", _SV("b")),
 						_P("list", _SV("c")),
 						_P("list", _SV("d")),
 					),
-					APIVersion: "v2",
-				},
+					"v2",
+					false,
+				),
 			},
 		},
 		"apply_twice_remove": {
@@ -508,13 +520,14 @@ func TestUpdateSet(t *testing.T) {
 				- c
 			`,
 			Managed: fieldpath.ManagedFields{
-				"default": &fieldpath.VersionedSet{
-					Set: _NS(
+				"default": fieldpath.NewVersionedSet(
+					_NS(
 						_P("list", _SV("a")),
 						_P("list", _SV("c")),
 					),
-					APIVersion: "v1",
-				},
+					"v1",
+					false,
+				),
 			},
 		},
 		"apply_twice_remove_across_versions": {
@@ -548,14 +561,15 @@ func TestUpdateSet(t *testing.T) {
 				- e
 			`,
 			Managed: fieldpath.ManagedFields{
-				"default": &fieldpath.VersionedSet{
-					Set: _NS(
+				"default": fieldpath.NewVersionedSet(
+					_NS(
 						_P("list", _SV("a")),
 						_P("list", _SV("c")),
 						_P("list", _SV("e")),
 					),
-					APIVersion: "v2",
-				},
+					"v2",
+					false,
+				),
 			},
 		},
 	}

--- a/merge/union_test.go
+++ b/merge/union_test.go
@@ -81,12 +81,13 @@ func TestUnion(t *testing.T) {
 				type: Numeric
 			`,
 			Managed: fieldpath.ManagedFields{
-				"default": &fieldpath.VersionedSet{
-					Set: _NS(
+				"default": fieldpath.NewVersionedSet(
+					_NS(
 						_P("numeric"), _P("type"),
 					),
-					APIVersion: "v1",
-				},
+					"v1",
+					false,
+				),
 			},
 		},
 		"union_apply_without_discriminator_conflict": {
@@ -114,12 +115,13 @@ func TestUnion(t *testing.T) {
 				type: String
 			`,
 			Managed: fieldpath.ManagedFields{
-				"controller": &fieldpath.VersionedSet{
-					Set: _NS(
+				"controller": fieldpath.NewVersionedSet(
+					_NS(
 						_P("string"), _P("type"),
 					),
-					APIVersion: "v1",
-				},
+					"v1",
+					false,
+				),
 			},
 		},
 		"union_apply_with_null_value": {

--- a/merge/update.go
+++ b/merge/update.go
@@ -49,10 +49,10 @@ func (s *Updater) update(oldObject, newObject *typed.TypedValue, version fieldpa
 		if manager == workflow {
 			continue
 		}
-		compare, ok := versions[managerSet.APIVersion]
+		compare, ok := versions[managerSet.APIVersion()]
 		if !ok {
 			var err error
-			versionedOldObject, err := s.Converter.Convert(oldObject, managerSet.APIVersion)
+			versionedOldObject, err := s.Converter.Convert(oldObject, managerSet.APIVersion())
 			if err != nil {
 				if s.Converter.IsMissingVersionError(err) {
 					delete(managers, manager)
@@ -60,7 +60,7 @@ func (s *Updater) update(oldObject, newObject *typed.TypedValue, version fieldpa
 				}
 				return nil, fmt.Errorf("failed to convert old object: %v", err)
 			}
-			versionedNewObject, err := s.Converter.Convert(newObject, managerSet.APIVersion)
+			versionedNewObject, err := s.Converter.Convert(newObject, managerSet.APIVersion())
 			if err != nil {
 				if s.Converter.IsMissingVersionError(err) {
 					delete(managers, manager)
@@ -72,22 +72,16 @@ func (s *Updater) update(oldObject, newObject *typed.TypedValue, version fieldpa
 			if err != nil {
 				return nil, fmt.Errorf("failed to compare objects: %v", err)
 			}
-			versions[managerSet.APIVersion] = compare
+			versions[managerSet.APIVersion()] = compare
 		}
 
-		conflictSet := managerSet.Intersection(compare.Modified.Union(compare.Added))
+		conflictSet := managerSet.Set().Intersection(compare.Modified.Union(compare.Added))
 		if !conflictSet.Empty() {
-			conflicts[manager] = &fieldpath.VersionedSet{
-				Set:        conflictSet,
-				APIVersion: managerSet.APIVersion,
-			}
+			conflicts[manager] = fieldpath.NewVersionedSet(conflictSet, managerSet.APIVersion(), false)
 		}
 
 		if !compare.Removed.Empty() {
-			removed[manager] = &fieldpath.VersionedSet{
-				Set:        compare.Removed,
-				APIVersion: managerSet.APIVersion,
-			}
+			removed[manager] = fieldpath.NewVersionedSet(compare.Removed, managerSet.APIVersion(), false)
 		}
 	}
 
@@ -96,15 +90,15 @@ func (s *Updater) update(oldObject, newObject *typed.TypedValue, version fieldpa
 	}
 
 	for manager, conflictSet := range conflicts {
-		managers[manager].Set = managers[manager].Set.Difference(conflictSet.Set)
+		managers[manager] = fieldpath.NewVersionedSet(managers[manager].Set().Difference(conflictSet.Set()), managers[manager].APIVersion(), managers[manager].Applied())
 	}
 
 	for manager, removedSet := range removed {
-		managers[manager].Set = managers[manager].Set.Difference(removedSet.Set)
+		managers[manager] = fieldpath.NewVersionedSet(managers[manager].Set().Difference(removedSet.Set()), managers[manager].APIVersion(), managers[manager].Applied())
 	}
 
 	for manager := range managers {
-		if managers[manager].Set.Empty() {
+		if managers[manager].Set().Empty() {
 			delete(managers, manager)
 		}
 	}
@@ -132,13 +126,14 @@ func (s *Updater) Update(liveObject, newObject *typed.TypedValue, version fieldp
 		return nil, fieldpath.ManagedFields{}, fmt.Errorf("failed to compare live and new objects: %v", err)
 	}
 	if _, ok := managers[manager]; !ok {
-		managers[manager] = &fieldpath.VersionedSet{
-			Set: fieldpath.NewSet(),
-		}
+		managers[manager] = fieldpath.NewVersionedSet(fieldpath.NewSet(), version, false)
 	}
-	managers[manager].Set = managers[manager].Set.Union(compare.Modified).Union(compare.Added).Difference(compare.Removed)
-	managers[manager].APIVersion = version
-	if managers[manager].Set.Empty() {
+	managers[manager] = fieldpath.NewVersionedSet(
+		managers[manager].Set().Union(compare.Modified).Union(compare.Added).Difference(compare.Removed),
+		version,
+		false,
+	)
+	if managers[manager].Set().Empty() {
 		delete(managers, manager)
 	}
 	return newObject, managers, nil
@@ -166,11 +161,7 @@ func (s *Updater) Apply(liveObject, configObject *typed.TypedValue, version fiel
 	if err != nil {
 		return nil, fieldpath.ManagedFields{}, fmt.Errorf("failed to get field set: %v", err)
 	}
-	managers[manager] = &fieldpath.VersionedSet{
-		Set:        set,
-		APIVersion: version,
-		Applied:    true,
-	}
+	managers[manager] = fieldpath.NewVersionedSet(set, version, true)
 	newObject, err = s.prune(newObject, managers, manager, lastSet)
 	if err != nil {
 		return nil, fieldpath.ManagedFields{}, fmt.Errorf("failed to prune fields: %v", err)
@@ -194,18 +185,18 @@ func shallowCopyManagers(managers fieldpath.ManagedFields) fieldpath.ManagedFiel
 // * applyingManager applied it last time
 // * applyingManager didn't apply it this time
 // * no other applier claims to manage it
-func (s *Updater) prune(merged *typed.TypedValue, managers fieldpath.ManagedFields, applyingManager string, lastSet *fieldpath.VersionedSet) (*typed.TypedValue, error) {
-	if lastSet == nil || lastSet.Set.Empty() {
+func (s *Updater) prune(merged *typed.TypedValue, managers fieldpath.ManagedFields, applyingManager string, lastSet fieldpath.VersionedSet) (*typed.TypedValue, error) {
+	if lastSet == nil || lastSet.Set().Empty() {
 		return merged, nil
 	}
-	convertedMerged, err := s.Converter.Convert(merged, lastSet.APIVersion)
+	convertedMerged, err := s.Converter.Convert(merged, lastSet.APIVersion())
 	if err != nil {
 		if s.Converter.IsMissingVersionError(err) {
 			return merged, nil
 		}
 		return nil, fmt.Errorf("failed to convert merged object to last applied version: %v", err)
 	}
-	pruned := convertedMerged.RemoveItems(lastSet.Set)
+	pruned := convertedMerged.RemoveItems(lastSet.Set())
 	pruned, err = s.addBackOwnedItems(convertedMerged, pruned, managers, applyingManager)
 	if err != nil {
 		return nil, fmt.Errorf("failed add back owned items: %v", err)
@@ -214,7 +205,7 @@ func (s *Updater) prune(merged *typed.TypedValue, managers fieldpath.ManagedFiel
 	if err != nil {
 		return nil, fmt.Errorf("failed add back dangling items: %v", err)
 	}
-	return s.Converter.Convert(pruned, managers[applyingManager].APIVersion)
+	return s.Converter.Convert(pruned, managers[applyingManager].APIVersion())
 }
 
 // addBackOwnedItems adds back any list and map items that were removed by prune,
@@ -223,11 +214,11 @@ func (s *Updater) addBackOwnedItems(merged, pruned *typed.TypedValue, managedFie
 	var err error
 	managedAtVersion := map[fieldpath.APIVersion]*fieldpath.Set{}
 	for _, managerSet := range managedFields {
-		if managerSet.Applied {
-			if _, ok := managedAtVersion[managerSet.APIVersion]; !ok {
-				managedAtVersion[managerSet.APIVersion] = fieldpath.NewSet()
+		if managerSet.Applied() {
+			if _, ok := managedAtVersion[managerSet.APIVersion()]; !ok {
+				managedAtVersion[managerSet.APIVersion()] = fieldpath.NewSet()
 			}
-			managedAtVersion[managerSet.APIVersion] = managedAtVersion[managerSet.APIVersion].Union(managerSet.Set)
+			managedAtVersion[managerSet.APIVersion()] = managedAtVersion[managerSet.APIVersion()].Union(managerSet.Set())
 		}
 	}
 	for version, managed := range managedAtVersion {
@@ -261,8 +252,8 @@ func (s *Updater) addBackOwnedItems(merged, pruned *typed.TypedValue, managedFie
 // addBackDanglingItems makes sure that the only items removed by prune are items that were
 // previously owned by the currently applying manager. This will add back unowned items and items
 // which are owned by Updaters that shouldn't be removed.
-func (s *Updater) addBackDanglingItems(merged, pruned *typed.TypedValue, lastSet *fieldpath.VersionedSet) (*typed.TypedValue, error) {
-	convertedPruned, err := s.Converter.Convert(pruned, lastSet.APIVersion)
+func (s *Updater) addBackDanglingItems(merged, pruned *typed.TypedValue, lastSet fieldpath.VersionedSet) (*typed.TypedValue, error) {
+	convertedPruned, err := s.Converter.Convert(pruned, lastSet.APIVersion())
 	if err != nil {
 		if s.Converter.IsMissingVersionError(err) {
 			return merged, nil
@@ -277,5 +268,5 @@ func (s *Updater) addBackDanglingItems(merged, pruned *typed.TypedValue, lastSet
 	if err != nil {
 		return nil, fmt.Errorf("failed to create field set from merged object in last applied version: %v", err)
 	}
-	return merged.RemoveItems(mergedSet.Difference(prunedSet).Intersection(lastSet.Set)), nil
+	return merged.RemoveItems(mergedSet.Difference(prunedSet).Intersection(lastSet.Set())), nil
 }


### PR DESCRIPTION
And create a new `versionedSet` object that implements that interface. A
side effect of this change is that the versionedSet is now mostly
immutable (since there are no setters on the interface), if you want to
change a `VersionedSet`, you should probably create a new one.

This will allow us to implement two things:
1. Cached `VersionedSet`: if such an object is not replaced with a new
instance, then we don't have to reserialize it.
2. Lazy `VersionSet`: we don't have to deserialize objects until we
actually need to look at the set.

This is breaking the API.