### PR TITLE
add extended remove method for typed values

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,12 +1,13 @@
 module sigs.k8s.io/structured-merge-diff/v3
 
-require gopkg.in/yaml.v2 v2.2.1
+require gopkg.in/yaml.v2 v2.2.2
 
 require (
 	github.com/google/gofuzz v1.0.0
 	github.com/json-iterator/go v1.1.6
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v1.0.1 // indirect
+	github.com/stretchr/testify v1.5.0 // indirect
 )
 
 go 1.13

--- a/go.sum
+++ b/go.sum
@@ -10,12 +10,11 @@ github.com/modern-go/reflect2 v1.0.1 h1:9f412s+6RmYXLWZSEzVVgPGK7C2PphHj5RJrvfx9
 github.com/modern-go/reflect2 v1.0.1/go.mod h1:bx2lNnkwVCuqBIxFjflWJWanXIb3RllmbCylyMrvgv0=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/stretchr/objx v0.1.0 h1:4G4v2dO3VZwixGIRoQ5Lfboy6nUhCyYzaqnIAPPhYs4=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
-github.com/stretchr/testify v1.3.0 h1:TivCn/peBQ7UY8ooIcPgZFpTNSz0Q2U6UrFlUfqbe0Q=
-github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
+github.com/stretchr/testify v1.5.0 h1:DMOzIV76tmoDNE9pX6RSN0aDtCYeCg5VueieJaAo1uw=
+github.com/stretchr/testify v1.5.0/go.mod h1:5W2xD1RspED5o8YsWQXVCued0rvSQ+mT+I5cxcmMvtA=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
-gopkg.in/yaml.v2 v2.2.1 h1:mUhvW9EsL+naU5Q3cakzfE91YhliOondGd6ZrsDBHQE=
-gopkg.in/yaml.v2 v2.2.1/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
-sigs.k8s.io/structured-merge-diff v1.0.1 h1:LOs1LZWMsz1xs77Phr/pkB4LFaavH7IVq/3+WTN9XTA=
-sigs.k8s.io/structured-merge-diff v1.0.1/go.mod h1:IIgPezJWb76P0hotTxzDbWsMYB8APh18qZnxkomBpxA=
+gopkg.in/yaml.v2 v2.2.2 h1:ZCJp+EgiOT7lHqUV2J862kp8Qj64Jo6az82+3Td9dZw=
+gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=

--- a/merge/multiple_appliers_test.go
+++ b/merge/multiple_appliers_test.go
@@ -670,7 +670,7 @@ func TestMultipleAppliersNestedType(t *testing.T) {
 			},
 			Object: `
 				mapOfMapsRecursive:
-				  a:
+				  a: {}
 				  c:
 				    d:
 				      e:
@@ -788,7 +788,7 @@ func TestMultipleAppliersDeducedType(t *testing.T) {
 				},
 			},
 			Object: `
-				a:
+				a: {}
 				c:
 				  d:
 				    e:

