### PR TITLE
Remove YAML parsing in benchmark

### DIFF
--- a/internal/fixture/state.go
+++ b/internal/fixture/state.go
@@ -71,7 +71,7 @@ func FixTabsOrDie(in typed.YAMLObject) typed.YAMLObject {
 
 func (s *State) checkInit() error {
 	if s.Live == nil {
-		obj, err := s.Parser.FromYAML("{}")
+		obj, err := s.Parser.FromUnstructured(nil)
 		if err != nil {
 			return fmt.Errorf("failed to create new empty object: %v", err)
 		}


### PR DESCRIPTION
This is quite trivial, but since we're doing this on every single benchmark step, it's a little misleading to have yaml parsing there ...