### PR TITLE
Various benchmarks improvements

### DIFF
--- a/internal/fixture/state.go
+++ b/internal/fixture/state.go
@@ -80,13 +80,11 @@ func (s *State) checkInit() error {
 	return nil
 }
 
-// Update the current state with the passed in object
-func (s *State) Update(obj typed.YAMLObject, version fieldpath.APIVersion, manager string) error {
-	obj = FixTabsOrDie(obj)
-	if err := s.checkInit(); err != nil {
+func (s *State) UpdateObject(tv *typed.TypedValue, version fieldpath.APIVersion, manager string) error {
+	err := s.checkInit()
+	if err != nil {
 		return err
 	}
-	tv, err := s.Parser.FromYAML(obj)
 	s.Live, err = s.Updater.Converter.Convert(s.Live, version)
 	if err != nil {
 		return err
@@ -101,13 +99,17 @@ func (s *State) Update(obj typed.YAMLObject, version fieldpath.APIVersion, manag
 	return nil
 }
 
-// Apply the passed in object to the current state
-func (s *State) Apply(obj typed.YAMLObject, version fieldpath.APIVersion, manager string, force bool) error {
-	obj = FixTabsOrDie(obj)
-	if err := s.checkInit(); err != nil {
+// Update the current state with the passed in object
+func (s *State) Update(obj typed.YAMLObject, version fieldpath.APIVersion, manager string) error {
+	tv, err := s.Parser.FromYAML(FixTabsOrDie(obj))
+	if err != nil {
 		return err
 	}
-	tv, err := s.Parser.FromYAML(obj)
+	return s.UpdateObject(tv, version, manager)
+}
+
+func (s *State) ApplyObject(tv *typed.TypedValue, version fieldpath.APIVersion, manager string, force bool) error {
+	err := s.checkInit()
 	if err != nil {
 		return err
 	}
@@ -123,6 +125,15 @@ func (s *State) Apply(obj typed.YAMLObject, version fieldpath.APIVersion, manage
 	s.Managers = managers
 
 	return nil
+}
+
+// Apply the passed in object to the current state
+func (s *State) Apply(obj typed.YAMLObject, version fieldpath.APIVersion, manager string, force bool) error {
+	tv, err := s.Parser.FromYAML(FixTabsOrDie(obj))
+	if err != nil {
+		return err
+	}
+	return s.ApplyObject(tv, version, manager, force)
 }
 
 // CompareLive takes a YAML string and returns the comparison with the
@@ -159,6 +170,7 @@ func (dummyConverter) IsMissingVersionError(err error) bool {
 // Operation is a step that will run when building a table-driven test.
 type Operation interface {
 	run(*State) error
+	preprocess(typed.ParseableType) (Operation, error)
 }
 
 func hasConflict(conflicts merge.Conflicts, conflict merge.Conflict) bool {
@@ -194,7 +206,37 @@ type Apply struct {
 var _ Operation = &Apply{}
 
 func (a Apply) run(state *State) error {
-	err := state.Apply(a.Object, a.APIVersion, a.Manager, false)
+	p, err := a.preprocess(state.Parser)
+	if err != nil {
+		return err
+	}
+	return p.run(state)
+}
+
+func (a Apply) preprocess(parser typed.ParseableType) (Operation, error) {
+	tv, err := parser.FromYAML(FixTabsOrDie(a.Object))
+	if err != nil {
+		return nil, err
+	}
+	return ApplyObject{
+		Manager:    a.Manager,
+		APIVersion: a.APIVersion,
+		Object:     tv,
+		Conflicts:  a.Conflicts,
+	}, nil
+}
+
+type ApplyObject struct {
+	Manager    string
+	APIVersion fieldpath.APIVersion
+	Object     *typed.TypedValue
+	Conflicts  merge.Conflicts
+}
+
+var _ Operation = &ApplyObject{}
+
+func (a ApplyObject) run(state *State) error {
+	err := state.ApplyObject(a.Object, a.APIVersion, a.Manager, false)
 	if err != nil {
 		if _, ok := err.(merge.Conflicts); !ok || a.Conflicts == nil {
 			return err
@@ -215,7 +257,10 @@ func (a Apply) run(state *State) error {
 		}
 	}
 	return nil
+}
 
+func (a ApplyObject) preprocess(parser typed.ParseableType) (Operation, error) {
+	return a, nil
 }
 
 // ForceApply is a type of operation. It is a forced-apply run by a
@@ -232,6 +277,36 @@ func (f ForceApply) run(state *State) error {
 	return state.Apply(f.Object, f.APIVersion, f.Manager, true)
 }
 
+func (f ForceApply) preprocess(parser typed.ParseableType) (Operation, error) {
+	tv, err := parser.FromYAML(FixTabsOrDie(f.Object))
+	if err != nil {
+		return nil, err
+	}
+	return ForceApplyObject{
+		Manager:    f.Manager,
+		APIVersion: f.APIVersion,
+		Object:     tv,
+	}, nil
+}
+
+// ForceApplyObject is a type of operation. It is a forced-apply run by
+// a manager with a given object. Any error will be returned.
+type ForceApplyObject struct {
+	Manager    string
+	APIVersion fieldpath.APIVersion
+	Object     *typed.TypedValue
+}
+
+var _ Operation = &ForceApplyObject{}
+
+func (f ForceApplyObject) run(state *State) error {
+	return state.ApplyObject(f.Object, f.APIVersion, f.Manager, true)
+}
+
+func (f ForceApplyObject) preprocess(parser typed.ParseableType) (Operation, error) {
+	return f, nil
+}
+
 // Update is a type of operation. It is a controller type of
 // update. Errors are passed along.
 type Update struct {
@@ -244,6 +319,36 @@ var _ Operation = &Update{}
 
 func (u Update) run(state *State) error {
 	return state.Update(u.Object, u.APIVersion, u.Manager)
+}
+
+func (u Update) preprocess(parser typed.ParseableType) (Operation, error) {
+	tv, err := parser.FromYAML(FixTabsOrDie(u.Object))
+	if err != nil {
+		return nil, err
+	}
+	return UpdateObject{
+		Manager:    u.Manager,
+		APIVersion: u.APIVersion,
+		Object:     tv,
+	}, nil
+}
+
+// UpdateObject is a type of operation. It is a controller type of
+// update. Errors are passed along.
+type UpdateObject struct {
+	Manager    string
+	APIVersion fieldpath.APIVersion
+	Object     *typed.TypedValue
+}
+
+var _ Operation = &Update{}
+
+func (u UpdateObject) run(state *State) error {
+	return state.UpdateObject(u.Object, u.APIVersion, u.Manager)
+}
+
+func (f UpdateObject) preprocess(parser typed.ParseableType) (Operation, error) {
+	return f, nil
 }
 
 // TestCase is the list of operations that need to be run, as well as
@@ -274,6 +379,18 @@ func (tc TestCase) Test(parser typed.ParseableType) error {
 // doesn't check exit conditions--see the comment for BenchWithConverter.
 func (tc TestCase) Bench(parser typed.ParseableType) error {
 	return tc.BenchWithConverter(parser, &dummyConverter{})
+}
+
+// Preprocess all the operations by parsing the yaml before-hand.
+func (tc TestCase) PreprocessOperations(parser typed.ParseableType) error {
+	for i := range tc.Ops {
+		op, err := tc.Ops[i].preprocess(parser)
+		if err != nil {
+			return err
+		}
+		tc.Ops[i] = op
+	}
+	return nil
 }
 
 // BenchWithConverter runs the test-case using the given parser and converter,

--- a/merge/deduced_test.go
+++ b/merge/deduced_test.go
@@ -603,6 +603,8 @@ func BenchmarkDeducedSimple(b *testing.B) {
 		b.Fatal(err)
 	}
 
+	test.PreprocessOperations(typed.DeducedParseableType)
+
 	b.ReportAllocs()
 	b.ResetTimer()
 	for n := 0; n < b.N; n++ {
@@ -712,6 +714,8 @@ func BenchmarkDeducedNested(b *testing.B) {
 		b.Fatal(err)
 	}
 
+	test.PreprocessOperations(typed.DeducedParseableType)
+
 	b.ReportAllocs()
 	b.ResetTimer()
 	for n := 0; n < b.N; n++ {
@@ -820,6 +824,8 @@ func BenchmarkDeducedNestedAcrossVersion(b *testing.B) {
 	if err := test.Test(typed.DeducedParseableType); err != nil {
 		b.Fatal(err)
 	}
+
+	test.PreprocessOperations(typed.DeducedParseableType)
 
 	b.ReportAllocs()
 	b.ResetTimer()

--- a/merge/leaf_test.go
+++ b/merge/leaf_test.go
@@ -536,6 +536,8 @@ func BenchmarkLeafConflictAcrossVersion(b *testing.B) {
 		b.Fatal(err)
 	}
 
+	test.PreprocessOperations(leafFieldsParser)
+
 	b.ReportAllocs()
 	b.ResetTimer()
 	for n := 0; n < b.N; n++ {

--- a/merge/multiple_appliers_test.go
+++ b/merge/multiple_appliers_test.go
@@ -1108,6 +1108,8 @@ func BenchmarkMultipleApplierRecursiveRealConversion(b *testing.B) {
 		b.Fatal(err)
 	}
 
+	test.PreprocessOperations(nestedTypeParser)
+
 	b.ReportAllocs()
 	b.ResetTimer()
 	for n := 0; n < b.N; n++ {

--- a/merge/pod_test.go
+++ b/merge/pod_test.go
@@ -1,0 +1,69 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package merge_test
+
+import (
+	"io/ioutil"
+	"path/filepath"
+	"testing"
+
+	. "sigs.k8s.io/structured-merge-diff/internal/fixture"
+	"sigs.k8s.io/structured-merge-diff/typed"
+)
+
+func testdata(file string) string {
+	return filepath.Join("..", "internal", "testdata", file)
+}
+
+func read(file string) []byte {
+	s, err := ioutil.ReadFile(file)
+	if err != nil {
+		panic(err)
+	}
+	return s
+}
+
+var podParser = func() typed.ParseableType {
+	s := read(testdata("k8s-schema.yaml"))
+	parser, err := typed.NewParser(typed.YAMLObject(s))
+	if err != nil {
+		panic(err)
+	}
+	return parser.Type("io.k8s.api.core.v1.Pod")
+}()
+
+func BenchmarkPodUpdates(b *testing.B) {
+	test := TestCase{
+		Ops: []Operation{
+			Update{
+				Manager:    "controller",
+				APIVersion: "v1",
+				Object:     typed.YAMLObject(read(testdata("pod.yaml"))),
+			},
+		},
+	}
+
+	test.PreprocessOperations(podParser)
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for n := 0; n < b.N; n++ {
+		if err := test.Bench(podParser); err != nil {
+			b.Fatal(err)
+		}
+	}
+}

--- a/typed/parser_test.go
+++ b/typed/parser_test.go
@@ -1,0 +1,61 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package typed_test
+
+import (
+	"io/ioutil"
+	"path/filepath"
+	"testing"
+
+	yaml "gopkg.in/yaml.v2"
+	"sigs.k8s.io/structured-merge-diff/typed"
+)
+
+func testdata(file string) string {
+	return filepath.Join("..", "internal", "testdata", file)
+}
+
+func BenchmarkFromUnstructured(b *testing.B) {
+	pod, err := ioutil.ReadFile(testdata("pod.yaml"))
+	if err != nil {
+		b.Fatal(err)
+	}
+
+	s, err := ioutil.ReadFile(testdata("k8s-schema.yaml"))
+	if err != nil {
+		b.Fatal(err)
+	}
+	parser, err := typed.NewParser(typed.YAMLObject(s))
+	if err != nil {
+		b.Fatal(err)
+	}
+	pt := parser.Type("io.k8s.api.core.v1.Pod")
+
+	obj := map[string]interface{}{}
+	if err := yaml.Unmarshal([]byte(pod), &obj); err != nil {
+		b.Fatal(err)
+	}
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for n := 0; n < b.N; n++ {
+		if _, err := pt.FromUnstructured(obj); err != nil {
+			b.Fatal(err)
+		}
+	}
+
+}


### PR DESCRIPTION
- Remove deserialization from benchmarks,
- Add actual pod to test performance,
- Add benchmark for converting objects to TypedValue