### PR TITLE
Use PathElementSet and similar to index PathElement

### DIFF
--- a/fieldpath/element.go
+++ b/fieldpath/element.go
@@ -143,6 +143,12 @@ type PathElementSet struct {
 	members sortedPathElements
 }
 
+func MakePathElementSet(size int) PathElementSet {
+	return PathElementSet{
+		members: make(sortedPathElements, 0, size),
+	}
+}
+
 type sortedPathElements []PathElement
 
 // Implement the sort interface; this would permit bulk creation, which would

--- a/fieldpath/pathelementmap.go
+++ b/fieldpath/pathelementmap.go
@@ -1,0 +1,85 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package fieldpath
+
+import (
+	"sort"
+
+	"sigs.k8s.io/structured-merge-diff/value"
+)
+
+// PathElementValueMap is a map from PathElement to value.Value.
+//
+// TODO(apelisse): We have multiple very similar implementation of this
+// for PathElementSet and SetNodeMap, so we could probably share the
+// code.
+type PathElementValueMap struct {
+	members sortedPathElementValues
+}
+
+func MakePathElementValueMap(size int) PathElementValueMap {
+	return PathElementValueMap{
+		members: make(sortedPathElementValues, 0, size),
+	}
+}
+
+type pathElementValue struct {
+	PathElement PathElement
+	Value       value.Value
+}
+
+type sortedPathElementValues []pathElementValue
+
+// Implement the sort interface; this would permit bulk creation, which would
+// be faster than doing it one at a time via Insert.
+func (spev sortedPathElementValues) Len() int { return len(spev) }
+func (spev sortedPathElementValues) Less(i, j int) bool {
+	return spev[i].PathElement.Less(spev[j].PathElement)
+}
+func (spev sortedPathElementValues) Swap(i, j int) { spev[i], spev[j] = spev[j], spev[i] }
+
+// Insert adds the pathelement and associated value in the map.
+func (s *PathElementValueMap) Insert(pe PathElement, v value.Value) {
+	loc := sort.Search(len(s.members), func(i int) bool {
+		return !s.members[i].PathElement.Less(pe)
+	})
+	if loc == len(s.members) {
+		s.members = append(s.members, pathElementValue{pe, v})
+		return
+	}
+	if s.members[loc].PathElement.Equals(pe) {
+		return
+	}
+	s.members = append(s.members, pathElementValue{})
+	copy(s.members[loc+1:], s.members[loc:])
+	s.members[loc] = pathElementValue{pe, v}
+}
+
+// Get retrieves the value associated with the given PathElement from the map.
+// (nil, false) is returned if there is no such PathElement.
+func (s *PathElementValueMap) Get(pe PathElement) (value.Value, bool) {
+	loc := sort.Search(len(s.members), func(i int) bool {
+		return !s.members[i].PathElement.Less(pe)
+	})
+	if loc == len(s.members) {
+		return value.Value{}, false
+	}
+	if s.members[loc].PathElement.Equals(pe) {
+		return s.members[loc].Value, true
+	}
+	return value.Value{}, false
+}

--- a/fieldpath/pathelementmap_test.go
+++ b/fieldpath/pathelementmap_test.go
@@ -1,0 +1,50 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package fieldpath
+
+import (
+	"testing"
+
+	"sigs.k8s.io/structured-merge-diff/value"
+)
+
+func TestPathElementValueMap(t *testing.T) {
+	m := PathElementValueMap{}
+
+	if _, ok := m.Get(PathElement{FieldName: strptr("onion")}); ok {
+		t.Fatal("Unexpected path-element found in empty map")
+	}
+
+	m.Insert(PathElement{FieldName: strptr("carrot")}, value.StringValue("knife"))
+	m.Insert(PathElement{FieldName: strptr("chive")}, value.IntValue(2))
+
+	if _, ok := m.Get(PathElement{FieldName: strptr("onion")}); ok {
+		t.Fatal("Unexpected path-element in map")
+	}
+
+	if val, ok := m.Get(PathElement{FieldName: strptr("carrot")}); !ok {
+		t.Fatal("Missing path-element in map")
+	} else if !val.Equals(value.StringValue("knife")) {
+		t.Fatalf("Unexpected value found: %#v", val)
+	}
+
+	if val, ok := m.Get(PathElement{FieldName: strptr("chive")}); !ok {
+		t.Fatal("Missing path-element in map")
+	} else if !val.Equals(value.IntValue(2)) {
+		t.Fatalf("Unexpected value found: %#v", val)
+	}
+}


### PR DESCRIPTION
Currently, we index PathElement by turning them into strings, which is neither fast nor accurate.
We can simply use the `PathElementSet` when we need a set, and we can build a map of PathElement to Value when needed using very similar code.

Improvement:
```
benchmark                                              old ns/op     new ns/op     delta
BenchmarkOperations/Pod/Update-12                      187994        162602        -13.51%
BenchmarkOperations/Pod/Apply-12                       525375        452963        -13.78%
BenchmarkOperations/Node/Update-12                     273261        220959        -19.14%
BenchmarkOperations/Node/Apply-12                      760287        667991        -12.14%
BenchmarkOperations/Endpoints/Update-12                32649         32794         +0.44%
BenchmarkOperations/Endpoints/Apply-12                 2072047       1862396       -10.12%
BenchmarkFromUnstructured/Pod-12                       202893        182379        -10.11%
BenchmarkFromUnstructured/Node-12                      331193        308072        -6.98%
BenchmarkFromUnstructured/Endpoints-12                 8057365       7754632       -3.76%

benchmark                                              old allocs     new allocs     delta
BenchmarkOperations/Pod/Update-12                      445            284            -36.18%
BenchmarkOperations/Pod/Apply-12                       1179           771            -34.61%
BenchmarkOperations/Node/Update-12                     601            336            -44.09%
BenchmarkOperations/Node/Apply-12                      1876           1138           -39.34%
BenchmarkOperations/Endpoints/Update-12                74             74             +0.00%
BenchmarkOperations/Endpoints/Apply-12                 3142           1120           -64.35%
BenchmarkFromUnstructured/Pod-12                       477            392            -17.82%
BenchmarkFromUnstructured/Node-12                      1107           900            -18.70%
BenchmarkFromUnstructured/Endpoints-12                 21115          19089          -9.60%
```