### PR TITLE
Use Compare when serializing rather than Less

### DIFF
--- a/fieldpath/serialize.go
+++ b/fieldpath/serialize.go
@@ -91,7 +91,7 @@ func (s *Set) emitContents_v1(includeSelf bool, stream *jsoniter.Stream, r *reus
 		mpe := s.Members.members[mi]
 		cpe := s.Children.members[ci].pathElement
 
-		if mpe.Less(cpe) {
+		if c := mpe.Compare(cpe); c < 0 {
 			preWrite()
 			if err := serializePathElementToWriter(r.reset(), mpe); err != nil {
 				return err
@@ -99,7 +99,7 @@ func (s *Set) emitContents_v1(includeSelf bool, stream *jsoniter.Stream, r *reus
 			stream.WriteObjectField(r.unsafeString())
 			stream.WriteEmptyObject()
 			mi++
-		} else if cpe.Less(mpe) {
+		} else if c > 0 {
 			preWrite()
 			if err := serializePathElementToWriter(r.reset(), cpe); err != nil {
 				return err


### PR DESCRIPTION
Compare the PathElement rather than calling twice in both direction. I don't think this has a "exponential" impact as it did in other places, but it's still the best thing to do.

I get a 2.5% time improvement on serialize tests. Nothing fancy.

@tedyu @jennybuckley 