### PR TITLE
Remove merge from Compare

### DIFF
--- a/internal/testdata/scalar-compare-output.txt
+++ b/internal/testdata/scalar-compare-output.txt
@@ -1,4 +1,2 @@
-- Merged Object:
-{types=[{name="scalar";scalar="numeric"}]}
 - Modified Fields:
 .types[name="scalar"].scalar

--- a/typed/deduced_test.go
+++ b/typed/deduced_test.go
@@ -466,7 +466,6 @@ func TestSymdiffDeduced(t *testing.T) {
 			if err != nil {
 				t.Fatalf("got validation errors: %v", err)
 			}
-			t.Logf("got merged:\n%s\n", got.Merged.AsValue())
 			t.Logf("got added:\n%s\n", got.Added)
 			if !got.Added.Equals(quint.added) {
 				t.Errorf("Expected added:\n%s\n", quint.added)

--- a/typed/symdiff_test.go
+++ b/typed/symdiff_test.go
@@ -531,7 +531,6 @@ func (tt symdiffTestCase) test(t *testing.T) {
 			if err != nil {
 				t.Fatalf("got validation errors: %v", err)
 			}
-			t.Logf("got merged:\n%s\n", got.Merged.AsValue())
 			t.Logf("got added:\n%s\n", got.Added)
 			if !got.Added.Equals(quint.added) {
 				t.Errorf("Expected added:\n%s\n", quint.added)


### PR DESCRIPTION
Speed is not super reliable on laptop because of throttling, allocs should be relevant:
```
benchmark                                             old ns/op     new ns/op     delta
BenchmarkDeducedSimple-8                              103885        86064         -17.15%
BenchmarkDeducedNested-8                              256101        247159        -3.49%
BenchmarkDeducedNestedAcrossVersion-8                 259720        286096        +10.16%
BenchmarkLeafConflictAcrossVersion-8                  85375         89451         +4.77%
BenchmarkMultipleApplierRecursiveRealConversion-8     733484        720364        -1.79%

benchmark                                             old allocs     new allocs     delta
BenchmarkDeducedSimple-8                              877            840            -4.22%
BenchmarkDeducedNested-8                              2465           2354           -4.50%
BenchmarkDeducedNestedAcrossVersion-8                 2579           2422           -6.09%
BenchmarkLeafConflictAcrossVersion-8                  866            812            -6.24%
BenchmarkMultipleApplierRecursiveRealConversion-8     5845           5680           -2.82%

benchmark                                             old bytes     new bytes     delta
BenchmarkDeducedSimple-8                              67670         63922         -5.54%
BenchmarkDeducedNested-8                              156494        145361        -7.11%
BenchmarkDeducedNestedAcrossVersion-8                 164866        148804        -9.74%
BenchmarkLeafConflictAcrossVersion-8                  69100         63307         -8.38%
BenchmarkMultipleApplierRecursiveRealConversion-8     570178        557684        -2.19%
```