### PR TITLE
Optimize benchmarks; permit serialization

### DIFF
--- a/fieldpath/element.go
+++ b/fieldpath/element.go
@@ -47,6 +47,54 @@ type PathElement struct {
 	Index *int
 }
 
+// Less provides an order for path elements.
+func (e PathElement) Less(rhs PathElement) bool {
+	if e.FieldName != nil {
+		if rhs.FieldName == nil {
+			return true
+		}
+		return *e.FieldName < *rhs.FieldName
+	} else if rhs.FieldName != nil {
+		return false
+	}
+
+	if len(e.Key) != 0 {
+		if len(rhs.Key) == 0 {
+			return true
+		}
+		return value.FieldCollectionLess(e.Key, rhs.Key)
+	} else if len(rhs.Key) != 0 {
+		return false
+	}
+
+	if e.Value != nil {
+		if rhs.Value == nil {
+			return true
+		}
+		return e.Value.Less(*rhs.Value)
+	} else if rhs.Value != nil {
+		return false
+	}
+
+	if e.Index != nil {
+		if rhs.Index == nil {
+			return true
+		}
+		return *e.Index < *rhs.Index
+	} else if rhs.Index != nil {
+		// Yes, I know the next statement is the same.  But this way
+		// the obvious way of extending the function wil be bug-free.
+		return false
+	}
+
+	return false
+}
+
+// Equals returns true if both path elements are equal.
+func (e PathElement) Equals(rhs PathElement) bool {
+	return !e.Less(rhs) && !rhs.Less(e)
+}
+
 // String presents the path element as a human-readable string.
 func (e PathElement) String() string {
 	switch {
@@ -92,61 +140,103 @@ func KeyByFields(nameValues ...interface{}) []value.Field {
 // PathElementSet is a set of path elements.
 // TODO: serialize as a list.
 type PathElementSet struct {
-	// The strange construction is because there's no way to test
-	// PathElements for equality (it can't be used as a key for a map).
-	members map[string]PathElement
+	members sortedPathElements
 }
+
+type sortedPathElements []PathElement
+
+// Implement the sort interface; this would permit bulk creation, which would
+// be faster than doing it one at a time via Insert.
+func (spe sortedPathElements) Len() int           { return len(spe) }
+func (spe sortedPathElements) Less(i, j int) bool { return spe[i].Less(spe[j]) }
+func (spe sortedPathElements) Swap(i, j int)      { spe[i], spe[j] = spe[j], spe[i] }
 
 // Insert adds pe to the set.
 func (s *PathElementSet) Insert(pe PathElement) {
-	serialized := pe.String()
-	if s.members == nil {
-		s.members = map[string]PathElement{
-			serialized: pe,
-		}
+	loc := sort.Search(len(s.members), func(i int) bool {
+		return !s.members[i].Less(pe)
+	})
+	if loc == len(s.members) {
+		s.members = append(s.members, pe)
 		return
 	}
-	if _, ok := s.members[serialized]; !ok {
-		s.members[serialized] = pe
+	if s.members[loc].Equals(pe) {
+		return
 	}
+	n := len(s.members) - 1
+	s.members = append(s.members, s.members[n])
+	for n > loc {
+		s.members[n] = s.members[n-1]
+		n--
+	}
+	s.members[loc] = pe
 }
 
 // Union returns a set containing elements that appear in either s or s2.
 func (s *PathElementSet) Union(s2 *PathElementSet) *PathElementSet {
-	out := &PathElementSet{
-		members: map[string]PathElement{},
+	out := &PathElementSet{}
+
+	i, j := 0, 0
+	for i < len(s.members) && j < len(s2.members) {
+		if s.members[i].Less(s2.members[j]) {
+			out.members = append(out.members, s.members[i])
+			i++
+		} else {
+			out.members = append(out.members, s2.members[j])
+			if !s2.members[j].Less(s.members[i]) {
+				i++
+			}
+			j++
+		}
 	}
-	for k, v := range s.members {
-		out.members[k] = v
+
+	if i < len(s.members) {
+		out.members = append(out.members, s.members[i:]...)
 	}
-	for k, v := range s2.members {
-		out.members[k] = v
+	if j < len(s2.members) {
+		out.members = append(out.members, s2.members[j:]...)
 	}
 	return out
 }
 
 // Intersection returns a set containing elements which appear in both s and s2.
 func (s *PathElementSet) Intersection(s2 *PathElementSet) *PathElementSet {
-	out := &PathElementSet{
-		members: map[string]PathElement{},
-	}
-	for k, v := range s.members {
-		if _, ok := s2.members[k]; ok {
-			out.members[k] = v
+	out := &PathElementSet{}
+
+	i, j := 0, 0
+	for i < len(s.members) && j < len(s2.members) {
+		if s.members[i].Less(s2.members[j]) {
+			i++
+		} else {
+			if !s2.members[j].Less(s.members[i]) {
+				out.members = append(out.members, s.members[i])
+				i++
+			}
+			j++
 		}
 	}
+
 	return out
 }
 
 // Difference returns a set containing elements which appear in s but not in s2.
 func (s *PathElementSet) Difference(s2 *PathElementSet) *PathElementSet {
-	out := &PathElementSet{
-		members: map[string]PathElement{},
-	}
-	for k, v := range s.members {
-		if _, ok := s2.members[k]; !ok {
-			out.members[k] = v
+	out := &PathElementSet{}
+
+	i, j := 0, 0
+	for i < len(s.members) && j < len(s2.members) {
+		if s.members[i].Less(s2.members[j]) {
+			out.members = append(out.members, s.members[i])
+			i++
+		} else {
+			if !s2.members[j].Less(s.members[i]) {
+				i++
+			}
+			j++
 		}
+	}
+	if i < len(s.members) {
+		out.members = append(out.members, s.members[i:]...)
 	}
 	return out
 }
@@ -156,11 +246,16 @@ func (s *PathElementSet) Size() int { return len(s.members) }
 
 // Has returns true if pe is a member of the set.
 func (s *PathElementSet) Has(pe PathElement) bool {
-	if s.members == nil {
+	loc := sort.Search(len(s.members), func(i int) bool {
+		return !s.members[i].Less(pe)
+	})
+	if loc == len(s.members) {
 		return false
 	}
-	_, ok := s.members[pe.String()]
-	return ok
+	if s.members[loc].Equals(pe) {
+		return true
+	}
+	return false
 }
 
 // Equals returns true if s and s2 have exactly the same members.
@@ -169,14 +264,14 @@ func (s *PathElementSet) Equals(s2 *PathElementSet) bool {
 		return false
 	}
 	for k := range s.members {
-		if _, ok := s2.members[k]; !ok {
+		if !s.members[k].Equals(s2.members[k]) {
 			return false
 		}
 	}
 	return true
 }
 
-// Iterate calls f for each PathElement in the set.
+// Iterate calls f for each PathElement in the set. The order is deterministic.
 func (s *PathElementSet) Iterate(f func(PathElement)) {
 	for _, pe := range s.members {
 		f(pe)

--- a/fieldpath/element.go
+++ b/fieldpath/element.go
@@ -35,7 +35,7 @@ type PathElement struct {
 	// Key selects the list element which has fields matching those given.
 	// The containing object must be an associative list with map typed
 	// elements.
-	Key []value.Field
+	Key *value.Map
 
 	// Value selects the list element with the given value. The containing
 	// object must be an associative list with a primitive typed element
@@ -58,12 +58,12 @@ func (e PathElement) Less(rhs PathElement) bool {
 		return false
 	}
 
-	if len(e.Key) != 0 {
-		if len(rhs.Key) == 0 {
+	if e.Key != nil {
+		if rhs.Key == nil {
 			return true
 		}
-		return value.FieldCollectionLess(e.Key, rhs.Key)
-	} else if len(rhs.Key) != 0 {
+		return e.Key.Less(rhs.Key)
+	} else if rhs.Key != nil {
 		return false
 	}
 
@@ -100,9 +100,9 @@ func (e PathElement) String() string {
 	switch {
 	case e.FieldName != nil:
 		return "." + *e.FieldName
-	case len(e.Key) > 0:
-		strs := make([]string, len(e.Key))
-		for i, k := range e.Key {
+	case e.Key != nil:
+		strs := make([]string, len(e.Key.Items))
+		for i, k := range e.Key.Items {
 			strs[i] = fmt.Sprintf("%v=%v", k.Name, k.Value)
 		}
 		// The order must be canonical, since we use the string value

--- a/fieldpath/element_test.go
+++ b/fieldpath/element_test.go
@@ -91,7 +91,7 @@ func TestPathElementLess(t *testing.T) {
 		}, {
 			name: "FieldName-3",
 			a:    PathElement{FieldName: strptr("capybara")},
-			b:    PathElement{Key: []value.Field{{Name: "dog", Value: value.IntValue(3)}}},
+			b:    PathElement{Key: &value.Map{Items: []value.Field{{Name: "dog", Value: value.IntValue(3)}}}},
 		}, {
 			name: "FieldName-4",
 			a:    PathElement{FieldName: strptr("elephant")},
@@ -102,28 +102,28 @@ func TestPathElementLess(t *testing.T) {
 			b:    PathElement{Index: intptr(5)},
 		}, {
 			name: "Key-1",
-			a:    PathElement{Key: []value.Field{{Name: "goat", Value: value.IntValue(1)}}},
-			b:    PathElement{Key: []value.Field{{Name: "goat", Value: value.IntValue(1)}}},
+			a:    PathElement{Key: &value.Map{Items: []value.Field{{Name: "goat", Value: value.IntValue(1)}}}},
+			b:    PathElement{Key: &value.Map{Items: []value.Field{{Name: "goat", Value: value.IntValue(1)}}}},
 			eq:   true,
 		}, {
 			name: "Key-2",
-			a:    PathElement{Key: []value.Field{{Name: "horse", Value: value.IntValue(1)}}},
-			b:    PathElement{Key: []value.Field{{Name: "horse", Value: value.IntValue(2)}}},
+			a:    PathElement{Key: &value.Map{Items: []value.Field{{Name: "horse", Value: value.IntValue(1)}}}},
+			b:    PathElement{Key: &value.Map{Items: []value.Field{{Name: "horse", Value: value.IntValue(2)}}}},
 		}, {
 			name: "Key-3",
-			a:    PathElement{Key: []value.Field{{Name: "ibex", Value: value.IntValue(1)}}},
-			b:    PathElement{Key: []value.Field{{Name: "jay", Value: value.IntValue(1)}}},
+			a:    PathElement{Key: &value.Map{Items: []value.Field{{Name: "ibex", Value: value.IntValue(1)}}}},
+			b:    PathElement{Key: &value.Map{Items: []value.Field{{Name: "jay", Value: value.IntValue(1)}}}},
 		}, {
 			name: "Key-4",
-			a:    PathElement{Key: []value.Field{{Name: "kite", Value: value.IntValue(1)}}},
-			b:    PathElement{Key: []value.Field{{Name: "kite", Value: value.IntValue(1)}, {Name: "kite-2", Value: value.IntValue(1)}}},
+			a:    PathElement{Key: &value.Map{Items: []value.Field{{Name: "kite", Value: value.IntValue(1)}}}},
+			b:    PathElement{Key: &value.Map{Items: []value.Field{{Name: "kite", Value: value.IntValue(1)}, {Name: "kite-2", Value: value.IntValue(1)}}}},
 		}, {
 			name: "Key-5",
-			a:    PathElement{Key: []value.Field{{Name: "kite", Value: value.IntValue(1)}}},
+			a:    PathElement{Key: &value.Map{Items: []value.Field{{Name: "kite", Value: value.IntValue(1)}}}},
 			b:    PathElement{Value: valptr(1)},
 		}, {
 			name: "Key-6",
-			a:    PathElement{Key: []value.Field{{Name: "kite", Value: value.IntValue(1)}}},
+			a:    PathElement{Key: &value.Map{Items: []value.Field{{Name: "kite", Value: value.IntValue(1)}}}},
 			b:    PathElement{Index: intptr(5)},
 		}, {
 			name: "Value-1",

--- a/fieldpath/element_test.go
+++ b/fieldpath/element_test.go
@@ -18,6 +18,8 @@ package fieldpath
 
 import (
 	"testing"
+
+	"sigs.k8s.io/structured-merge-diff/value"
 )
 
 func TestPathElementSet(t *testing.T) {
@@ -27,5 +29,143 @@ func TestPathElementSet(t *testing.T) {
 	s2.Insert(PathElement{})
 	if s2.Equals(s) {
 		t.Errorf("unequal sets should not equal")
+	}
+	if !s2.Has(PathElement{}) {
+		t.Errorf("expected to have something: %#v", s2)
+	}
+
+	n1 := "aoeu"
+	n2 := "asdf"
+	s2.Insert(PathElement{FieldName: &n1})
+	if !s2.Has(PathElement{FieldName: &n1}) {
+		t.Errorf("expected to have something: %#v", s2)
+	}
+	if s2.Has(PathElement{FieldName: &n2}) {
+		t.Errorf("expected to not have something: %#v", s2)
+	}
+
+	s2.Insert(PathElement{FieldName: &n2})
+	expected := []*string{&n1, &n2, nil}
+	i := 0
+	s2.Iterate(func(pe PathElement) {
+		e, a := expected[i], pe.FieldName
+		if e == nil || a == nil {
+			if e != a {
+				t.Errorf("index %v wanted %#v, got %#v", i, e, a)
+			}
+		} else {
+			if *e != *a {
+				t.Errorf("index %v wanted %#v, got %#v", i, *e, *a)
+			}
+		}
+		i++
+	})
+}
+
+func strptr(s string) *string   { return &s }
+func intptr(i int) *int         { return &i }
+func valptr(i int) *value.Value { v := value.IntValue(i); return &v }
+
+func TestPathElementLess(t *testing.T) {
+	table := []struct {
+		name string
+		// we expect a < b and !(b < a) unless eq is true, in which
+		// case we expect less to return false in both orders.
+		a, b PathElement
+		eq   bool
+	}{
+		{
+			name: "FieldName-0",
+			a:    PathElement{},
+			b:    PathElement{},
+			eq:   true,
+		}, {
+			name: "FieldName-1",
+			a:    PathElement{FieldName: strptr("anteater")},
+			b:    PathElement{FieldName: strptr("zebra")},
+		}, {
+			name: "FieldName-2",
+			a:    PathElement{FieldName: strptr("bee")},
+			b:    PathElement{FieldName: strptr("bee")},
+			eq:   true,
+		}, {
+			name: "FieldName-3",
+			a:    PathElement{FieldName: strptr("capybara")},
+			b:    PathElement{Key: []value.Field{{Name: "dog", Value: value.IntValue(3)}}},
+		}, {
+			name: "FieldName-4",
+			a:    PathElement{FieldName: strptr("elephant")},
+			b:    PathElement{Value: valptr(4)},
+		}, {
+			name: "FieldName-5",
+			a:    PathElement{FieldName: strptr("falcon")},
+			b:    PathElement{Index: intptr(5)},
+		}, {
+			name: "Key-1",
+			a:    PathElement{Key: []value.Field{{Name: "goat", Value: value.IntValue(1)}}},
+			b:    PathElement{Key: []value.Field{{Name: "goat", Value: value.IntValue(1)}}},
+			eq:   true,
+		}, {
+			name: "Key-2",
+			a:    PathElement{Key: []value.Field{{Name: "horse", Value: value.IntValue(1)}}},
+			b:    PathElement{Key: []value.Field{{Name: "horse", Value: value.IntValue(2)}}},
+		}, {
+			name: "Key-3",
+			a:    PathElement{Key: []value.Field{{Name: "ibex", Value: value.IntValue(1)}}},
+			b:    PathElement{Key: []value.Field{{Name: "jay", Value: value.IntValue(1)}}},
+		}, {
+			name: "Key-4",
+			a:    PathElement{Key: []value.Field{{Name: "kite", Value: value.IntValue(1)}}},
+			b:    PathElement{Key: []value.Field{{Name: "kite", Value: value.IntValue(1)}, {Name: "kite-2", Value: value.IntValue(1)}}},
+		}, {
+			name: "Key-5",
+			a:    PathElement{Key: []value.Field{{Name: "kite", Value: value.IntValue(1)}}},
+			b:    PathElement{Value: valptr(1)},
+		}, {
+			name: "Key-6",
+			a:    PathElement{Key: []value.Field{{Name: "kite", Value: value.IntValue(1)}}},
+			b:    PathElement{Index: intptr(5)},
+		}, {
+			name: "Value-1",
+			a:    PathElement{Value: valptr(1)},
+			b:    PathElement{Value: valptr(2)},
+		}, {
+			name: "Value-2",
+			a:    PathElement{Value: valptr(1)},
+			b:    PathElement{Value: valptr(1)},
+			eq:   true,
+		}, {
+			name: "Value-3",
+			a:    PathElement{Value: valptr(1)},
+			b:    PathElement{Index: intptr(1)},
+		}, {
+			name: "Index-1",
+			a:    PathElement{Index: intptr(1)},
+			b:    PathElement{Index: intptr(2)},
+		}, {
+			name: "Index-2",
+			a:    PathElement{Index: intptr(1)},
+			b:    PathElement{Index: intptr(1)},
+			eq:   true,
+		},
+	}
+
+	for i := range table {
+		i := i
+		t.Run(table[i].name, func(t *testing.T) {
+			tt := table[i]
+			if tt.eq {
+				if tt.a.Less(tt.b) {
+					t.Errorf("oops, a < b: %#v, %#v", tt.a, tt.b)
+				}
+			} else {
+				if !tt.a.Less(tt.b) {
+					t.Errorf("oops, a >= b: %#v, %#v", tt.a, tt.b)
+				}
+			}
+			if tt.b.Less(tt.b) {
+				t.Errorf("oops, b < a: %#v, %#v", tt.b, tt.a)
+			}
+		})
 	}
 }

--- a/fieldpath/fromvalue.go
+++ b/fieldpath/fromvalue.go
@@ -117,7 +117,7 @@ func GuessBestListPathElement(index int, item value.Value) PathElement {
 		keys = append(keys, *f)
 	}
 	if len(keys) > 0 {
-		return PathElement{Key: keys}
+		return PathElement{Key: &value.Map{Items: keys}}
 	}
 	return PathElement{Index: &index}
 }

--- a/fieldpath/path.go
+++ b/fieldpath/path.go
@@ -35,6 +35,35 @@ func (fp Path) String() string {
 	return strings.Join(strs, "")
 }
 
+// Less provides a lexical order for Paths.
+func (fp Path) Less(rhs Path) bool {
+	i := 0
+	for {
+		if i >= len(fp) && i >= len(rhs) {
+			// Paths are the same length and all items are equal.
+			return false
+		}
+		if i >= len(fp) {
+			// LHS is shorter.
+			return true
+		}
+		if i >= len(rhs) {
+			// RHS is shorter.
+			return false
+		}
+		if fp[i].Less(rhs[i]) {
+			// LHS is less; return
+			return true
+		}
+		if rhs[i].Less(fp[i]) {
+			// RHS is less; return
+			return false
+		}
+		// The items are equal; continue.
+		i++
+	}
+}
+
 func (fp Path) Copy() Path {
 	new := make(Path, len(fp))
 	copy(new, fp)

--- a/fieldpath/path.go
+++ b/fieldpath/path.go
@@ -35,6 +35,11 @@ func (fp Path) String() string {
 	return strings.Join(strs, "")
 }
 
+// Equals returns true if the two paths are equivalent.
+func (fp Path) Equals(fp2 Path) bool {
+	return !fp.Less(fp2) && !fp2.Less(fp)
+}
+
 // Less provides a lexical order for Paths.
 func (fp Path) Less(rhs Path) bool {
 	i := 0
@@ -87,7 +92,7 @@ func MakePath(parts ...interface{}) (Path, error) {
 			if len(t) == 0 {
 				return nil, fmt.Errorf("associative list key type path elements must have at least one key (got zero)")
 			}
-			fp = append(fp, PathElement{Key: t})
+			fp = append(fp, PathElement{Key: &value.Map{Items: t}})
 		case value.Value:
 			// TODO: understand schema and verify that this is a set type
 			// TODO: make a copy of t

--- a/fieldpath/path_test.go
+++ b/fieldpath/path_test.go
@@ -22,7 +22,7 @@ import (
 	"sigs.k8s.io/structured-merge-diff/value"
 )
 
-func TestPath(t *testing.T) {
+func TestPathString(t *testing.T) {
 	table := []struct {
 		name   string
 		fp     Path

--- a/fieldpath/set.go
+++ b/fieldpath/set.go
@@ -17,6 +17,7 @@ limitations under the License.
 package fieldpath
 
 import (
+	"sort"
 	"strings"
 )
 
@@ -172,24 +173,29 @@ type setNode struct {
 
 // SetNodeMap is a map of PathElement to subset.
 type SetNodeMap struct {
-	members map[string]setNode
+	members []setNode
 }
 
 // Descend adds pe to the set if necessary, returning the associated subset.
 func (s *SetNodeMap) Descend(pe PathElement) *Set {
-	serialized := pe.String()
-	if s.members == nil {
-		s.members = map[string]setNode{}
+	loc := sort.Search(len(s.members), func(i int) bool {
+		return !s.members[i].pathElement.Less(pe)
+	})
+	if loc == len(s.members) {
+		s.members = append(s.members, setNode{pathElement: pe, set: &Set{}})
+		return s.members[loc].set
 	}
-	if n, ok := s.members[serialized]; ok {
-		return n.set
+	if s.members[loc].pathElement.Equals(pe) {
+		return s.members[loc].set
 	}
-	ss := &Set{}
-	s.members[serialized] = setNode{
-		pathElement: pe,
-		set:         ss,
+	n := len(s.members) - 1
+	s.members = append(s.members, s.members[n])
+	for n > loc {
+		s.members[n] = s.members[n-1]
+		n--
 	}
-	return ss
+	s.members[loc] = setNode{pathElement: pe, set: &Set{}}
+	return s.members[loc].set
 }
 
 // Size returns the sum of the number of members of all subsets.
@@ -213,12 +219,14 @@ func (s *SetNodeMap) Empty() bool {
 
 // Get returns (the associated set, true) or (nil, false) if there is none.
 func (s *SetNodeMap) Get(pe PathElement) (*Set, bool) {
-	if s.members == nil {
+	loc := sort.Search(len(s.members), func(i int) bool {
+		return !s.members[i].pathElement.Less(pe)
+	})
+	if loc == len(s.members) {
 		return nil, false
 	}
-	serialized := pe.String()
-	if n, ok := s.members[serialized]; ok {
-		return n.set, true
+	if s.members[loc].pathElement.Equals(pe) {
+		return s.members[loc].set, true
 	}
 	return nil, false
 }
@@ -229,12 +237,11 @@ func (s *SetNodeMap) Equals(s2 *SetNodeMap) bool {
 	if len(s.members) != len(s2.members) {
 		return false
 	}
-	for k, v := range s.members {
-		v2, ok := s2.members[k]
-		if !ok {
+	for i := range s.members {
+		if !s.members[i].pathElement.Equals(s2.members[i].pathElement) {
 			return false
 		}
-		if !v.set.Equals(v2.set) {
+		if !s.members[i].set.Equals(s2.members[i].set) {
 			return false
 		}
 	}
@@ -244,21 +251,28 @@ func (s *SetNodeMap) Equals(s2 *SetNodeMap) bool {
 // Union returns a SetNodeMap with members that appear in either s or s2.
 func (s *SetNodeMap) Union(s2 *SetNodeMap) *SetNodeMap {
 	out := &SetNodeMap{}
-	for k, sn := range s.members {
-		pe := sn.pathElement
-		if sn2, ok := s2.members[k]; ok {
-			*out.Descend(pe) = *sn.set.Union(sn2.set)
+
+	i, j := 0, 0
+	for i < len(s.members) && j < len(s2.members) {
+		if s.members[i].pathElement.Less(s2.members[j].pathElement) {
+			out.members = append(out.members, s.members[i])
+			i++
 		} else {
-			*out.Descend(pe) = *sn.set
+			if !s2.members[j].pathElement.Less(s.members[i].pathElement) {
+				out.members = append(out.members, setNode{pathElement: s.members[i].pathElement, set: s.members[i].set.Union(s2.members[j].set)})
+				i++
+			} else {
+				out.members = append(out.members, s2.members[j])
+			}
+			j++
 		}
 	}
-	for k, sn2 := range s2.members {
-		pe := sn2.pathElement
-		if _, ok := s.members[k]; ok {
-			// already handled
-			continue
-		}
-		*out.Descend(pe) = *sn2.set
+
+	if i < len(s.members) {
+		out.members = append(out.members, s.members[i:]...)
+	}
+	if j < len(s2.members) {
+		out.members = append(out.members, s2.members[j:]...)
 	}
 	return out
 }
@@ -266,13 +280,20 @@ func (s *SetNodeMap) Union(s2 *SetNodeMap) *SetNodeMap {
 // Intersection returns a SetNodeMap with members that appear in both s and s2.
 func (s *SetNodeMap) Intersection(s2 *SetNodeMap) *SetNodeMap {
 	out := &SetNodeMap{}
-	for k, sn := range s.members {
-		pe := sn.pathElement
-		if sn2, ok := s2.members[k]; ok {
-			i := *sn.set.Intersection(sn2.set)
-			if !i.Empty() {
-				*out.Descend(pe) = i
+
+	i, j := 0, 0
+	for i < len(s.members) && j < len(s2.members) {
+		if s.members[i].pathElement.Less(s2.members[j].pathElement) {
+			i++
+		} else {
+			if !s2.members[j].pathElement.Less(s.members[i].pathElement) {
+				res := s.members[i].set.Intersection(s2.members[j].set)
+				if !res.Empty() {
+					out.members = append(out.members, setNode{pathElement: s.members[i].pathElement, set: res})
+				}
+				i++
 			}
+			j++
 		}
 	}
 	return out
@@ -281,17 +302,29 @@ func (s *SetNodeMap) Intersection(s2 *SetNodeMap) *SetNodeMap {
 // Difference returns a SetNodeMap with members that appear in s but not in s2.
 func (s *SetNodeMap) Difference(s2 *Set) *SetNodeMap {
 	out := &SetNodeMap{}
-	for k, sn := range s.members {
-		pe := sn.pathElement
-		if sn2, ok := s2.Children.members[k]; ok {
-			diff := *sn.set.Difference(sn2.set)
-			// We aren't permitted to add nodes with no elements.
-			if !diff.Empty() {
-				*out.Descend(pe) = diff
-			}
+
+	i, j := 0, 0
+	for i < len(s.members) && j < len(s2.Children.members) {
+		if s.members[i].pathElement.Less(s2.Children.members[j].pathElement) {
+			out.members = append(out.members, setNode{pathElement: s.members[i].pathElement, set: s.members[i].set})
+			i++
 		} else {
-			*out.Descend(pe) = *sn.set
+			if !s2.Children.members[j].pathElement.Less(s.members[i].pathElement) {
+
+				diff := s.members[i].set.Difference(s2.Children.members[j].set)
+				// We aren't permitted to add nodes with no elements.
+				if !diff.Empty() {
+					out.members = append(out.members, setNode{pathElement: s.members[i].pathElement, set: diff})
+				}
+
+				i++
+			}
+			j++
 		}
+	}
+
+	if i < len(s.members) {
+		out.members = append(out.members, s.members[i:]...)
 	}
 	return out
 }

--- a/fieldpath/set_test.go
+++ b/fieldpath/set_test.go
@@ -17,10 +17,108 @@ limitations under the License.
 package fieldpath
 
 import (
+	"fmt"
+	"math/rand"
 	"testing"
 
 	"sigs.k8s.io/structured-merge-diff/value"
 )
+
+type randomPathAlphabet []PathElement
+
+func (a randomPathAlphabet) makePath(minLen, maxLen int) Path {
+	n := minLen
+	if minLen < maxLen {
+		n += rand.Intn(maxLen - minLen)
+	}
+	var p Path
+	for i := 0; i < n; i++ {
+		p = append(p, a[rand.Intn(len(a))])
+	}
+	return p
+}
+
+var randomPathMaker = randomPathAlphabet(MakePathOrDie(
+	"aaa",
+	"aab",
+	"aac",
+	"aad",
+	"aae",
+	"aaf",
+	KeyByFields("name", value.StringValue("first")),
+	KeyByFields("name", value.StringValue("second")),
+	KeyByFields("port", value.IntValue(443), "protocol", value.StringValue("tcp")),
+	KeyByFields("port", value.IntValue(443), "protocol", value.StringValue("udp")),
+	value.IntValue(1),
+	value.IntValue(2),
+	value.IntValue(3),
+	value.StringValue("aa"),
+	value.StringValue("ab"),
+	value.BooleanValue(true),
+	1, 2, 3, 4,
+))
+
+func BenchmarkFieldSet(b *testing.B) {
+	cases := []struct {
+		size       int
+		minPathLen int
+		maxPathLen int
+	}{
+		//{10, 1, 2},
+		{20, 2, 3},
+		{50, 2, 4},
+		{100, 3, 6},
+		{500, 3, 7},
+		{1000, 3, 8},
+	}
+	for i := range cases {
+		here := cases[i]
+		makeSet := func() *Set {
+			x := NewSet()
+			for j := 0; j < here.size; j++ {
+				x.Insert(randomPathMaker.makePath(here.minPathLen, here.maxPathLen))
+			}
+			return x
+		}
+		operands := make([]*Set, 500)
+		for i := range operands {
+			operands[i] = makeSet()
+		}
+		randOperand := func() *Set { return operands[rand.Intn(len(operands))] }
+
+		b.Run(fmt.Sprintf("insert-%v", here.size), func(b *testing.B) {
+			b.ReportAllocs()
+			for i := 0; i < b.N; i++ {
+				makeSet()
+			}
+		})
+		b.Run(fmt.Sprintf("has-%v", here.size), func(b *testing.B) {
+			b.ReportAllocs()
+			for i := 0; i < b.N; i++ {
+				randOperand().Has(randomPathMaker.makePath(here.minPathLen, here.maxPathLen))
+			}
+		})
+
+		b.Run(fmt.Sprintf("union-%v", here.size), func(b *testing.B) {
+			b.ReportAllocs()
+			for i := 0; i < b.N; i++ {
+				randOperand().Union(randOperand())
+			}
+		})
+		b.Run(fmt.Sprintf("intersection-%v", here.size), func(b *testing.B) {
+			b.ReportAllocs()
+			for i := 0; i < b.N; i++ {
+				randOperand().Intersection(randOperand())
+			}
+		})
+		b.Run(fmt.Sprintf("difference-%v", here.size), func(b *testing.B) {
+			b.ReportAllocs()
+			for i := 0; i < b.N; i++ {
+				randOperand().Difference(randOperand())
+			}
+		})
+	}
+}
 
 func TestSetInsertHas(t *testing.T) {
 	s1 := NewSet(

--- a/fieldpath/set_test.go
+++ b/fieldpath/set_test.go
@@ -83,7 +83,7 @@ func TestSetInsertHas(t *testing.T) {
 }
 
 func TestSetString(t *testing.T) {
-	p := MakePathOrDie("foo", PathElement{Key: KeyByFields("name", value.StringValue("first"))})
+	p := MakePathOrDie("foo", PathElement{Key: &value.Map{Items: KeyByFields("name", value.StringValue("first"))}})
 	s1 := NewSet(p)
 
 	if p.String() != s1.String() {

--- a/internal/fixture/state.go
+++ b/internal/fixture/state.go
@@ -19,7 +19,6 @@ package fixture
 import (
 	"bytes"
 	"fmt"
-	"reflect"
 
 	"sigs.k8s.io/structured-merge-diff/fieldpath"
 	"sigs.k8s.io/structured-merge-diff/merge"
@@ -164,7 +163,7 @@ type Operation interface {
 
 func hasConflict(conflicts merge.Conflicts, conflict merge.Conflict) bool {
 	for i := range conflicts {
-		if reflect.DeepEqual(conflict, conflicts[i]) {
+		if conflict.Equals(conflicts[i]) {
 			return true
 		}
 	}

--- a/internal/fixture/state.go
+++ b/internal/fixture/state.go
@@ -268,6 +268,32 @@ func (tc TestCase) Test(parser typed.ParseableType) error {
 	return tc.TestWithConverter(parser, &dummyConverter{})
 }
 
+// Bench runs the test-case using the given parser and a dummy converter, but
+// doesn't check exit conditions--see the comment for BenchWithConverter.
+func (tc TestCase) Bench(parser typed.ParseableType) error {
+	return tc.BenchWithConverter(parser, &dummyConverter{})
+}
+
+// BenchWithConverter runs the test-case using the given parser and converter,
+// but doesn't do any comparison operations aftewards; you should probably run
+// TestWithConverter once and reset the benchmark, to make sure the test case
+// actually passes..
+func (tc TestCase) BenchWithConverter(parser typed.ParseableType, converter merge.Converter) error {
+	state := State{
+		Updater: &merge.Updater{Converter: converter},
+		Parser:  parser,
+	}
+	// We currently don't have any test that converts, we can take
+	// care of that later.
+	for i, ops := range tc.Ops {
+		err := ops.run(&state)
+		if err != nil {
+			return fmt.Errorf("failed operation %d: %v", i, err)
+		}
+	}
+	return nil
+}
+
 // TestWithConverter runs the test-case using the given parser and converter.
 func (tc TestCase) TestWithConverter(parser typed.ParseableType, converter merge.Converter) error {
 	state := State{

--- a/merge/conflict.go
+++ b/merge/conflict.go
@@ -40,6 +40,14 @@ func (c Conflict) Error() string {
 	return fmt.Sprintf("conflict with %q: %v", c.Manager, c.Path)
 }
 
+// Equals returns true if c == c2
+func (c Conflict) Equals(c2 Conflict) bool {
+	if c.Manager != c2.Manager {
+		return false
+	}
+	return c.Path.Equals(c2.Path)
+}
+
 // Conflicts accumulates multiple conflicts and aggregates them by managers.
 type Conflicts []Conflict
 
@@ -72,6 +80,19 @@ func (conflicts Conflicts) Error() string {
 		}
 	}
 	return strings.Join(messages, "\n")
+}
+
+// Equals returns true if the lists of conflicts are the same.
+func (c Conflicts) Equals(c2 Conflicts) bool {
+	if len(c) != len(c2) {
+		return false
+	}
+	for i := range c {
+		if !c[i].Equals(c2[i]) {
+			return false
+		}
+	}
+	return true
 }
 
 // ConflictsFromManagers creates a list of conflicts given Managers sets.

--- a/merge/deduced_test.go
+++ b/merge/deduced_test.go
@@ -598,9 +598,15 @@ func BenchmarkDeducedSimple(b *testing.B) {
 		},
 	}
 
+	// Make sure this passes...
+	if err := test.Test(typed.DeducedParseableType); err != nil {
+		b.Fatal(err)
+	}
+
 	b.ReportAllocs()
+	b.ResetTimer()
 	for n := 0; n < b.N; n++ {
-		if err := test.Test(typed.DeducedParseableType); err != nil {
+		if err := test.Bench(typed.DeducedParseableType); err != nil {
 			b.Fatal(err)
 		}
 	}
@@ -701,9 +707,15 @@ func BenchmarkDeducedNested(b *testing.B) {
 			`,
 	}
 
+	// Make sure this passes...
+	if err := test.Test(typed.DeducedParseableType); err != nil {
+		b.Fatal(err)
+	}
+
 	b.ReportAllocs()
+	b.ResetTimer()
 	for n := 0; n < b.N; n++ {
-		if err := test.Test(typed.DeducedParseableType); err != nil {
+		if err := test.Bench(typed.DeducedParseableType); err != nil {
 			b.Fatal(err)
 		}
 	}
@@ -804,9 +816,15 @@ func BenchmarkDeducedNestedAcrossVersion(b *testing.B) {
 		`,
 	}
 
+	// Make sure this passes...
+	if err := test.Test(typed.DeducedParseableType); err != nil {
+		b.Fatal(err)
+	}
+
 	b.ReportAllocs()
+	b.ResetTimer()
 	for n := 0; n < b.N; n++ {
-		if err := test.Test(typed.DeducedParseableType); err != nil {
+		if err := test.Bench(typed.DeducedParseableType); err != nil {
 			b.Fatal(err)
 		}
 	}

--- a/merge/leaf_test.go
+++ b/merge/leaf_test.go
@@ -531,9 +531,15 @@ func BenchmarkLeafConflictAcrossVersion(b *testing.B) {
 		},
 	}
 
+	// Make sure this passes...
+	if err := test.Test(leafFieldsParser); err != nil {
+		b.Fatal(err)
+	}
+
 	b.ReportAllocs()
+	b.ResetTimer()
 	for n := 0; n < b.N; n++ {
-		if err := test.Test(leafFieldsParser); err != nil {
+		if err := test.Bench(leafFieldsParser); err != nil {
 			b.Fatal(err)
 		}
 	}

--- a/merge/multiple_appliers_test.go
+++ b/merge/multiple_appliers_test.go
@@ -1103,9 +1103,15 @@ func BenchmarkMultipleApplierRecursiveRealConversion(b *testing.B) {
 		},
 	}
 
+	// Make sure this passes...
+	if err := test.TestWithConverter(nestedTypeParser, repeatingConverter{nestedTypeParser}); err != nil {
+		b.Fatal(err)
+	}
+
 	b.ReportAllocs()
+	b.ResetTimer()
 	for n := 0; n < b.N; n++ {
-		if err := test.TestWithConverter(nestedTypeParser, repeatingConverter{nestedTypeParser}); err != nil {
+		if err := test.BenchWithConverter(nestedTypeParser, repeatingConverter{nestedTypeParser}); err != nil {
 			b.Fatal(err)
 		}
 	}

--- a/typed/helpers.go
+++ b/typed/helpers.go
@@ -197,6 +197,7 @@ func keyedAssociativeListItemToPathElement(list schema.List, index int, child va
 	if child.MapValue == nil {
 		return pe, errors.New("associative list with keys may not have non-map elements")
 	}
+	keyMap := &value.Map{}
 	for _, fieldName := range list.Keys {
 		var fieldValue value.Value
 		field, ok := child.MapValue.Get(fieldName)
@@ -206,11 +207,9 @@ func keyedAssociativeListItemToPathElement(list schema.List, index int, child va
 			// Treat keys as required.
 			return pe, fmt.Errorf("associative list with keys has an element that omits key field %q", fieldName)
 		}
-		pe.Key = append(pe.Key, value.Field{
-			Name:  fieldName,
-			Value: fieldValue,
-		})
+		keyMap.Set(fieldName, fieldValue)
 	}
+	pe.Key = keyMap
 	return pe, nil
 }
 

--- a/value/less_test.go
+++ b/value/less_test.go
@@ -1,0 +1,313 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package value
+
+import (
+	"testing"
+)
+
+func TestValueLess(t *testing.T) {
+	table := []struct {
+		name string
+		// we expect a < b and !(b < a) unless eq is true, in which
+		// case we expect less to return false in both orders.
+		a, b Value
+		eq   bool
+	}{
+		{
+			name: "Invalid-1",
+			a:    Value{},
+			b:    Value{},
+			eq:   true,
+		}, {
+			name: "Invalid-2",
+			a:    FloatValue(1),
+			b:    Value{},
+		}, {
+			name: "Invalid-3",
+			a:    IntValue(1),
+			b:    Value{},
+		}, {
+			name: "Invalid-4",
+			a:    StringValue("aoeu"),
+			b:    Value{},
+		}, {
+			name: "Invalid-5",
+			a:    BooleanValue(true),
+			b:    Value{},
+		}, {
+			name: "Invalid-6",
+			a:    Value{ListValue: &List{}},
+			b:    Value{},
+		}, {
+			name: "Invalid-7",
+			a:    Value{MapValue: &Map{}},
+			b:    Value{},
+		}, {
+			name: "Invalid-8",
+			a:    Value{Null: true},
+			b:    Value{},
+		}, {
+			name: "Float-1",
+			a:    FloatValue(1.14),
+			b:    FloatValue(3.14),
+		}, {
+			name: "Float-2",
+			a:    FloatValue(1),
+			b:    FloatValue(1),
+			eq:   true,
+		}, {
+			name: "Float-3",
+			a:    FloatValue(1),
+			b:    IntValue(1),
+			eq:   true,
+		}, {
+			name: "Float-4",
+			a:    FloatValue(1),
+			b:    IntValue(2),
+		}, {
+			name: "Float-5",
+			a:    FloatValue(1),
+			b:    StringValue("aoeu"),
+		}, {
+			name: "Float-6",
+			a:    FloatValue(1),
+			b:    BooleanValue(true),
+		}, {
+			name: "Float-7",
+			a:    FloatValue(1),
+			b:    Value{ListValue: &List{}},
+		}, {
+			name: "Float-8",
+			a:    FloatValue(1),
+			b:    Value{MapValue: &Map{}},
+		}, {
+			name: "Float-9",
+			a:    FloatValue(1),
+			b:    Value{Null: true},
+		}, {
+			name: "Int-1",
+			a:    IntValue(1),
+			b:    IntValue(2),
+		}, {
+			name: "Int-2",
+			a:    IntValue(1),
+			b:    IntValue(1),
+			eq:   true,
+		}, {
+			name: "Int-3",
+			a:    IntValue(1),
+			b:    FloatValue(1),
+			eq:   true,
+		}, {
+			name: "Int-4",
+			a:    IntValue(1),
+			b:    FloatValue(2),
+		}, {
+			name: "Int-5",
+			a:    IntValue(1),
+			b:    StringValue("aoeu"),
+		}, {
+			name: "Int-6",
+			a:    IntValue(1),
+			b:    BooleanValue(true),
+		}, {
+			name: "Int-7",
+			a:    IntValue(1),
+			b:    Value{ListValue: &List{}},
+		}, {
+			name: "Int-8",
+			a:    IntValue(1),
+			b:    Value{MapValue: &Map{}},
+		}, {
+			name: "Int-9",
+			a:    IntValue(1),
+			b:    Value{Null: true},
+		}, {
+			name: "String-1",
+			a:    StringValue("b-12"),
+			b:    StringValue("b-9"),
+		}, {
+			name: "String-2",
+			a:    StringValue("folate"),
+			b:    StringValue("folate"),
+			eq:   true,
+		}, {
+			name: "String-3",
+			a:    StringValue("folate"),
+			b:    BooleanValue(true),
+		}, {
+			name: "String-4",
+			a:    StringValue("folate"),
+			b:    Value{ListValue: &List{}},
+		}, {
+			name: "String-5",
+			a:    StringValue("folate"),
+			b:    Value{MapValue: &Map{}},
+		}, {
+			name: "String-6",
+			a:    StringValue("folate"),
+			b:    Value{Null: true},
+		}, {
+			name: "Bool-1",
+			a:    BooleanValue(false),
+			b:    BooleanValue(true),
+		}, {
+			name: "Bool-2",
+			a:    BooleanValue(false),
+			b:    BooleanValue(false),
+			eq:   true,
+		}, {
+			name: "Bool-3",
+			a:    BooleanValue(true),
+			b:    BooleanValue(true),
+			eq:   true,
+		}, {
+			name: "Bool-4",
+			a:    BooleanValue(false),
+			b:    Value{ListValue: &List{}},
+		}, {
+			name: "Bool-5",
+			a:    BooleanValue(false),
+			b:    Value{MapValue: &Map{}},
+		}, {
+			name: "Bool-6",
+			a:    BooleanValue(false),
+			b:    Value{Null: true},
+		}, {
+			name: "List-1",
+			a:    Value{ListValue: &List{}},
+			b:    Value{ListValue: &List{}},
+			eq:   true,
+		}, {
+			name: "List-2",
+			a:    Value{ListValue: &List{Items: []Value{IntValue(1)}}},
+			b:    Value{ListValue: &List{Items: []Value{IntValue(1)}}},
+			eq:   true,
+		}, {
+			name: "List-3",
+			a:    Value{ListValue: &List{Items: []Value{IntValue(1)}}},
+			b:    Value{ListValue: &List{Items: []Value{IntValue(2)}}},
+		}, {
+			name: "List-4",
+			a:    Value{ListValue: &List{Items: []Value{IntValue(1)}}},
+			b:    Value{ListValue: &List{Items: []Value{IntValue(1), IntValue(1)}}},
+		}, {
+			name: "List-5",
+			a:    Value{ListValue: &List{Items: []Value{IntValue(1), IntValue(1)}}},
+			b:    Value{ListValue: &List{Items: []Value{IntValue(2)}}},
+		}, {
+			name: "List-6",
+			a:    Value{ListValue: &List{}},
+			b:    Value{MapValue: &Map{}},
+		}, {
+			name: "List-7",
+			a:    Value{ListValue: &List{}},
+			b:    Value{Null: true},
+		}, {
+			name: "Map-1",
+			a:    Value{MapValue: &Map{}},
+			b:    Value{MapValue: &Map{}},
+			eq:   true,
+		}, {
+			name: "Map-2",
+			a:    Value{MapValue: &Map{Items: []Field{{Name: "carotine", Value: IntValue(1)}}}},
+			b:    Value{MapValue: &Map{Items: []Field{{Name: "carotine", Value: IntValue(1)}}}},
+			eq:   true,
+		}, {
+			name: "Map-3",
+			a:    Value{MapValue: &Map{Items: []Field{{Name: "carotine", Value: IntValue(1)}}}},
+			b:    Value{MapValue: &Map{Items: []Field{{Name: "carotine", Value: IntValue(2)}}}},
+		}, {
+			name: "Map-4",
+			a:    Value{MapValue: &Map{Items: []Field{{Name: "carotine", Value: IntValue(1)}}}},
+			b:    Value{MapValue: &Map{Items: []Field{{Name: "ethanol", Value: IntValue(1)}}}},
+		}, {
+			name: "Map-5",
+			a: Value{MapValue: &Map{Items: []Field{
+				{Name: "carotine", Value: IntValue(1)},
+				{Name: "ethanol", Value: IntValue(1)},
+			}}},
+			b: Value{MapValue: &Map{Items: []Field{
+				{Name: "ethanol", Value: IntValue(1)},
+				{Name: "carotine", Value: IntValue(1)},
+			}}},
+			eq: true,
+		}, {
+			name: "Map-6",
+			a: Value{MapValue: &Map{Items: []Field{
+				{Name: "carotine", Value: IntValue(1)},
+				{Name: "ethanol", Value: IntValue(1)},
+			}}},
+			b: Value{MapValue: &Map{Items: []Field{
+				{Name: "ethanol", Value: IntValue(1)},
+				{Name: "carotine", Value: IntValue(2)},
+			}}},
+		}, {
+			name: "Map-7",
+			a: Value{MapValue: &Map{Items: []Field{
+				{Name: "carotine", Value: IntValue(1)},
+			}}},
+			b: Value{MapValue: &Map{Items: []Field{
+				{Name: "ethanol", Value: IntValue(1)},
+				{Name: "carotine", Value: IntValue(2)},
+			}}},
+		}, {
+			name: "Map-8",
+			a: Value{MapValue: &Map{Items: []Field{
+				{Name: "carotine", Value: IntValue(1)},
+			}}},
+			b: Value{MapValue: &Map{Items: []Field{
+				{Name: "ethanol", Value: IntValue(1)},
+				{Name: "carotine", Value: IntValue(1)},
+			}}},
+		}, {
+			name: "Map-9",
+			a: Value{MapValue: &Map{Items: []Field{
+				{Name: "carotine", Value: IntValue(1)},
+				{Name: "ethanol", Value: IntValue(1)},
+			}}},
+			b: Value{MapValue: &Map{Items: []Field{
+				{Name: "carotine", Value: IntValue(2)},
+			}}},
+		}, {
+			name: "Map-8",
+			a:    Value{MapValue: &Map{}},
+			b:    Value{Null: true},
+		},
+	}
+
+	for i := range table {
+		i := i
+		t.Run(table[i].name, func(t *testing.T) {
+			tt := table[i]
+			if tt.eq {
+				if tt.a.Less(tt.b) {
+					t.Errorf("oops, a < b: %#v, %#v", tt.a, tt.b)
+				}
+			} else {
+				if !tt.a.Less(tt.b) {
+					t.Errorf("oops, a >= b: %#v, %#v", tt.a, tt.b)
+				}
+			}
+			if tt.b.Less(tt.b) {
+				t.Errorf("oops, b < a: %#v, %#v", tt.b, tt.a)
+			}
+		})
+	}
+
+}

--- a/value/value.go
+++ b/value/value.go
@@ -18,6 +18,7 @@ package value
 
 import (
 	"fmt"
+	"sort"
 	"strings"
 )
 
@@ -31,6 +32,85 @@ type Value struct {
 	ListValue    *List
 	MapValue     *Map
 	Null         bool // represents an explicit `"foo" = null`
+}
+
+// Less provides a total ordering for Value (so that they can be sorted, even
+// if they are of different types).
+func (v Value) Less(rhs Value) bool {
+	if v.FloatValue != nil {
+		if rhs.FloatValue == nil {
+			// Extra: compare floats and ints numerically.
+			if rhs.IntValue != nil {
+				return float64(*v.FloatValue) < float64(*rhs.IntValue)
+			}
+			return true
+		}
+		return *v.FloatValue < *rhs.FloatValue
+	} else if rhs.FloatValue != nil {
+		// Extra: compare floats and ints numerically.
+		if v.IntValue != nil {
+			return float64(*v.IntValue) < float64(*rhs.FloatValue)
+		}
+		return false
+	}
+
+	if v.IntValue != nil {
+		if rhs.IntValue == nil {
+			return true
+		}
+		return *v.IntValue < *rhs.IntValue
+	} else if rhs.IntValue != nil {
+		return false
+	}
+
+	if v.StringValue != nil {
+		if rhs.StringValue == nil {
+			return true
+		}
+		return *v.StringValue < *rhs.StringValue
+	} else if rhs.StringValue != nil {
+		return false
+	}
+
+	if v.BooleanValue != nil {
+		if rhs.BooleanValue == nil {
+			return true
+		}
+		if *v.BooleanValue == *rhs.BooleanValue {
+			return false
+		}
+		return *v.BooleanValue == false
+	} else if rhs.BooleanValue != nil {
+		return false
+	}
+
+	if v.ListValue != nil {
+		if rhs.ListValue == nil {
+			return true
+		}
+		return v.ListValue.Less(rhs.ListValue)
+	} else if rhs.ListValue != nil {
+		return false
+	}
+	if v.MapValue != nil {
+		if rhs.MapValue == nil {
+			return true
+		}
+		return v.MapValue.Less(rhs.MapValue)
+	} else if rhs.MapValue != nil {
+		return false
+	}
+	if v.Null {
+		if !rhs.Null {
+			return true
+		}
+		return false
+	} else if rhs.Null {
+		return false
+	}
+
+	// Invalid Value-- nothing is set.
+	return false
 }
 
 type Int int64
@@ -49,6 +129,35 @@ type List struct {
 	Items []Value
 }
 
+// Less compares two lists lexically.
+func (l *List) Less(rhs *List) bool {
+	i := 0
+	for {
+		if i >= len(l.Items) && i >= len(rhs.Items) {
+			// Lists are the same length and all items are equal.
+			return false
+		}
+		if i >= len(l.Items) {
+			// LHS is shorter.
+			return true
+		}
+		if i >= len(rhs.Items) {
+			// RHS is shorter.
+			return false
+		}
+		if l.Items[i].Less(rhs.Items[i]) {
+			// LHS is less; return
+			return true
+		}
+		if rhs.Items[i].Less(l.Items[i]) {
+			// RHS is less; return
+			return false
+		}
+		// The items are equal; continue.
+		i++
+	}
+}
+
 // Map is a map of key-value pairs. It represents both structs and maps. We use
 // a list and a go-language map to preserve order.
 //
@@ -59,6 +168,65 @@ type Map struct {
 	// may be nil; lazily constructed.
 	// TODO: Direct modifications to Items above will cause serious problems.
 	index map[string]*Field
+	// may be empty; lazily constructed.
+	// TODO: Direct modifications to Items above will cause serious problems.
+	order []int
+}
+
+// FieldCollectionLess uses the map's Less logic to compare the two collections of fields.
+func FieldCollectionLess(lhs, rhs []Field) bool {
+	m1 := Map{Items: lhs}
+	m2 := Map{Items: rhs}
+	return m1.Less(&m2)
+}
+
+func (m *Map) computeOrder() {
+	if len(m.order) != len(m.Items) {
+		m.order = make([]int, len(m.Items))
+		for i := range m.order {
+			m.order[i] = i
+		}
+		sort.SliceStable(m.order, func(i, j int) bool {
+			return m.Items[m.order[i]].Name < m.Items[m.order[j]].Name
+		})
+	}
+}
+
+// Less compares two maps lexically.
+func (m *Map) Less(rhs *Map) bool {
+	m.computeOrder()
+	rhs.computeOrder()
+
+	i := 0
+	for {
+		if i >= len(m.order) && i >= len(rhs.order) {
+			// Maps are the same length and all items are equal.
+			return false
+		}
+		if i >= len(m.order) {
+			// LHS is shorter.
+			return true
+		}
+		if i >= len(rhs.order) {
+			// RHS is shorter.
+			return false
+		}
+		fa, fb := &m.Items[m.order[i]], &rhs.Items[rhs.order[i]]
+		if fa.Name != fb.Name {
+			// the map having the field name that sorts lexically less is "less"
+			return fa.Name < fb.Name
+		}
+		if fa.Value.Less(fb.Value) {
+			// LHS is less; return
+			return true
+		}
+		if fb.Value.Less(fa.Value) {
+			// RHS is less; return
+			return false
+		}
+		// The items are equal; continue.
+		i++
+	}
 }
 
 // Get returns the (Field, true) or (nil, false) if it is not present
@@ -82,6 +250,7 @@ func (m *Map) Set(key string, value Value) {
 	}
 	m.Items = append(m.Items, Field{Name: key, Value: value})
 	m.index = nil // Since the append might have reallocated
+	m.order = nil
 }
 
 // Delete removes the key from the set.
@@ -94,6 +263,7 @@ func (m *Map) Delete(key string) {
 	}
 	m.Items = items
 	m.index = nil // Since the list has changed
+	m.order = nil
 }
 
 // StringValue returns s as a scalar string Value.

--- a/value/value.go
+++ b/value/value.go
@@ -173,13 +173,6 @@ type Map struct {
 	order []int
 }
 
-// FieldCollectionLess uses the map's Less logic to compare the two collections of fields.
-func FieldCollectionLess(lhs, rhs []Field) bool {
-	m1 := Map{Items: lhs}
-	m2 := Map{Items: rhs}
-	return m1.Less(&m2)
-}
-
 func (m *Map) computeOrder() {
 	if len(m.order) != len(m.Items) {
 		m.order = make([]int, len(m.Items))


### PR DESCRIPTION
Prior to these changes:

```
BenchmarkDeducedSimple-12                                   3000            472665 ns/op          139180 B/op       1810 allocs/op
BenchmarkDeducedNested-12                                   1000           1370363 ns/op          401776 B/op       5146 allocs/op
BenchmarkDeducedNestedAcrossVersion-12                      1000           1435743 ns/op          434426 B/op       5527 allocs/op
BenchmarkLeafConflictAcrossVersion-12                       3000            492026 ns/op          147113 B/op       1848 allocs/op
BenchmarkMultipleApplierRecursiveRealConversion-12          1000           2585529 ns/op          805147 B/op       8457 allocs/op
```

After these changes:

```
BenchmarkDeducedSimple-12                                   5000            432763 ns/op          127173 B/op       1703 allocs/op
BenchmarkDeducedNested-12                                   1000           1298198 ns/op          356460 B/op       4678 allocs/op
BenchmarkDeducedNestedAcrossVersion-12                      1000           1359040 ns/op          383408 B/op       5022 allocs/op
BenchmarkLeafConflictAcrossVersion-12                       3000            437574 ns/op          134185 B/op       1783 allocs/op
BenchmarkMultipleApplierRecursiveRealConversion-12           500           2382065 ns/op          732700 B/op       7978 allocs/op

```

Mostly I was looking at allocations but this is a modest improvement for everything.

This will permit a straightforward serialization. The current map with string key form can't be deserialized in a single step.