### PR TITLE
rename value conversion methods

### DIFF
--- a/fieldpath/fromvalue.go
+++ b/fieldpath/fromvalue.go
@@ -55,7 +55,7 @@ func (w *objectWalker) walk() {
 	case w.value.IsList():
 		// If the list were atomic, we'd break here, but we don't have
 		// a schema, so we can't tell.
-		list := w.value.List()
+		list := w.value.AsList()
 		for i := 0; i < list.Length(); i++ {
 			w2 := *w
 			w2.path = append(w.path, GuessBestListPathElement(i, list.At(i)))
@@ -67,7 +67,7 @@ func (w *objectWalker) walk() {
 		// If the map/struct were atomic, we'd break here, but we don't
 		// have a schema, so we can't tell.
 
-		w.value.Map().Iterate(func(k string, val value.Value) bool {
+		w.value.AsMap().Iterate(func(k string, val value.Value) bool {
 			w2 := *w
 			w2.path = append(w.path, PathElement{FieldName: &k})
 			w2.value = val
@@ -106,7 +106,7 @@ func GuessBestListPathElement(index int, item value.Value) PathElement {
 
 	var keys value.FieldList
 	for _, name := range AssociativeListCandidateFieldNames {
-		f, ok := item.Map().Get(name)
+		f, ok := item.AsMap().Get(name)
 		if !ok {
 			continue
 		}

--- a/typed/helpers.go
+++ b/typed/helpers.go
@@ -162,7 +162,7 @@ func listValue(val value.Value) (value.List, error) {
 	if !val.IsList() {
 		return nil, fmt.Errorf("expected list, got %v", val)
 	}
-	return val.List(), nil
+	return val.AsList(), nil
 }
 
 // Returns the map, or an error. Reminder: nil is a valid map and might be returned.
@@ -177,7 +177,7 @@ func mapValue(val value.Value) (value.Map, error) {
 	if !val.IsMap() {
 		return nil, fmt.Errorf("expected map, got %v", val)
 	}
-	return val.Map(), nil
+	return val.AsMap(), nil
 }
 
 func keyedAssociativeListItemToPathElement(list *schema.List, index int, child value.Value) (fieldpath.PathElement, error) {
@@ -192,7 +192,7 @@ func keyedAssociativeListItemToPathElement(list *schema.List, index int, child v
 	}
 	keyMap := value.FieldList{}
 	for _, fieldName := range list.Keys {
-		if val, ok := child.Map().Get(fieldName); ok {
+		if val, ok := child.AsMap().Get(fieldName); ok {
 			keyMap = append(keyMap, value.Field{Name: fieldName, Value: val})
 		} else {
 			return pe, fmt.Errorf("associative list with keys has an element that omits key field %q", fieldName)

--- a/typed/remove.go
+++ b/typed/remove.go
@@ -42,7 +42,7 @@ func (w *removingWalker) doScalar(t *schema.Scalar) ValidationErrors {
 }
 
 func (w *removingWalker) doList(t *schema.List) (errs ValidationErrors) {
-	l := w.value.List()
+	l := w.value.AsList()
 
 	// If list is null, empty, or atomic just return
 	if l == nil || l.Length() == 0 || t.ElementRelationship == schema.Atomic {
@@ -70,7 +70,7 @@ func (w *removingWalker) doList(t *schema.List) (errs ValidationErrors) {
 }
 
 func (w *removingWalker) doMap(t *schema.Map) ValidationErrors {
-	m := w.value.Map()
+	m := w.value.AsMap()
 
 	// If map is null, empty, or atomic just return
 	if m == nil || m.Length() == 0 || t.ElementRelationship == schema.Atomic {

--- a/typed/union.go
+++ b/typed/union.go
@@ -36,10 +36,10 @@ func normalizeUnions(w *mergingWalker) error {
 
 	var old value.Map
 	if w.lhs != nil && !w.lhs.IsNull() {
-		old = w.lhs.Map()
+		old = w.lhs.AsMap()
 	}
 	for _, union := range atom.Map.Unions {
-		if err := newUnion(&union).Normalize(old, w.rhs.Map(), value.NewValueInterface(*w.out).Map()); err != nil {
+		if err := newUnion(&union).Normalize(old, w.rhs.AsMap(), value.NewValueInterface(*w.out).AsMap()); err != nil {
 			return err
 		}
 	}
@@ -58,12 +58,12 @@ func normalizeUnionsApply(w *mergingWalker) error {
 
 	var old value.Map
 	if w.lhs != nil && !w.lhs.IsNull() {
-		old = w.lhs.Map()
+		old = w.lhs.AsMap()
 	}
 
 	for _, union := range atom.Map.Unions {
 		out := value.NewValueInterface(*w.out)
-		if err := newUnion(&union).NormalizeApply(old, w.rhs.Map(), out.Map()); err != nil {
+		if err := newUnion(&union).NormalizeApply(old, w.rhs.AsMap(), out.AsMap()); err != nil {
 			return err
 		}
 		*w.out = out.Unstructured()
@@ -126,7 +126,7 @@ func (d *discriminator) Get(m value.Map) discriminated {
 	if !val.IsString() {
 		return ""
 	}
-	return discriminated(val.String())
+	return discriminated(val.AsString())
 }
 
 type fieldsSet map[field]struct{}

--- a/value/valueunstructured.go
+++ b/value/valueunstructured.go
@@ -49,7 +49,7 @@ func (v valueUnstructured) IsMap() bool {
 	return false
 }
 
-func (v valueUnstructured) Map() Map {
+func (v valueUnstructured) AsMap() Map {
 	if v.Value == nil {
 		panic("invalid nil")
 	}
@@ -70,7 +70,7 @@ func (v valueUnstructured) IsList() bool {
 	return ok
 }
 
-func (v valueUnstructured) List() List {
+func (v valueUnstructured) AsList() List {
 	return listUnstructured(v.Value.([]interface{}))
 }
 
@@ -85,7 +85,7 @@ func (v valueUnstructured) IsFloat() bool {
 	return false
 }
 
-func (v valueUnstructured) Float() float64 {
+func (v valueUnstructured) AsFloat() float64 {
 	if f, ok := v.Value.(float32); ok {
 		return float64(f)
 	}
@@ -117,7 +117,7 @@ func (v valueUnstructured) IsInt() bool {
 	return false
 }
 
-func (v valueUnstructured) Int() int64 {
+func (v valueUnstructured) AsInt() int64 {
 	if i, ok := v.Value.(int); ok {
 		return int64(i)
 	} else if i, ok := v.Value.(int8); ok {
@@ -146,7 +146,7 @@ func (v valueUnstructured) IsString() bool {
 	return ok
 }
 
-func (v valueUnstructured) String() string {
+func (v valueUnstructured) AsString() string {
 	return v.Value.(string)
 }
 
@@ -158,7 +158,7 @@ func (v valueUnstructured) IsBool() bool {
 	return ok
 }
 
-func (v valueUnstructured) Bool() bool {
+func (v valueUnstructured) AsBool() bool {
 	return v.Value.(bool)
 }
 


### PR DESCRIPTION
Renames all conversion methods for value.Value
e.g. `Map()` -> `AsMap()`

This removes the implementation of `String() string`.
Without this change, calling String() on a value would behave differently than usually expected in go.