--- a/typed/remove_test.go
+++ b/typed/remove_test.go
@@ -1,0 +1,492 @@
+package typed
+
+import (
+	"fmt"
+	"testing"
+
+	"sigs.k8s.io/structured-merge-diff/v3/fieldpath"
+	"sigs.k8s.io/structured-merge-diff/v3/value"
+)
+
+var (
+	// Short names for readable test cases.
+	_NS  = fieldpath.NewSet
+	_P   = fieldpath.MakePathOrDie
+	_KBF = fieldpath.KeyByFields
+	_V   = value.NewValueInterface
+)
+
+func TestRemoveDeduced(t *testing.T) {
+	var cases = []struct {
+		object YAMLObject
+		remove *fieldpath.Set
+		expect YAMLObject
+	}{
+		{
+			object: `{}`,
+			remove: _NS(_P("a")),
+			expect: `{}`,
+		},
+		{
+			object: `{"a": "value"}`,
+			remove: _NS(_P("a")),
+			expect: `{}`,
+		},
+		{
+			object: `{"a": "value", "b": "value"}`,
+			remove: _NS(_P("a")),
+			expect: `{"b": "value"}`,
+		},
+		{
+			object: `{"a": "value", "b": {}}`,
+			remove: _NS(_P("a")),
+			expect: `{"b": {}}`,
+		},
+		{
+			object: `{"a": "value", "b": {"c":"value"}}`,
+			remove: _NS(_P("b")),
+			expect: `{"a": "value"}`,
+		},
+		{
+			object: `{"a": "value", "b": {"c":"value"}}`,
+			remove: _NS(_P("b", "c")),
+			expect: `{"a": "value", "b": {}}`,
+		},
+		{
+			object: `{"a": "value", "b": []}`,
+			remove: _NS(_P("b")),
+			expect: `{"a": "value"}`,
+		},
+		{
+			object: `{"a": "value", "b": ["c"]}`,
+			remove: _NS(_P("b")),
+			expect: `{"a": "value"}`,
+		},
+		{
+			object: `{"a": "value", "b": ["c"]}`,
+			remove: _NS(_P("b", "c")),
+			// `c` won't get removed, as it is not a field, while being addressed as one in MakePathOrDie.
+			// There is a test for removing `c` below.
+			expect: `{"a": "value", "b": ["c"]}`,
+		},
+		{
+			object: `{"a": "value", "b": ["c", "d"]}`,
+			remove: _NS(_P("b", "c")),
+			// `c` won't get removed, as it is not a field, while being addressed as one in MakePathOrDie.
+			// There is a test for removing `c` below.
+			expect: `{"a": "value", "b": ["c", "d"]}`,
+		},
+		{
+			object: `{"a": "value", "b": ["c"]}`,
+			remove: _NS(_P("b", 0)),
+			expect: `{"a": "value", "b": []}`,
+		},
+		{
+			object: `{"a": "value", "b": ["c", "d"]}`,
+			remove: _NS(_P("b", 1)),
+			expect: `{"a": "value", "b": ["c"]}`,
+		},
+		{
+			object: `{"a": "value", "b": [{"c": "value"}, {"d": "value"}]}`,
+			remove: _NS(_P("b", "c")),
+			// `c` won't get removed, as it is not a field, but a field inside a list item, MakePath does not address it accordingly.
+			// It would be unexpected to remove all `c`s from a lists items.
+			// To remove only the list item or `c` the path must be specified differently (see below).
+			expect: `{"a": "value", "b": [{"c": "value"}, {"d": "value"}]}`,
+		},
+		{
+			object: `{"a": "value", "b": [{"c": "value"}, {"d": "value"}]}`,
+			remove: _NS(_P("b", 0)),
+			expect: `{"a": "value", "b": [{"d": "value"}]}`,
+		},
+		{
+			object: `{"a": "value", "b": [{"c": "value"}, {"d": "value"}]}`,
+			remove: _NS(_P("b", 0, "c")),
+			expect: `{"a": "value", "b": [{}, {"d": "value"}]}`,
+		},
+		{
+			object: `{"a": "value", "b": {"c":"value", "d":{"e":"value"}}}`,
+			remove: _NS(_P("b", "d")),
+			expect: `{"a": "value", "b": {"c":"value"}}`,
+		},
+		{
+			object: `{"a": "value", "b": {"c":"value", "d": {"e":"value"}}}`,
+			remove: _NS(_P("b", "d", "e")),
+			expect: `{"a": "value", "b": {"c":"value", "d": {}}}`,
+		},
+	}
+
+	for i, c := range cases {
+		c := c
+		t.Run(fmt.Sprintf("case-%d", i), func(t *testing.T) {
+			t.Parallel()
+
+			obj, err := DeducedParseableType.FromYAML(c.object)
+			if err != nil {
+				t.Fatalf("unable to parse/validate object: %v\n%v", err, c.object)
+			}
+
+			parseable := &ParseableType{
+				Schema:  obj.schema,
+				TypeRef: obj.typeRef,
+			}
+			expectTyped, err := parseable.FromYAML(c.expect)
+			if err != nil {
+				t.Fatalf("unable to parse/validate expected object: %v\n%v", err, c.expect)
+			}
+			expect := expectTyped.AsValue()
+
+			result := obj.Remove(c.remove).AsValue()
+			if !value.Equals(result, expect) {
+				t.Fatalf("unexpected result after Remove:\ngot: %v\nexp: %v",
+					value.ToString(result), value.ToString(expect),
+				)
+			}
+
+			result = obj.RemoveItems(c.remove).AsValue()
+			if !value.Equals(result, expect) {
+				t.Fatalf("unexpected result after RemoveItems:\ngot: %v\nexp: %v",
+					value.ToString(result), value.ToString(expect),
+				)
+			}
+		})
+	}
+}
+
+func TestRemove(t *testing.T) {
+	var cases = []struct {
+		object          YAMLObject
+		schema          YAMLObject
+		remove          *fieldpath.Set
+		expect          YAMLObject
+		expectItemsOnly YAMLObject
+	}{
+		{
+			schema: `types:
+- name: type
+  map:
+    fields:
+    - name: a
+      type:
+        scalar: string
+    - name: b
+      type:
+        map:
+          elementType:
+            scalar: string
+`,
+			object:          `{"a": "value", "b":{"c":"value", "d": "value"}}`,
+			remove:          _NS(_P("b", "d")),
+			expect:          `{"a": "value", "b":{"c":"value"}}`,
+			expectItemsOnly: `{"a": "value", "b":{"c":"value"}}`,
+		},
+		{
+			schema: `types:
+- name: type
+  map:
+    fields:
+    - name: a
+      type:
+        scalar: string
+    - name: b
+      type:
+        map:
+          elementType:
+            scalar: string
+`,
+			object:          `{"a": "value", "b":{"c":"value", "d": "value"}}`,
+			remove:          _NS(_P("b")),
+			expect:          `{"a": "value"}`,
+			expectItemsOnly: `{"a": "value", "b":{"c":"value", "d": "value"}}}`,
+		},
+		{
+			schema: `types:
+- name: type
+  map:
+    fields:
+    - name: a
+      type:
+        scalar: string
+    - name: b
+      type:
+        map:
+          fields:
+          - name: c
+            type:
+              scalar: string
+`,
+			object:          `{"a": "value", "b":{"c":"value"}}`,
+			remove:          _NS(_P("b")),
+			expect:          `{"a": "value"}`,
+			expectItemsOnly: `{"a": "value", "b":{"c":"value"}}`,
+		},
+		{
+			schema: `types:
+- name: type
+  map:
+    fields:
+    - name: a
+      type:
+        scalar: string
+    - name: b
+      type:
+        map:
+          fields:
+          - name: c
+            type:
+              scalar: string
+`,
+			object:          `{"a": "value", "b":{"c":"value"}}`,
+			remove:          _NS(_P("b")),
+			expect:          `{"a": "value"}`,
+			expectItemsOnly: `{"a": "value", "b":{"c":"value"}}`,
+		},
+		{
+			schema: `types:
+- name: type
+  map:
+    fields:
+    - name: a
+      type:
+        scalar: string
+    - name: b
+      type:
+        map:
+          fields:
+          - name: c
+            type:
+              scalar: string
+          elementRelationship: separable
+`,
+			object:          `{"a": "value", "b":{"c":"value"}}`,
+			remove:          _NS(_P("b", "c")),
+			expect:          `{"a": "value", "b": {}}`,
+			expectItemsOnly: `{"a": "value", "b": {"c":"value"}}`,
+		},
+		{
+			schema: `types:
+- name: type
+  map:
+    fields:
+    - name: a
+      type:
+        scalar: string
+    - name: b
+      type:
+        map:
+          fields:
+          - name: c
+            type:
+              scalar: string
+          elementRelationship: separable
+`,
+			object:          `{"a": "value", "b":{"c":"value"}}`,
+			remove:          _NS(_P("b")),
+			expect:          `{"a": "value"}`,
+			expectItemsOnly: `{"a": "value", "b":{"c":"value"}}`,
+		},
+		{
+			schema: `types:
+- name: type
+  map:
+    fields:
+    - name: a
+      type:
+        scalar: string
+    - name: b
+      type:
+        map:
+          fields:
+          - name: c
+            type:
+              scalar: string
+          elementRelationship: atomic
+`,
+			object:          `{"a": "value", "b": {"c":"value"}}`,
+			remove:          _NS(_P("b", "c")),
+			expect:          `{"a": "value", "b": {}}`,
+			expectItemsOnly: `{"a": "value", "b": {"c":"value"}}`,
+		},
+		{
+			schema: `types:
+- name: type
+  map:
+    fields:
+    - name: a
+      type:
+        scalar: string
+    - name: b
+      type:
+        map:
+          fields:
+          - name: c
+            type:
+              scalar: string
+          elementRelationship: atomic
+`,
+			object:          `{"a": "value", "b":{"c":"value"}}`,
+			remove:          _NS(_P("b")),
+			expect:          `{"a": "value"}`,
+			expectItemsOnly: `{"a": "value", "b":{"c":"value"}}`,
+		},
+		{
+			schema: `types:
+- name: type
+  map:
+    fields:
+    - name: a
+      type:
+        scalar: string
+    - name: b
+      type:
+        list:
+          elementType:
+            scalar: string
+          elementRelationship: associative
+`,
+			object: `{"a": "value", "b": ["c"]}`,
+			remove: _NS(_P("b", "c")),
+			// `c` won't get removed, as it is not a field, while being addressed as one in MakePathOrDie.
+			// There is a test for removing `c` below.
+			expect:          `{"a": "value", "b": ["c"]}`,
+			expectItemsOnly: `{"a": "value", "b": ["c"]}`,
+		},
+		{
+			schema: `types:
+- name: type
+  map:
+    fields:
+    - name: a
+      type:
+        scalar: string
+    - name: b
+      type:
+        list:
+          elementType:
+            scalar: string
+          elementRelationship: associative
+`,
+			object:          `{"a": "value", "b": ["c"]}`,
+			remove:          _NS(_P("b")),
+			expect:          `{"a": "value"}`,
+			expectItemsOnly: `{"a": "value", "b": ["c"]}`,
+		},
+		{
+			schema: `types:
+- name: type
+  map:
+    fields:
+    - name: a
+      type:
+        scalar: string
+    - name: b
+      type:
+        list:
+          keys:
+          - name
+          elementType:
+            map:
+              fields:
+              - name: name
+                type:
+                  scalar: string
+              - name: c
+                type:
+                  scalar: number
+              - name: d
+                type:
+                  scalar: string
+          elementRelationship: associative
+`,
+			object:          `{"a": "value", "b": [{"name": "item1", "c": 1, "d": "value"}, {"name": "item2", "c": 1, "d": "value"}]}`,
+			remove:          _NS(_P("b", _KBF("name", "item1"))),
+			expect:          `{"a": "value", "b": [{"name": "item2", "c": 1, "d": "value"}]}`,
+			expectItemsOnly: `{"a": "value", "b": [{"name": "item2", "c": 1, "d": "value"}]}`,
+		},
+		{
+			schema: `types:
+- name: type
+  map:
+    fields:
+    - name: a
+      type:
+        scalar: string
+    - name: b
+      type:
+        list:
+          elementType:
+            scalar: string
+          elementRelationship: atomic
+`,
+			object: `{"a": "value", "b": ["c"]}`,
+			remove: _NS(_P("b", "c")),
+			// `c` won't get removed, as it is not a field, while being addressed as one in the path.
+			expect:          `{"a": "value", "b": ["c"]}`,
+			expectItemsOnly: `{"a": "value", "b": ["c"]}`,
+		},
+		{
+			schema: `types:
+- name: type
+  map:
+    fields:
+    - name: a
+      type:
+        scalar: string
+    - name: b
+      type:
+        list:
+          elementType:
+            scalar: string
+          elementRelationship: associative
+`,
+			object:          `{"a": "value", "b": ["c"]}`,
+			remove:          _NS(_P("b", _V("c"))),
+			expect:          `{"a": "value", "b": []}`,
+			expectItemsOnly: `{"a": "value", "b": []}`,
+		},
+	}
+
+	for i, c := range cases {
+		c := c
+		t.Run(fmt.Sprintf("case-%d", i), func(t *testing.T) {
+			t.Parallel()
+
+			parser, err := NewParser(c.schema)
+			if err != nil {
+				t.Fatalf("unable to parse schema: %v\n%v", err, c.schema)
+			}
+
+			parseable := parser.Type("type")
+			obj, err := parseable.FromYAML(c.object)
+			if err != nil {
+				t.Fatalf("unable to parse object: %v\n%v", err, c.object)
+			}
+
+			expectTyped, err := parseable.FromYAML(c.expect)
+			if err != nil {
+				t.Fatalf("unable to parse expected object: %v\n%v", err, c.expect)
+			}
+			expect := expectTyped.AsValue()
+
+			expectItemsOnlyTyped, err := parseable.FromYAML(c.expectItemsOnly)
+			if err != nil {
+				t.Fatalf("unable to parse/validate expected object: %v\n%v", err, c.expectItemsOnly)
+			}
+			expectItemsOnly := expectItemsOnlyTyped.AsValue()
+
+			result := obj.Remove(c.remove).AsValue()
+			if !value.Equals(result, expect) {
+				t.Fatalf("unexpected result after Remove:\ngot: %v\nexp: %v",
+					value.ToString(result), value.ToString(expect),
+				)
+			}
+
+			result = obj.RemoveItems(c.remove).AsValue()
+			if !value.Equals(result, expectItemsOnly) {
+				t.Fatalf("unexpected result after RemoveItems:\ngot: %v\nexp: %v",
+					value.ToString(result), value.ToString(expectItemsOnly),
+				)
+			}
+		})
+	}
+}

