### PR TITLE
use zero alloc read function in jsoniter

### DIFF
--- a/fieldpath/serialize-pe_test.go
+++ b/fieldpath/serialize-pe_test.go
@@ -38,7 +38,7 @@ func TestPathElementRoundTrip(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test, func(t *testing.T) {
-			pe, err := DeserializePathElement(test)
+			pe, err := DeserializePathElement([]byte(test))
 			if err != nil {
 				t.Fatalf("Failed to create path element: %v", err)
 			}
@@ -54,7 +54,7 @@ func TestPathElementRoundTrip(t *testing.T) {
 }
 
 func TestPathElementIgnoreUnknown(t *testing.T) {
-	_, err := DeserializePathElement("r:Hello")
+	_, err := DeserializePathElement([]byte("r:Hello"))
 	if err != ErrUnknownPathElementType {
 		t.Fatalf("Unknown qualifiers must not return an invalid path element")
 	}
@@ -75,7 +75,7 @@ func TestDeserializePathElementError(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test, func(t *testing.T) {
-			pe, err := DeserializePathElement(test)
+			pe, err := DeserializePathElement([]byte(test))
 			if err == nil {
 				t.Fatalf("Expected error, no error found. got: %#v, %s", pe, pe)
 			}

--- a/fieldpath/serialize_test.go
+++ b/fieldpath/serialize_test.go
@@ -17,9 +17,7 @@ limitations under the License.
 package fieldpath
 
 import (
-	"bytes"
 	"fmt"
-	"strings"
 	"testing"
 )
 
@@ -35,7 +33,7 @@ func TestSerializeV1(t *testing.T) {
 			continue
 		}
 		x2 := NewSet()
-		err = x2.FromJSON(bytes.NewReader(b))
+		err = x2.FromJSON(b)
 		if err != nil {
 			t.Errorf("Failed to deserialize %s: %v\n%#v", b, err, x)
 		}
@@ -54,7 +52,7 @@ func TestSerializeV1GoldenData(t *testing.T) {
 	for i, str := range examples {
 		t.Run(fmt.Sprintf("%v", i), func(t *testing.T) {
 			x := NewSet()
-			err := x.FromJSON(strings.NewReader(str))
+			err := x.FromJSON([]byte(str))
 			if err != nil {
 				t.Errorf("Failed to deserialize %s: %v\n%#v", str, err, x)
 			}
@@ -74,7 +72,7 @@ func TestDropUnknown(t *testing.T) {
 	input := `{"f:aaa":{},"r:aab":{}}`
 	expect := `{"f:aaa":{}}`
 	x := NewSet()
-	err := x.FromJSON(strings.NewReader(input))
+	err := x.FromJSON([]byte(input))
 	if err != nil {
 		t.Errorf("Failed to deserialize %s: %v\n%#v", input, err, x)
 	}

--- a/fieldpath/set_test.go
+++ b/fieldpath/set_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package fieldpath
 
 import (
-	"bytes"
 	"fmt"
 	"math/rand"
 	"testing"
@@ -111,7 +110,7 @@ func BenchmarkFieldSet(b *testing.B) {
 			b.ReportAllocs()
 			s := NewSet()
 			for i := 0; i < b.N; i++ {
-				s.FromJSON(bytes.NewReader(serialized[rand.Intn(len(serialized))]))
+				s.FromJSON(serialized[rand.Intn(len(serialized))])
 			}
 		})
 

--- a/value/fastjson.go
+++ b/value/fastjson.go
@@ -87,7 +87,7 @@ func ReadJSONIter(iter *jsoniter.Iterator) (Value, error) {
 		return Value{ListValue: list}, iter.Error
 	case jsoniter.ObjectValue:
 		m := &Map{}
-		iter.ReadObjectCB(func(iter *jsoniter.Iterator, key string) bool {
+		iter.ReadMapCB(func(iter *jsoniter.Iterator, key string) bool {
 			v, err := ReadJSONIter(iter)
 			if err != nil {
 				iter.Error = err

--- a/value/unstructured_test.go
+++ b/value/unstructured_test.go
@@ -164,6 +164,7 @@ func TestToFromJSON(t *testing.T) {
 		`[]`,
 		`{}`,
 		`{"a":[null,1.2],"b":"something"}`,
+		//`{"a\"":[null,1.2],"a\u2029oeu":"something"}`,
 	}
 
 	for i, j := range js {
@@ -176,7 +177,7 @@ func TestToFromJSON(t *testing.T) {
 			if err != nil {
 				t.Fatalf("failed to marshal into json: %v", err)
 			}
-			if !reflect.DeepEqual(j, string(o)) {
+			if j != string(o) {
 				t.Fatalf("Failed to round-trip.\ninput: %#v\noutput: %#v", j, string(o))
 			}
 		})
@@ -189,8 +190,8 @@ func TestToFromJSON(t *testing.T) {
 			if err != nil {
 				t.Fatalf("failed to marshal into json: %v", err)
 			}
-			if !reflect.DeepEqual(j, string(o)) {
-				t.Fatalf("Failed to round-trip.\ninput: %#v\noutput: %#v", j, string(o))
+			if j != string(o) {
+				t.Fatalf("Failed to round-trip.\ninput:  %#v\noutput: %#v", j, string(o))
 			}
 		})
 	}


### PR DESCRIPTION
```
benchmark                                 old ns/op     new ns/op     delta
BenchmarkFieldSet/serialize-20-12         15649         15722         +0.47%
BenchmarkFieldSet/deserialize-20-12       36035         26974         -25.14%
BenchmarkFieldSet/serialize-50-12         37865         38637         +2.04%
BenchmarkFieldSet/deserialize-50-12       81147         66082         -18.57%
BenchmarkFieldSet/serialize-100-12        114218        118479        +3.73%
BenchmarkFieldSet/deserialize-100-12      224422        192446        -14.25%
BenchmarkFieldSet/serialize-500-12        617479        611650        -0.94%
BenchmarkFieldSet/deserialize-500-12      1053144       842299        -20.02%
BenchmarkFieldSet/serialize-1000-12       1236755       1160060       -6.20%
BenchmarkFieldSet/deserialize-1000-12     2054208       1669777       -18.71%

benchmark                                 old allocs     new allocs     delta
BenchmarkFieldSet/serialize-20-12         23             23             +0.00%
BenchmarkFieldSet/deserialize-20-12       216            141            -34.72%
BenchmarkFieldSet/serialize-50-12         48             48             +0.00%
BenchmarkFieldSet/deserialize-50-12       614            405            -34.04%
BenchmarkFieldSet/serialize-100-12        93             94             +1.08%
BenchmarkFieldSet/deserialize-100-12      2166           1441           -33.47%
BenchmarkFieldSet/serialize-500-12        470            470            +0.00%
BenchmarkFieldSet/deserialize-500-12      10779          7137           -33.79%
BenchmarkFieldSet/serialize-1000-12       999            998            -0.10%
BenchmarkFieldSet/deserialize-1000-12     23523          15604          -33.66%
```

This depends on https://github.com/json-iterator/go/pull/394. It doesn't really move the needle on the main repo benchmarks, sadly. But I already did the work, so I'm just publishing it.