### PR TITLE
Fix wg-apply mailing list link

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ Learn how to engage with the Kubernetes community on the [community page](http:/
 You can reach the maintainers of this project at:
 
 - [Slack](http://slack.k8s.io/)
-- [Mailing List](https://groups.google.com/forum/#!forum/kubernetes-dev)
+- [Mailing List](https://groups.google.com/forum/#!forum/kubernetes-wg-apply)
 
 ### Code of conduct
 


### PR DESCRIPTION
I'm sure we can also fix the slack link, not sure how to refer to a specific channel.