### PR TITLE
use the technically-correct copy()

### DIFF
--- a/fieldpath/element.go
+++ b/fieldpath/element.go
@@ -163,12 +163,8 @@ func (s *PathElementSet) Insert(pe PathElement) {
 	if s.members[loc].Equals(pe) {
 		return
 	}
-	n := len(s.members) - 1
-	s.members = append(s.members, s.members[n])
-	for n > loc {
-		s.members[n] = s.members[n-1]
-		n--
-	}
+	s.members = append(s.members, PathElement{})
+	copy(s.members[loc+1:], s.members[loc:])
 	s.members[loc] = pe
 }
 

--- a/fieldpath/set.go
+++ b/fieldpath/set.go
@@ -188,12 +188,8 @@ func (s *SetNodeMap) Descend(pe PathElement) *Set {
 	if s.members[loc].pathElement.Equals(pe) {
 		return s.members[loc].set
 	}
-	n := len(s.members) - 1
-	s.members = append(s.members, s.members[n])
-	for n > loc {
-		s.members[n] = s.members[n-1]
-		n--
-	}
+	s.members = append(s.members, setNode{})
+	copy(s.members[loc+1:], s.members[loc:])
 	s.members[loc] = setNode{pathElement: pe, set: &Set{}}
 	return s.members[loc].set
 }


### PR DESCRIPTION
```
benchmark                                  old ns/op     new ns/op     delta
BenchmarkFieldSet/insert-20-12             19315         19975         +3.42%
BenchmarkFieldSet/has-20-12                704           699           -0.71%
BenchmarkFieldSet/union-20-12              11495         11874         +3.30%
BenchmarkFieldSet/intersection-20-12       5153          5120          -0.64%
BenchmarkFieldSet/difference-20-12         8763          8780          +0.19%
BenchmarkFieldSet/insert-50-12             62701         65663         +4.72%
BenchmarkFieldSet/has-50-12                873           876           +0.34%
BenchmarkFieldSet/union-50-12              29569         28755         -2.75%
BenchmarkFieldSet/intersection-50-12       10213         9916          -2.91%
BenchmarkFieldSet/difference-50-12         20901         20904         +0.01%
BenchmarkFieldSet/insert-100-12            165516        177455        +7.21%
BenchmarkFieldSet/has-100-12               1287          1200          -6.76%
BenchmarkFieldSet/union-100-12             62777         56087         -10.66%
BenchmarkFieldSet/intersection-100-12      20617         19769         -4.11%
BenchmarkFieldSet/difference-100-12        46939         46328         -1.30%
BenchmarkFieldSet/insert-500-12            770229        795607        +3.29%
BenchmarkFieldSet/has-500-12               1459          1491          +2.19%
BenchmarkFieldSet/union-500-12             283355        265356        -6.35%
BenchmarkFieldSet/intersection-500-12      126864        122291        -3.60%
BenchmarkFieldSet/difference-500-12        260655        229437        -11.98%
BenchmarkFieldSet/insert-1000-12           2120121       1949241       -8.06%
BenchmarkFieldSet/has-1000-12              1360          1358          -0.15%
BenchmarkFieldSet/union-1000-12            540864        522880        -3.33%
BenchmarkFieldSet/intersection-1000-12     213266        219356        +2.86%
BenchmarkFieldSet/difference-1000-12       394617        399513        +1.24%

benchmark                                  old allocs     new allocs     delta
BenchmarkFieldSet/insert-20-12             78             78             +0.00%
BenchmarkFieldSet/has-20-12                2              2              +0.00%
BenchmarkFieldSet/union-20-12              54             54             +0.00%
BenchmarkFieldSet/intersection-20-12       29             29             +0.00%
BenchmarkFieldSet/difference-20-12         43             43             +0.00%
BenchmarkFieldSet/insert-50-12             247            247            +0.00%
BenchmarkFieldSet/has-50-12                2              2              +0.00%
BenchmarkFieldSet/union-50-12              133            133            +0.00%
BenchmarkFieldSet/intersection-50-12       61             61             +0.00%
BenchmarkFieldSet/difference-50-12         101            101            +0.00%
BenchmarkFieldSet/insert-100-12            813            813            +0.00%
BenchmarkFieldSet/has-100-12               3              3              +0.00%
BenchmarkFieldSet/union-100-12             257            257            +0.00%
BenchmarkFieldSet/intersection-100-12      124            124            +0.00%
BenchmarkFieldSet/difference-100-12        214            214            +0.00%
BenchmarkFieldSet/insert-500-12            4141           4141           +0.00%
BenchmarkFieldSet/has-500-12               3              3              +0.00%
BenchmarkFieldSet/union-500-12             1468           1471           +0.20%
BenchmarkFieldSet/intersection-500-12      739            738            -0.14%
BenchmarkFieldSet/difference-500-12        1162           1160           -0.17%
BenchmarkFieldSet/insert-1000-12           8981           8981           +0.00%
BenchmarkFieldSet/has-1000-12              3              3              +0.00%
BenchmarkFieldSet/union-1000-12            2842           2855           +0.46%
BenchmarkFieldSet/intersection-1000-12     1330           1329           -0.08%
BenchmarkFieldSet/difference-1000-12       2238           2236           -0.09%
```

Not a big difference, but it occasionally saves an alloc and the code is shorter, so OK.