### PR TITLE
Improve Value and PathElement String()

### DIFF
--- a/value/value.go
+++ b/value/value.go
@@ -17,8 +17,8 @@ limitations under the License.
 package value
 
 import (
-	"fmt"
 	"sort"
+	"strconv"
 	"strings"
 )
 
@@ -334,25 +334,42 @@ func BooleanValue(b bool) Value {
 func (v Value) String() string {
 	switch {
 	case v.FloatValue != nil:
-		return fmt.Sprintf("%v", *v.FloatValue)
+		return strconv.FormatFloat(float64(*v.FloatValue), 'f', -1, 64)
 	case v.IntValue != nil:
-		return fmt.Sprintf("%v", *v.IntValue)
+		return strconv.FormatInt(int64(*v.IntValue), 10)
 	case v.StringValue != nil:
-		return fmt.Sprintf("%q", *v.StringValue)
+		b := strings.Builder{}
+		b.Grow(len(*v.StringValue) + 2)
+		b.WriteRune('"')
+		b.WriteString(string(*v.StringValue))
+		b.WriteRune('"')
+		return b.String()
 	case v.BooleanValue != nil:
-		return fmt.Sprintf("%v", *v.BooleanValue)
+		return strconv.FormatBool(bool(*v.BooleanValue))
 	case v.ListValue != nil:
-		strs := []string{}
-		for _, item := range v.ListValue.Items {
-			strs = append(strs, item.String())
+		b := strings.Builder{}
+		b.WriteRune('[')
+		for i, item := range v.ListValue.Items {
+			if i != 0 {
+				b.WriteRune(',')
+			}
+			b.WriteString(item.String())
 		}
-		return "[" + strings.Join(strs, ",") + "]"
+		b.WriteRune(']')
+		return b.String()
 	case v.MapValue != nil:
-		strs := []string{}
-		for _, i := range v.MapValue.Items {
-			strs = append(strs, fmt.Sprintf("%v=%v", i.Name, i.Value))
+		b := strings.Builder{}
+		b.WriteRune('{')
+		for i, item := range v.MapValue.Items {
+			if i > 0 {
+				b.WriteRune(';')
+			}
+			b.WriteString(item.Name)
+			b.WriteRune('=')
+			b.WriteString(item.Value.String())
 		}
-		return "{" + strings.Join(strs, ";") + "}"
+		b.WriteRune('}')
+		return b.String()
 	default:
 		fallthrough
 	case v.Null == true:


### PR DESCRIPTION
PathElements are frequently turned into strings to find out if a path has already been evaluated. Values are part of PathElements so they are also turned into strings. That's a non-negligible improvement.

```
benchmark                                   old ns/op     new ns/op     delta
BenchmarkOperations/Pod/Update-12           384166        329574        -14.21%
BenchmarkOperations/Node/Update-12          576277        498512        -13.49%
BenchmarkOperations/Pod/Apply-12            543377        482016        -11.29%
BenchmarkOperations/Node/Apply-12           764054        684379        -10.43%
BenchmarkOperations/Endpoints/Apply-12      2065245       1997567       -3.28%
BenchmarkOperations/Endpoints/Update-12     55470         53943         -2.75%

benchmark                                  old allocs     new allocs     delta
BenchmarkOperations/Node/Update-12         1155           967            -16.28%
BenchmarkOperations/Node/Apply-12          1876           1581           -15.72%
BenchmarkOperations/Pod/Update-12          843            727            -13.76%
BenchmarkOperations/Pod/Apply-12           1179           1024           -13.15%
BenchmarkOperations/Endpoints/Apply-12     3142           3043           -3.15%
```