### PR TITLE
disable unions, since they're still experimental

### DIFF
--- a/merge/union_test.go
+++ b/merge/union_test.go
@@ -67,6 +67,7 @@ var unionFieldsParser = func() typed.ParseableType {
 func TestUnion(t *testing.T) {
 	tests := map[string]TestCase{
 		"union_apply_owns_discriminator": {
+			RequiresUnions: true,
 			Ops: []Operation{
 				Apply{
 					Manager:    "default",
@@ -91,6 +92,7 @@ func TestUnion(t *testing.T) {
 			},
 		},
 		"union_apply_without_discriminator_conflict": {
+			RequiresUnions: true,
 			Ops: []Operation{
 				Update{
 					Manager:    "controller",
@@ -125,6 +127,7 @@ func TestUnion(t *testing.T) {
 			},
 		},
 		"union_apply_with_null_value": {
+			RequiresUnions: true,
 			Ops: []Operation{
 				Apply{
 					Manager:    "default",
@@ -138,6 +141,7 @@ func TestUnion(t *testing.T) {
 			},
 		},
 		"union_apply_multiple_unions": {
+			RequiresUnions: true,
 			Ops: []Operation{
 				Apply{
 					Manager:    "default",
@@ -176,6 +180,7 @@ func TestUnion(t *testing.T) {
 func TestUnionErrors(t *testing.T) {
 	tests := map[string]TestCase{
 		"union_apply_two": {
+			RequiresUnions: true,
 			Ops: []Operation{
 				Apply{
 					Manager:    "default",
@@ -188,6 +193,7 @@ func TestUnionErrors(t *testing.T) {
 			},
 		},
 		"union_apply_two_and_discriminator": {
+			RequiresUnions: true,
 			Ops: []Operation{
 				Apply{
 					Manager:    "default",
@@ -201,6 +207,7 @@ func TestUnionErrors(t *testing.T) {
 			},
 		},
 		"union_apply_wrong_discriminator": {
+			RequiresUnions: true,
 			Ops: []Operation{
 				Apply{
 					Manager:    "default",

--- a/merge/update.go
+++ b/merge/update.go
@@ -31,6 +31,14 @@ type Converter interface {
 // merge the object on Apply.
 type Updater struct {
 	Converter Converter
+
+	enableUnions bool
+}
+
+// EnableUnionFeature turns on union handling. It is disabled by default until the
+// feature is complete.
+func (s *Updater) EnableUnionFeature() {
+	s.enableUnions = true
 }
 
 func (s *Updater) update(oldObject, newObject *typed.TypedValue, version fieldpath.APIVersion, managers fieldpath.ManagedFields, workflow string, force bool) (fieldpath.ManagedFields, error) {
@@ -112,9 +120,12 @@ func (s *Updater) update(oldObject, newObject *typed.TypedValue, version fieldpa
 // PATCH call), and liveObject must be the original object (empty if
 // this is a CREATE call).
 func (s *Updater) Update(liveObject, newObject *typed.TypedValue, version fieldpath.APIVersion, managers fieldpath.ManagedFields, manager string) (*typed.TypedValue, fieldpath.ManagedFields, error) {
-	newObject, err := liveObject.NormalizeUnions(newObject)
-	if err != nil {
-		return nil, fieldpath.ManagedFields{}, err
+	var err error
+	if s.enableUnions {
+		newObject, err = liveObject.NormalizeUnions(newObject)
+		if err != nil {
+			return nil, fieldpath.ManagedFields{}, err
+		}
 	}
 	managers = shallowCopyManagers(managers)
 	managers, err = s.update(liveObject, newObject, version, managers, manager, true)
@@ -144,9 +155,12 @@ func (s *Updater) Update(liveObject, newObject *typed.TypedValue, version fieldp
 // and return it.
 func (s *Updater) Apply(liveObject, configObject *typed.TypedValue, version fieldpath.APIVersion, managers fieldpath.ManagedFields, manager string, force bool) (*typed.TypedValue, fieldpath.ManagedFields, error) {
 	managers = shallowCopyManagers(managers)
-	configObject, err := configObject.NormalizeUnionsApply(configObject)
-	if err != nil {
-		return nil, fieldpath.ManagedFields{}, err
+	var err error
+	if s.enableUnions {
+		configObject, err = configObject.NormalizeUnionsApply(configObject)
+		if err != nil {
+			return nil, fieldpath.ManagedFields{}, err
+		}
 	}
 	newObject, err := liveObject.Merge(configObject)
 	if err != nil {

--- a/typed/typed.go
+++ b/typed/typed.go
@@ -153,6 +153,8 @@ func (tv TypedValue) RemoveItems(items *fieldpath.Set) *TypedValue {
 // - If discriminator changed to non-nil, all other fields but the
 // discriminated one will be cleared,
 // - Otherwise, If only one field is left, update discriminator to that value.
+//
+// Please note: union behavior isn't finalized yet and this is still experimental.
 func (tv TypedValue) NormalizeUnions(new *TypedValue) (*TypedValue, error) {
 	var errs ValidationErrors
 	var normalizeFn = func(w *mergingWalker) {
@@ -177,6 +179,8 @@ func (tv TypedValue) NormalizeUnions(new *TypedValue) (*TypedValue, error) {
 // NormalizeUnionsApply specifically normalize unions on apply. It
 // validates that the applied union is correct (there should be no
 // ambiguity there), and clear the fields according to the sent intent.
+//
+// Please note: union behavior isn't finalized yet and this is still experimental.
 func (tv TypedValue) NormalizeUnionsApply(new *TypedValue) (*TypedValue, error) {
 	var errs ValidationErrors
 	var normalizeFn = func(w *mergingWalker) {


### PR DESCRIPTION
```
benchmark                       old ns/op     new ns/op     delta
BenchmarkApplyNewObject-12      1355981       1363050       +0.52%
BenchmarkUpdateNewObject-12     1565341       1228947       -21.49%
BenchmarkRepeatedUpdate-12      443528        396604        -10.58%
BenchmarkSetToFields-12         5154          5107          -0.91%
BenchmarkFieldsToSet-12         10050         10170         +1.19%
BenchmarkYAMLToTyped-12         56860         54439         -4.26%

benchmark                       old allocs     new allocs     delta
BenchmarkApplyNewObject-12      4264           4214           -1.17%
BenchmarkUpdateNewObject-12     4850           3661           -24.52%
BenchmarkRepeatedUpdate-12      1255           1179           -6.06%
BenchmarkSetToFields-12         14             14             +0.00%
BenchmarkFieldsToSet-12         82             82             +0.00%
BenchmarkYAMLToTyped-12         90             90             +0.00%
```