### PR TITLE
improved memory management

### DIFF
--- a/typed/helpers.go
+++ b/typed/helpers.go
@@ -67,6 +67,14 @@ func (ef *errorFormatter) descend(pe fieldpath.PathElement) {
 	ef.path = append(ef.path, pe)
 }
 
+// parent returns the parent, for the purpose of buffer reuse. It's an error to
+// call this if there is no parent.
+func (ef *errorFormatter) parent() errorFormatter {
+	return errorFormatter{
+		path: ef.path[:len(ef.path)-1],
+	}
+}
+
 func (ef errorFormatter) errorf(format string, args ...interface{}) ValidationErrors {
 	return ValidationErrors{{
 		Path:         append(fieldpath.Path{}, ef.path...),

--- a/typed/merge.go
+++ b/typed/merge.go
@@ -43,6 +43,9 @@ type mergingWalker struct {
 
 	// internal housekeeping--don't set when constructing.
 	inLeaf bool // Set to true if we're in a "big leaf"--atomic map/list
+
+	// Allocate only as many walkers as needed for the depth by storing them here.
+	spareWalkers *[]*mergingWalker
 }
 
 // merge rules examine w.lhs and w.rhs (up to one of which may be nil) and
@@ -117,13 +120,30 @@ func (w *mergingWalker) doScalar(t schema.Scalar) (errs ValidationErrors) {
 }
 
 func (w *mergingWalker) prepareDescent(pe fieldpath.PathElement, tr schema.TypeRef) *mergingWalker {
-	w2 := *w
+	if w.spareWalkers == nil {
+		// first descent.
+		w.spareWalkers = &[]*mergingWalker{}
+	}
+	var w2 *mergingWalker
+	if n := len(*w.spareWalkers); n > 0 {
+		w2, *w.spareWalkers = (*w.spareWalkers)[n-1], (*w.spareWalkers)[:n-1]
+	} else {
+		w2 = &mergingWalker{}
+	}
+	*w2 = *w
 	w2.typeRef = tr
 	w2.errorFormatter.descend(pe)
 	w2.lhs = nil
 	w2.rhs = nil
 	w2.out = nil
-	return &w2
+	return w2
+}
+
+func (w *mergingWalker) finishDescent(w2 *mergingWalker) {
+	// if the descent caused a realloc, ensure that we reuse the buffer
+	// for the next sibling.
+	w.errorFormatter = w2.errorFormatter.parent()
+	*w.spareWalkers = append(*w.spareWalkers, w2)
 }
 
 func (w *mergingWalker) derefMap(prefix string, v *value.Value, dest **value.Map) (errs ValidationErrors) {
@@ -198,6 +218,7 @@ func (w *mergingWalker) visitListItems(t schema.List, lhs, rhs *value.List) (err
 			} else if w2.out != nil {
 				out.Items = append(out.Items, *w2.out)
 			}
+			w.finishDescent(w2)
 			// Keep track of children that have been handled
 			delete(observedRHS, keyStr)
 		}
@@ -212,6 +233,7 @@ func (w *mergingWalker) visitListItems(t schema.List, lhs, rhs *value.List) (err
 			} else if w2.out != nil {
 				out.Items = append(out.Items, *w2.out)
 			}
+			w.finishDescent(w2)
 		}
 	}
 
@@ -272,13 +294,13 @@ func (w *mergingWalker) visitMapItems(t schema.Map, lhs, rhs *value.Map) (errs V
 	}
 
 	if lhs != nil {
-		for _, litem := range lhs.Items {
-			name := litem.Name
+		for i := range lhs.Items {
+			litem := &lhs.Items[i]
 			fieldType := t.ElementType
-			if ft, ok := fieldTypes[name]; ok {
+			if ft, ok := fieldTypes[litem.Name]; ok {
 				fieldType = ft
 			}
-			w2 := w.prepareDescent(fieldpath.PathElement{FieldName: &name}, fieldType)
+			w2 := w.prepareDescent(fieldpath.PathElement{FieldName: &litem.Name}, fieldType)
 			w2.lhs = &litem.Value
 			if rhs != nil {
 				if ritem, ok := rhs.Get(litem.Name); ok {
@@ -288,31 +310,33 @@ func (w *mergingWalker) visitMapItems(t schema.Map, lhs, rhs *value.Map) (errs V
 			if newErrs := w2.merge(); len(newErrs) > 0 {
 				errs = append(errs, newErrs...)
 			} else if w2.out != nil {
-				out.Set(name, *w2.out)
+				out.Items = append(out.Items, value.Field{litem.Name, *w2.out})
 			}
+			w.finishDescent(w2)
 		}
 	}
 
 	if rhs != nil {
-		for _, ritem := range rhs.Items {
+		for j := range rhs.Items {
+			ritem := &rhs.Items[j]
 			if lhs != nil {
 				if _, ok := lhs.Get(ritem.Name); ok {
 					continue
 				}
 			}
 
-			name := ritem.Name
 			fieldType := t.ElementType
-			if ft, ok := fieldTypes[name]; ok {
+			if ft, ok := fieldTypes[ritem.Name]; ok {
 				fieldType = ft
 			}
-			w2 := w.prepareDescent(fieldpath.PathElement{FieldName: &name}, fieldType)
+			w2 := w.prepareDescent(fieldpath.PathElement{FieldName: &ritem.Name}, fieldType)
 			w2.rhs = &ritem.Value
 			if newErrs := w2.merge(); len(newErrs) > 0 {
 				errs = append(errs, newErrs...)
 			} else if w2.out != nil {
-				out.Set(name, *w2.out)
+				out.Items = append(out.Items, value.Field{ritem.Name, *w2.out})
 			}
+			w.finishDescent(w2)
 		}
 	}
 

--- a/typed/validate.go
+++ b/typed/validate.go
@@ -49,9 +49,36 @@ type validatingObjectWalker struct {
 
 	// internal housekeeping--don't set when constructing.
 	inLeaf bool // Set to true if we're in a "big leaf"--atomic map/list
+
+	// Allocate only as many walkers as needed for the depth by storing them here.
+	spareWalkers *[]*validatingObjectWalker
 }
 
-func (v validatingObjectWalker) validate() ValidationErrors {
+func (v *validatingObjectWalker) prepareDescent(pe fieldpath.PathElement, tr schema.TypeRef) *validatingObjectWalker {
+	if v.spareWalkers == nil {
+		// first descent.
+		v.spareWalkers = &[]*validatingObjectWalker{}
+	}
+	var v2 *validatingObjectWalker
+	if n := len(*v.spareWalkers); n > 0 {
+		v2, *v.spareWalkers = (*v.spareWalkers)[n-1], (*v.spareWalkers)[:n-1]
+	} else {
+		v2 = &validatingObjectWalker{}
+	}
+	*v2 = *v
+	v2.typeRef = tr
+	v2.errorFormatter.descend(pe)
+	return v2
+}
+
+func (v *validatingObjectWalker) finishDescent(v2 *validatingObjectWalker) {
+	// if the descent caused a realloc, ensure that we reuse the buffer
+	// for the next sibling.
+	v.errorFormatter = v2.errorFormatter.parent()
+	*v.spareWalkers = append(*v.spareWalkers, v2)
+}
+
+func (v *validatingObjectWalker) validate() ValidationErrors {
 	return resolveSchema(v.schema, v.typeRef, &v.value, v)
 }
 
@@ -87,7 +114,7 @@ func (v *validatingObjectWalker) doNode() {
 	}
 }
 
-func (v validatingObjectWalker) doScalar(t schema.Scalar) ValidationErrors {
+func (v *validatingObjectWalker) doScalar(t schema.Scalar) ValidationErrors {
 	if errs := v.validateScalar(t, &v.value, ""); len(errs) > 0 {
 		return errs
 	}
@@ -98,7 +125,7 @@ func (v validatingObjectWalker) doScalar(t schema.Scalar) ValidationErrors {
 	return nil
 }
 
-func (v validatingObjectWalker) visitListItems(t schema.List, list *value.List) (errs ValidationErrors) {
+func (v *validatingObjectWalker) visitListItems(t schema.List, list *value.List) (errs ValidationErrors) {
 	observedKeys := map[string]struct{}{}
 	for i, child := range list.Items {
 		pe, err := listItemToPathElement(t, i, child)
@@ -114,18 +141,17 @@ func (v validatingObjectWalker) visitListItems(t schema.List, list *value.List) 
 			errs = append(errs, v.errorf("duplicate entries for key %v", keyStr)...)
 		}
 		observedKeys[keyStr] = struct{}{}
-		v2 := v
-		v2.errorFormatter.descend(pe)
+		v2 := v.prepareDescent(pe, t.ElementType)
 		v2.value = child
-		v2.typeRef = t.ElementType
 		errs = append(errs, v2.validate()...)
 
 		v2.doNode()
+		v.finishDescent(v2)
 	}
 	return errs
 }
 
-func (v validatingObjectWalker) doList(t schema.List) (errs ValidationErrors) {
+func (v *validatingObjectWalker) doList(t schema.List) (errs ValidationErrors) {
 	list, err := listValue(v.value)
 	if err != nil {
 		return v.error(err)
@@ -144,7 +170,7 @@ func (v validatingObjectWalker) doList(t schema.List) (errs ValidationErrors) {
 	return errs
 }
 
-func (v validatingObjectWalker) visitMapItems(t schema.Map, m *value.Map) (errs ValidationErrors) {
+func (v *validatingObjectWalker) visitMapItems(t schema.Map, m *value.Map) (errs ValidationErrors) {
 	fieldTypes := map[string]schema.TypeRef{}
 	for i := range t.Fields {
 		// I don't want to use the loop variable since a reference
@@ -153,25 +179,27 @@ func (v validatingObjectWalker) visitMapItems(t schema.Map, m *value.Map) (errs 
 		fieldTypes[f.Name] = f.Type
 	}
 
-	for _, item := range m.Items {
-		v2 := v
-		name := item.Name
-		v2.errorFormatter.descend(fieldpath.PathElement{FieldName: &name})
-		v2.value = item.Value
+	for i := range m.Items {
+		item := &m.Items[i]
+		pe := fieldpath.PathElement{FieldName: &item.Name}
 
-		var ok bool
-		if v2.typeRef, ok = fieldTypes[name]; ok {
+		if tr, ok := fieldTypes[item.Name]; ok {
+			v2 := v.prepareDescent(pe, tr)
+			v2.value = item.Value
 			errs = append(errs, v2.validate()...)
+			v.finishDescent(v2)
 		} else {
-			v2.typeRef = t.ElementType
+			v2 := v.prepareDescent(pe, t.ElementType)
+			v2.value = item.Value
 			errs = append(errs, v2.validate()...)
 			v2.doNode()
+			v.finishDescent(v2)
 		}
 	}
 	return errs
 }
 
-func (v validatingObjectWalker) doMap(t schema.Map) (errs ValidationErrors) {
+func (v *validatingObjectWalker) doMap(t schema.Map) (errs ValidationErrors) {
 	m, err := mapValue(v.value)
 	if err != nil {
 		return v.error(err)


### PR DESCRIPTION
```
benchmark                       old ns/op     new ns/op     delta
BenchmarkApplyNewObject-12      1937221       1549953       -19.99%
BenchmarkUpdateNewObject-12     2175330       2054741       -5.54%
BenchmarkRepeatedUpdate-12      761351        635385        -16.55%
BenchmarkSetToFields-12         5200          5173          -0.52%
BenchmarkFieldsToSet-12         10336         10240         -0.93%
BenchmarkYAMLToTyped-12         64579         61926         -4.11%

benchmark                       old allocs     new allocs     delta
BenchmarkApplyNewObject-12      6820           6355           -6.82%
BenchmarkUpdateNewObject-12     7901           7398           -6.37%
BenchmarkRepeatedUpdate-12      2264           2035           -10.11%
BenchmarkSetToFields-12         14             14             +0.00%
BenchmarkFieldsToSet-12         82             82             +0.00%
BenchmarkYAMLToTyped-12         152            134            -11.84%
```

(benchmarks from the main repo)

These 18 lines do as much as my entire serialization change for the bottom line, lol.