--- a/typed/typed.go
+++ b/typed/typed.go
@@ -138,9 +138,16 @@ func (tv TypedValue) Compare(rhs *TypedValue) (c *Comparison, err error) {
 	return c, nil
 }
 
+// Remove recursively removes each provided path, including its sub-paths.
+// For example `.a` would also remove `.a.b` as it's a sub-path.
+func (tv TypedValue) Remove(items *fieldpath.Set) *TypedValue {
+	tv.value = removeWithSchema(tv.value, items, tv.schema, tv.typeRef, false)
+	return &tv
+}
+
 // RemoveItems removes each provided list or map item from the value.
 func (tv TypedValue) RemoveItems(items *fieldpath.Set) *TypedValue {
-	tv.value = removeItemsWithSchema(tv.value, items, tv.schema, tv.typeRef)
+	tv.value = removeWithSchema(tv.value, items, tv.schema, tv.typeRef, true)
 	return &tv
 }
 


### PR DESCRIPTION
While working on an implementation of https://github.com/kubernetes/enhancements/pull/1123
i discovered that removing fields is not behaving like I expected.

Provided an original fieldSet like:
```
.status.phase
```
and a fieldSet to be removed:
```
.status
```
The current Difference and Intersect methods for fieldSets do not match all child paths when a parent path is defined, because `.status` != `.status.phase`.

For most cases, this seems reasonable (like ownership).

But to define a set of fields that should be removed from the object, it is impractical.
To avoid a user has to define every deep path to be removed (for status wiping),
a second Remove method is added to value.TypedValue that removes a fieldpath once found.

It extends the already available RemoveItems behavior to also remove from maps.