### PR TITLE
Fix useless error message 'invalid atom'

### DIFF
--- a/typed/helpers.go
+++ b/typed/helpers.go
@@ -114,17 +114,27 @@ func resolveSchema(s *schema.Schema, tr schema.TypeRef, v *value.Value, ah atomH
 	return handleAtom(a, tr, ah)
 }
 
-func deduceAtom(a schema.Atom, v *value.Value) schema.Atom {
+// deduceAtom determines which of the possible types in atom 'atom' applies to value 'val'.
+// If val is of a type allowed by atom, return a copy of atom with all other types set to nil.
+// if val is nil, or is not of a type allowed by atom, just return the original atom,
+// and validation will fail at a later stage. (with a more useful error)
+func deduceAtom(atom schema.Atom, val *value.Value) schema.Atom {
 	switch {
-	case v == nil:
-	case v.FloatValue != nil, v.IntValue != nil, v.StringValue != nil, v.BooleanValue != nil:
-		return schema.Atom{Scalar: a.Scalar}
-	case v.ListValue != nil:
-		return schema.Atom{List: a.List}
-	case v.MapValue != nil:
-		return schema.Atom{Map: a.Map}
+	case val == nil:
+	case val.FloatValue != nil, val.IntValue != nil, val.StringValue != nil, val.BooleanValue != nil:
+		if atom.Scalar != nil {
+			return schema.Atom{Scalar: atom.Scalar}
+		}
+	case val.ListValue != nil:
+		if atom.List != nil {
+			return schema.Atom{List: atom.List}
+		}
+	case val.MapValue != nil:
+		if atom.Map != nil {
+			return schema.Atom{Map: atom.Map}
+		}
 	}
-	return a
+	return atom
 }
 
 func handleAtom(a schema.Atom, tr schema.TypeRef, ah atomHandler) ValidationErrors {

--- a/typed/symdiff_test.go
+++ b/typed/symdiff_test.go
@@ -300,6 +300,244 @@ var symdiffCases = []symdiffTestCase{{
 		added:    _NS(_P("a", "b")),
 	}},
 }, {
+	name:         "untyped deduced",
+	rootTypeName: "__untyped_deduced_",
+	schema: `types:
+- name: __untyped_atomic_
+  scalar: untyped
+  list:
+    elementType:
+      namedType: __untyped_atomic_
+    elementRelationship: atomic
+  map:
+    elementType:
+      namedType: __untyped_atomic_
+    elementRelationship: atomic
+- name: __untyped_deduced_
+  scalar: untyped
+  list:
+    elementType:
+      namedType: __untyped_atomic_
+    elementRelationship: atomic
+  map:
+    elementType:
+      namedType: __untyped_deduced_
+    elementRelationship: separable
+`,
+	quints: []symdiffQuint{{
+		lhs:      `{"a":{}}}`,
+		rhs:      `{"a":{"b":{}}}`,
+		removed:  _NS(),
+		modified: _NS(),
+		added:    _NS(_P("a", "b")),
+	}, {
+		lhs:      `{"a":null}`,
+		rhs:      `{"a":{"b":{}}}`,
+		removed:  _NS(),
+		modified: _NS(),
+		added:    _NS(_P("a", "b")),
+	}, {
+		lhs:      `{"a":{"b":{}}}`,
+		rhs:      `{"a":{}}}`,
+		removed:  _NS(_P("a", "b")),
+		modified: _NS(),
+		added:    _NS(),
+	}, {
+		lhs:      `{"a":{"b":{}}}`,
+		rhs:      `{"a":null}`,
+		removed:  _NS(_P("a", "b")),
+		modified: _NS(),
+		added:    _NS(),
+	}, {
+		lhs:      `{"a":[]}`,
+		rhs:      `{"a":["b"]}`,
+		removed:  _NS(),
+		modified: _NS(_P("a")),
+		added:    _NS(),
+	}, {
+		lhs:      `{"a":null}`,
+		rhs:      `{"a":["b"]}`,
+		removed:  _NS(),
+		modified: _NS(_P("a")),
+		added:    _NS(),
+	}, {
+		lhs:      `{"a":["b"]}`,
+		rhs:      `{"a":[]}`,
+		removed:  _NS(),
+		modified: _NS(_P("a")),
+		added:    _NS(),
+	}, {
+		lhs:      `{"a":["b"]}`,
+		rhs:      `{"a":null}`,
+		removed:  _NS(),
+		modified: _NS(_P("a")),
+		added:    _NS(),
+	}, {
+		lhs:      `{"a":null}`,
+		rhs:      `{"a":"b"}`,
+		removed:  _NS(),
+		modified: _NS(_P("a")),
+		added:    _NS(),
+	}, {
+		lhs:      `{"a":"b"}`,
+		rhs:      `{"a":null}`,
+		removed:  _NS(),
+		modified: _NS(_P("a")),
+		added:    _NS(),
+	}, {
+		lhs:      `{"a":{"b":{}}}`,
+		rhs:      `{"a":["b"]}}`,
+		removed:  _NS(_P("a", "b")),
+		modified: _NS(_P("a")),
+		added:    _NS(),
+	}, {
+		lhs:      `{"a":["b"]}}`,
+		rhs:      `{"a":{"b":{}}}`,
+		removed:  _NS(),
+		modified: _NS(_P("a")),
+		added:    _NS(_P("a", "b")),
+	}, {
+		lhs:      `{"a":{"b":{}}}`,
+		rhs:      `{"a":"b"}`,
+		removed:  _NS(_P("a", "b")),
+		modified: _NS(_P("a")),
+		added:    _NS(),
+	}, {
+		lhs:      `{"a":"b"}`,
+		rhs:      `{"a":{"b":{}}}`,
+		removed:  _NS(),
+		modified: _NS(_P("a")),
+		added:    _NS(_P("a", "b")),
+	}, {
+		lhs:      `{"a":["b"]}}`,
+		rhs:      `{"a":"b"}`,
+		removed:  _NS(),
+		modified: _NS(_P("a")),
+		added:    _NS(),
+	}, {
+		lhs:      `{"a":"b"}`,
+		rhs:      `{"a":["b"]}}`,
+		removed:  _NS(),
+		modified: _NS(_P("a")),
+		added:    _NS(),
+	}},
+}, {
+	name:         "untyped separable",
+	rootTypeName: "__untyped_separable_",
+	schema: `types:
+- name: __untyped_separable_
+  scalar: untyped
+  list:
+    elementType:
+      namedType: __untyped_separable_
+    elementRelationship: associative
+  map:
+    elementType:
+      namedType: __untyped_separable_
+    elementRelationship: separable
+`,
+	quints: []symdiffQuint{{
+		lhs:      `{"a":{}}}`,
+		rhs:      `{"a":{"b":{}}}`,
+		removed:  _NS(),
+		modified: _NS(),
+		added:    _NS(_P("a", "b")),
+	}, {
+		lhs:      `{"a":null}`,
+		rhs:      `{"a":{"b":{}}}`,
+		removed:  _NS(),
+		modified: _NS(),
+		added:    _NS(_P("a", "b")),
+	}, {
+		lhs:      `{"a":{"b":{}}}`,
+		rhs:      `{"a":{}}}`,
+		removed:  _NS(_P("a", "b")),
+		modified: _NS(),
+		added:    _NS(),
+	}, {
+		lhs:      `{"a":{"b":{}}}`,
+		rhs:      `{"a":null}`,
+		removed:  _NS(_P("a", "b")),
+		modified: _NS(),
+		added:    _NS(),
+	}, {
+		lhs:      `{"a":[]}`,
+		rhs:      `{"a":["b"]}`,
+		removed:  _NS(),
+		modified: _NS(),
+		added:    _NS(_P("a", _SV("b"))),
+	}, {
+		lhs:     `{"a":null}`,
+		rhs:     `{"a":["b"]}`,
+		removed: _NS(),
+		// TODO: result should be the same as the previous case
+		// nothing shoule be modified here.
+		modified: _NS(_P("a")),
+		added:    _NS(_P("a", _SV("b"))),
+	}, {
+		lhs:      `{"a":["b"]}`,
+		rhs:      `{"a":[]}`,
+		removed:  _NS(_P("a", _SV("b"))),
+		modified: _NS(),
+		added:    _NS(),
+	}, {
+		lhs:     `{"a":["b"]}`,
+		rhs:     `{"a":null}`,
+		removed: _NS(_P("a", _SV("b"))),
+		// TODO: result should be the same as the previous case
+		// nothing shoule be modified here.
+		modified: _NS(_P("a")),
+		added:    _NS(),
+	}, {
+		lhs:      `{"a":null}`,
+		rhs:      `{"a":"b"}`,
+		removed:  _NS(),
+		modified: _NS(_P("a")),
+		added:    _NS(),
+	}, {
+		lhs:      `{"a":"b"}`,
+		rhs:      `{"a":null}`,
+		removed:  _NS(),
+		modified: _NS(_P("a")),
+		added:    _NS(),
+	}, {
+		lhs:      `{"a":{"b":{}}}`,
+		rhs:      `{"a":["b"]}}`,
+		removed:  _NS(_P("a", "b")),
+		modified: _NS(),
+		added:    _NS(_P("a", _SV("b"))),
+	}, {
+		lhs:      `{"a":["b"]}}`,
+		rhs:      `{"a":{"b":{}}}`,
+		removed:  _NS(_P("a", _SV("b"))),
+		modified: _NS(),
+		added:    _NS(_P("a", "b")),
+	}, {
+		lhs:      `{"a":{"b":{}}}`,
+		rhs:      `{"a":"b"}`,
+		removed:  _NS(_P("a", "b")),
+		modified: _NS(_P("a")),
+		added:    _NS(),
+	}, {
+		lhs:      `{"a":"b"}`,
+		rhs:      `{"a":{"b":{}}}`,
+		removed:  _NS(),
+		modified: _NS(_P("a")),
+		added:    _NS(_P("a", "b")),
+	}, {
+		lhs:      `{"a":["b"]}}`,
+		rhs:      `{"a":"b"}`,
+		removed:  _NS(_P("a", _SV("b"))),
+		modified: _NS(_P("a")),
+		added:    _NS(),
+	}, {
+		lhs:      `{"a":"b"}`,
+		rhs:      `{"a":["b"]}}`,
+		removed:  _NS(),
+		modified: _NS(_P("a")),
+		added:    _NS(_P("a", _SV("b"))),
+	}},
+}, {
 	name:         "struct grab bag",
 	rootTypeName: "myStruct",
 	schema: `types:

--- a/typed/validate.go
+++ b/typed/validate.go
@@ -198,7 +198,11 @@ func (v *validatingObjectWalker) visitMapItems(t *schema.Map, m *value.Map) (err
 		} else {
 			v2 := v.prepareDescent(pe, t.ElementType)
 			v2.value = item.Value
-			errs = append(errs, v2.validate()...)
+			if (t.ElementType == schema.TypeRef{}) {
+				errs = append(errs, v2.errorf("field not declared in schema")...)
+			} else {
+				errs = append(errs, v2.validate()...)
+			}
 			v2.doNode()
 			v.finishDescent(v2)
 		}

--- a/typed/validate_test.go
+++ b/typed/validate_test.go
@@ -18,6 +18,7 @@ package typed_test
 
 import (
 	"fmt"
+	"strings"
 	"testing"
 
 	"sigs.k8s.io/structured-merge-diff/schema"
@@ -216,6 +217,8 @@ var validationCases = []validationTestCase{{
 	invalidObjects: []typed.YAMLObject{
 		`{"key":true,"value":1}`,
 		`{"list":{"key":true,"value":1}}`,
+		`{"list":true}`,
+		`true`,
 		`{"list":[{"key":true,"value":1}]}`,
 		`{"list":[{"key":[],"value":1}]}`,
 		`{"list":[{"key":{},"value":1}]}`,
@@ -260,6 +263,9 @@ func (tt validationTestCase) test(t *testing.T) {
 			_, err := pt.FromYAML(iv)
 			if err == nil {
 				t.Errorf("Object should fail: %v\n%v", err, iv)
+			}
+			if strings.Contains(err.Error(), "invalid atom") {
+				t.Errorf("Error should be useful, but got: %v\n%v", err, iv)
 			}
 		})
 	}


### PR DESCRIPTION
For a while now, any schema errors would result in a very useless error message "invalid atom", this was confusing, and also made debugging wiring the schema and value interface very tricky. This problem was originally caused when I made a schema able to represent something which could possibly be one of multiple types (was needed for CRD support) because we started hitting the "schema error: invalid atom" error before the validation code can generate a more useful error message.

Some examples of this problem (from typed/validate_test.go): 

| input | old error | new error |
|---|---|---|
| **TestSchemaValidation/simple_pair:** |
| `{"key":{"foo":true}}` | `.key: schema error: invalid atom: inlined` | `.key: expected string, got {foo=true}` |
| `{"key":[1, 2]}` | `.key: schema error: invalid atom: inlined` | `.key: expected string, got [1, 2]` |
| **TestSchemaValidation/associative_list:** |
| `{"key":true,"value":1}` | `.key: schema error: invalid atom: inlined\n.value: schema error: invalid atom: inlined` | `.key: field not declared in schema\n.value: field not declared in schema` |
| `{"list":{"key":true,"value":1}}` | `.list: schema error: invalid atom: named type: myList` | `.list: expected list, got {key=true;value=1}` |
| **TestSchemaValidation/struct_grab_bag:** |
| `{"numeric":{"a":1}}` | `.numeric: schema error: invalid atom: inlined` | `.numeric: expected numeric (int or float), got {a=1}` |
| `{"bool":["foo"]}` | `.bool: schema error: invalid atom: inlined` | `.bool: expected boolean, got ["foo"]` |