### PR TITLE
Allow tests to specify objects in different versions

### DIFF
--- a/merge/deduced_test.go
+++ b/merge/deduced_test.go
@@ -22,7 +22,6 @@ import (
 	"sigs.k8s.io/structured-merge-diff/v3/fieldpath"
 	. "sigs.k8s.io/structured-merge-diff/v3/internal/fixture"
 	"sigs.k8s.io/structured-merge-diff/v3/merge"
-	"sigs.k8s.io/structured-merge-diff/v3/typed"
 )
 
 func TestDeduced(t *testing.T) {
@@ -52,6 +51,7 @@ func TestDeduced(t *testing.T) {
 				string: "string"
 				bool: false
 			`,
+			APIVersion: "v1",
 			Managed: fieldpath.ManagedFields{
 				"default": fieldpath.NewVersionedSet(
 					_NS(
@@ -95,6 +95,7 @@ func TestDeduced(t *testing.T) {
 				string: "string"
 				bool: true
 			`,
+			APIVersion: "v1",
 			Managed: fieldpath.ManagedFields{
 				"default": fieldpath.NewVersionedSet(
 					_NS(
@@ -156,6 +157,7 @@ func TestDeduced(t *testing.T) {
 				string: "user string"
 				bool: true
 			`,
+			APIVersion: "v1",
 			Managed: fieldpath.ManagedFields{
 				"default": fieldpath.NewVersionedSet(
 					_NS(
@@ -195,6 +197,7 @@ func TestDeduced(t *testing.T) {
 			Object: `
 				string: "new string"
 			`,
+			APIVersion: "v1",
 			Managed: fieldpath.ManagedFields{
 				"default": fieldpath.NewVersionedSet(
 					_NS(
@@ -225,6 +228,7 @@ func TestDeduced(t *testing.T) {
 			Object: `
 				string: "new string"
 			`,
+			APIVersion: "v1",
 			Managed: fieldpath.ManagedFields{
 				"controller": fieldpath.NewVersionedSet(
 					_NS(
@@ -265,6 +269,7 @@ func TestDeduced(t *testing.T) {
 				- c
 				- b
 			`,
+			APIVersion: "v1",
 			Managed: fieldpath.ManagedFields{
 				"default": fieldpath.NewVersionedSet(
 					_NS(_P("list")),
@@ -312,6 +317,7 @@ func TestDeduced(t *testing.T) {
 				- b
 				- c
 			`,
+			APIVersion: "v1",
 			Managed: fieldpath.ManagedFields{
 				"default": fieldpath.NewVersionedSet(
 					_NS(_P("list")),
@@ -335,8 +341,9 @@ func TestDeduced(t *testing.T) {
 					Object:     ``,
 				},
 			},
-			Object:  ``,
-			Managed: fieldpath.ManagedFields{},
+			Object:     ``,
+			APIVersion: "v1",
+			Managed:    fieldpath.ManagedFields{},
 		},
 		"apply_update_apply_nested": {
 			Ops: []Operation{
@@ -430,6 +437,7 @@ func TestDeduced(t *testing.T) {
 				      value: 1
 				g: 5
 			`,
+			APIVersion: "v1",
 		},
 		"apply_update_apply_nested_different_version": {
 			Ops: []Operation{
@@ -523,12 +531,13 @@ func TestDeduced(t *testing.T) {
 				      value: 1
 				g: 5
 			`,
+			APIVersion: "v1",
 		},
 	}
 
 	for name, test := range tests {
 		t.Run(name, func(t *testing.T) {
-			if err := test.Test(typed.DeducedParseableType); err != nil {
+			if err := test.Test(DeducedParser); err != nil {
 				t.Fatal(err)
 			}
 		})
@@ -580,6 +589,7 @@ func BenchmarkDeducedSimple(b *testing.B) {
 				string: "user string"
 				bool: true
 			`,
+		APIVersion: "v1",
 		Managed: fieldpath.ManagedFields{
 			"default": fieldpath.NewVersionedSet(
 				_NS(
@@ -599,16 +609,16 @@ func BenchmarkDeducedSimple(b *testing.B) {
 	}
 
 	// Make sure this passes...
-	if err := test.Test(typed.DeducedParseableType); err != nil {
+	if err := test.Test(DeducedParser); err != nil {
 		b.Fatal(err)
 	}
 
-	test.PreprocessOperations(typed.DeducedParseableType)
+	test.PreprocessOperations(DeducedParser)
 
 	b.ReportAllocs()
 	b.ResetTimer()
 	for n := 0; n < b.N; n++ {
-		if err := test.Bench(typed.DeducedParseableType); err != nil {
+		if err := test.Bench(DeducedParser); err != nil {
 			b.Fatal(err)
 		}
 	}
@@ -707,19 +717,20 @@ func BenchmarkDeducedNested(b *testing.B) {
 				      value: 1
 				g: 5
 			`,
+		APIVersion: "v1",
 	}
 
 	// Make sure this passes...
-	if err := test.Test(typed.DeducedParseableType); err != nil {
+	if err := test.Test(DeducedParser); err != nil {
 		b.Fatal(err)
 	}
 
-	test.PreprocessOperations(typed.DeducedParseableType)
+	test.PreprocessOperations(DeducedParser)
 
 	b.ReportAllocs()
 	b.ResetTimer()
 	for n := 0; n < b.N; n++ {
-		if err := test.Bench(typed.DeducedParseableType); err != nil {
+		if err := test.Bench(DeducedParser); err != nil {
 			b.Fatal(err)
 		}
 	}
@@ -818,19 +829,20 @@ func BenchmarkDeducedNestedAcrossVersion(b *testing.B) {
 			      value: 1
 			g: 5
 		`,
+		APIVersion: "v1",
 	}
 
 	// Make sure this passes...
-	if err := test.Test(typed.DeducedParseableType); err != nil {
+	if err := test.Test(DeducedParser); err != nil {
 		b.Fatal(err)
 	}
 
-	test.PreprocessOperations(typed.DeducedParseableType)
+	test.PreprocessOperations(DeducedParser)
 
 	b.ReportAllocs()
 	b.ResetTimer()
 	for n := 0; n < b.N; n++ {
-		if err := test.Bench(typed.DeducedParseableType); err != nil {
+		if err := test.Bench(DeducedParser); err != nil {
 			b.Fatal(err)
 		}
 	}

--- a/merge/key_test.go
+++ b/merge/key_test.go
@@ -24,7 +24,7 @@ import (
 	"sigs.k8s.io/structured-merge-diff/v3/typed"
 )
 
-var associativeListParser = func() typed.ParseableType {
+var associativeListParser = func() Parser {
 	parser, err := typed.NewParser(`types:
 - name: type
   map:
@@ -52,7 +52,7 @@ var associativeListParser = func() typed.ParseableType {
 	if err != nil {
 		panic(err)
 	}
-	return parser.Type("type")
+	return SameVersionParser{T: parser.Type("type")}
 }()
 
 func TestUpdateAssociativeLists(t *testing.T) {
@@ -83,6 +83,7 @@ func TestUpdateAssociativeLists(t *testing.T) {
 				- name: b
 				  value: 2
 			`,
+			APIVersion: "v1",
 			Managed: fieldpath.ManagedFields{
 				"default": fieldpath.NewVersionedSet(
 					_NS(

--- a/merge/leaf_test.go
+++ b/merge/leaf_test.go
@@ -25,7 +25,7 @@ import (
 	"sigs.k8s.io/structured-merge-diff/v3/typed"
 )
 
-var leafFieldsParser = func() typed.ParseableType {
+var leafFieldsParser = func() Parser {
 	parser, err := typed.NewParser(`types:
 - name: leafFields
   map:
@@ -42,7 +42,7 @@ var leafFieldsParser = func() typed.ParseableType {
 	if err != nil {
 		panic(err)
 	}
-	return parser.Type("leafFields")
+	return SameVersionParser{T: parser.Type("leafFields")}
 }()
 
 func TestUpdateLeaf(t *testing.T) {
@@ -72,6 +72,7 @@ func TestUpdateLeaf(t *testing.T) {
 				string: "string"
 				bool: false
 			`,
+			APIVersion: "v1",
 			Managed: fieldpath.ManagedFields{
 				"default": fieldpath.NewVersionedSet(
 					_NS(
@@ -107,6 +108,7 @@ func TestUpdateLeaf(t *testing.T) {
 				string: "string"
 				bool: false
 			`,
+			APIVersion: "v1",
 			Managed: fieldpath.ManagedFields{
 				"default": fieldpath.NewVersionedSet(
 					_NS(
@@ -150,6 +152,7 @@ func TestUpdateLeaf(t *testing.T) {
 				string: "string"
 				bool: true
 			`,
+			APIVersion: "v1",
 			Managed: fieldpath.ManagedFields{
 				"default": fieldpath.NewVersionedSet(
 					_NS(
@@ -200,6 +203,7 @@ func TestUpdateLeaf(t *testing.T) {
 				string: "string"
 				bool: true
 			`,
+			APIVersion: "v1",
 			Managed: fieldpath.ManagedFields{
 				"default": fieldpath.NewVersionedSet(
 					_NS(
@@ -261,6 +265,7 @@ func TestUpdateLeaf(t *testing.T) {
 				string: "user string"
 				bool: true
 			`,
+			APIVersion: "v1",
 			Managed: fieldpath.ManagedFields{
 				"default": fieldpath.NewVersionedSet(
 					_NS(
@@ -322,6 +327,7 @@ func TestUpdateLeaf(t *testing.T) {
 				string: "user string"
 				bool: true
 			`,
+			APIVersion: "v1",
 			Managed: fieldpath.ManagedFields{
 				"default": fieldpath.NewVersionedSet(
 					_NS(
@@ -363,6 +369,7 @@ func TestUpdateLeaf(t *testing.T) {
 				string: "new string"
 				bool: false
 			`,
+			APIVersion: "v1",
 			Managed: fieldpath.ManagedFields{
 				"default": fieldpath.NewVersionedSet(
 					_NS(
@@ -397,6 +404,7 @@ func TestUpdateLeaf(t *testing.T) {
 				string: "new string"
 				bool: false
 			`,
+			APIVersion: "v1",
 			Managed: fieldpath.ManagedFields{
 				"default": fieldpath.NewVersionedSet(
 					_NS(
@@ -427,6 +435,7 @@ func TestUpdateLeaf(t *testing.T) {
 			Object: `
 				string: "new string"
 			`,
+			APIVersion: "v1",
 			Managed: fieldpath.ManagedFields{
 				"controller": fieldpath.NewVersionedSet(
 					_NS(
@@ -455,7 +464,8 @@ func TestUpdateLeaf(t *testing.T) {
 			Object: `
 				string: "string"
 			`,
-			Managed: fieldpath.ManagedFields{},
+			APIVersion: "v1",
+			Managed:    fieldpath.ManagedFields{},
 		},
 	}
 
@@ -513,6 +523,7 @@ func BenchmarkLeafConflictAcrossVersion(b *testing.B) {
 			string: "user string"
 			bool: true
 		`,
+		APIVersion: "v1",
 		Managed: fieldpath.ManagedFields{
 			"default": fieldpath.NewVersionedSet(
 				_NS(

--- a/merge/multiple_appliers_test.go
+++ b/merge/multiple_appliers_test.go
@@ -64,6 +64,7 @@ func TestMultipleAppliersSet(t *testing.T) {
 				- name: a
 				- name: c
 			`,
+			APIVersion: "v1",
 			Managed: fieldpath.ManagedFields{
 				"apply-one": fieldpath.NewVersionedSet(
 					_NS(
@@ -109,6 +110,7 @@ func TestMultipleAppliersSet(t *testing.T) {
 				- name: a
 				  value: 0
 			`,
+			APIVersion: "v1",
 			Managed: fieldpath.ManagedFields{
 				"apply-one": fieldpath.NewVersionedSet(
 					_NS(
@@ -159,6 +161,7 @@ func TestMultipleAppliersSet(t *testing.T) {
 				- name: a
 				  value: 0
 			`,
+			APIVersion: "v1",
 			Managed: fieldpath.ManagedFields{
 				"apply-one": fieldpath.NewVersionedSet(
 					_NS(
@@ -207,6 +210,7 @@ func TestMultipleAppliersSet(t *testing.T) {
 				- name: c
 				- name: d
 			`,
+			APIVersion: "v1",
 			Managed: fieldpath.ManagedFields{
 				"apply-one": fieldpath.NewVersionedSet(
 					_NS(
@@ -280,6 +284,7 @@ func TestMultipleAppliersNestedType(t *testing.T) {
 				  value:
 				  - d
 			`,
+			APIVersion: "v1",
 			Managed: fieldpath.ManagedFields{
 				"apply-one": fieldpath.NewVersionedSet(
 					_NS(
@@ -353,6 +358,7 @@ func TestMultipleAppliersNestedType(t *testing.T) {
 				  - d
 				  - e
 			`,
+			APIVersion: "v1",
 			Managed: fieldpath.ManagedFields{
 				"apply-one": fieldpath.NewVersionedSet(
 					_NS(
@@ -432,6 +438,7 @@ func TestMultipleAppliersNestedType(t *testing.T) {
 				  value:
 				  - b
 			`,
+			APIVersion: "v1",
 			Managed: fieldpath.ManagedFields{
 				"apply-one": fieldpath.NewVersionedSet(
 					_NS(
@@ -504,6 +511,7 @@ func TestMultipleAppliersNestedType(t *testing.T) {
 				  value:
 				  - b
 			`,
+			APIVersion: "v1",
 			Managed: fieldpath.ManagedFields{
 				"apply-one": fieldpath.NewVersionedSet(
 					_NS(
@@ -563,6 +571,7 @@ func TestMultipleAppliersNestedType(t *testing.T) {
 				  value:
 				  - d
 			`,
+			APIVersion: "v1",
 			Managed: fieldpath.ManagedFields{
 				"apply-one": fieldpath.NewVersionedSet(
 					_NS(
@@ -668,6 +677,7 @@ func TestMultipleAppliersNestedType(t *testing.T) {
 				        f:
 				          g:
 			`,
+			APIVersion: "v1",
 			Managed: fieldpath.ManagedFields{
 				"apply-two": fieldpath.NewVersionedSet(
 					_NS(
@@ -785,6 +795,7 @@ func TestMultipleAppliersDeducedType(t *testing.T) {
 				      f:
 				        g:
 			`,
+			APIVersion: "v1",
 			Managed: fieldpath.ManagedFields{
 				"apply-two": fieldpath.NewVersionedSet(
 					_NS(
@@ -816,7 +827,7 @@ func TestMultipleAppliersDeducedType(t *testing.T) {
 
 	for name, test := range tests {
 		t.Run(name, func(t *testing.T) {
-			if err := test.Test(typed.DeducedParseableType); err != nil {
+			if err := test.Test(DeducedParser); err != nil {
 				t.Fatal(err)
 			}
 		})
@@ -879,6 +890,7 @@ func TestMultipleAppliersRealConversion(t *testing.T) {
 				      eeee:
 				        ffff:
 			`,
+			APIVersion: "v4",
 			Managed: fieldpath.ManagedFields{
 				"apply-two": fieldpath.NewVersionedSet(
 					_NS(
@@ -937,6 +949,7 @@ func TestMultipleAppliersRealConversion(t *testing.T) {
 				  aaa:
 				  ccc:
 			`,
+			APIVersion: "v3",
 			Managed: fieldpath.ManagedFields{
 				"controller": fieldpath.NewVersionedSet(
 					_NS(
@@ -969,7 +982,7 @@ func TestMultipleAppliersRealConversion(t *testing.T) {
 
 // repeatingConverter repeats a single letterkey v times, where v is the version.
 type repeatingConverter struct {
-	typed.ParseableType
+	parser Parser
 }
 
 var _ merge.Converter = repeatingConverter{}
@@ -1004,7 +1017,7 @@ func (r repeatingConverter) Convert(v *typed.TypedValue, version fieldpath.APIVe
 			str2 = fmt.Sprintf("%v\n%v%v:", str2, spaces, c)
 		}
 	}
-	v2, err := r.ParseableType.FromYAML(typed.YAMLObject(str2))
+	v2, err := r.parser.Type(string(version)).FromYAML(typed.YAMLObject(str2))
 	if err != nil {
 		return nil, err
 	}
@@ -1083,6 +1096,7 @@ func BenchmarkMultipleApplierRecursiveRealConversion(b *testing.B) {
 			      eeee:
 			        ffff:
 		`,
+		APIVersion: "v4",
 		Managed: fieldpath.ManagedFields{
 			"apply-two": fieldpath.NewVersionedSet(
 				_NS(

--- a/merge/nested_test.go
+++ b/merge/nested_test.go
@@ -24,7 +24,7 @@ import (
 	"sigs.k8s.io/structured-merge-diff/v3/typed"
 )
 
-var nestedTypeParser = func() typed.ParseableType {
+var nestedTypeParser = func() Parser {
 	parser, err := typed.NewParser(`types:
 - name: type
   map:
@@ -101,7 +101,7 @@ var nestedTypeParser = func() typed.ParseableType {
 	if err != nil {
 		panic(err)
 	}
-	return parser.Type("type")
+	return SameVersionParser{T: parser.Type("type")}
 }()
 
 func TestUpdateNestedType(t *testing.T) {
@@ -138,6 +138,7 @@ func TestUpdateNestedType(t *testing.T) {
 				  - a
 				  - c
 			`,
+			APIVersion: "v1",
 			Managed: fieldpath.ManagedFields{
 				"default": fieldpath.NewVersionedSet(
 					_NS(
@@ -183,6 +184,7 @@ func TestUpdateNestedType(t *testing.T) {
 				  - a
 				  - c
 			`,
+			APIVersion: "v1",
 			Managed: fieldpath.ManagedFields{
 				"default": fieldpath.NewVersionedSet(
 					_NS(
@@ -228,6 +230,7 @@ func TestUpdateNestedType(t *testing.T) {
 				    a: "x"
 				    c: "z"
 			`,
+			APIVersion: "v1",
 			Managed: fieldpath.ManagedFields{
 				"default": fieldpath.NewVersionedSet(
 					_NS(
@@ -273,6 +276,7 @@ func TestUpdateNestedType(t *testing.T) {
 				    a: "x"
 				    c: "z"
 			`,
+			APIVersion: "v1",
 			Managed: fieldpath.ManagedFields{
 				"default": fieldpath.NewVersionedSet(
 					_NS(
@@ -315,6 +319,7 @@ func TestUpdateNestedType(t *testing.T) {
 				  - a
 				  - c
 			`,
+			APIVersion: "v1",
 			Managed: fieldpath.ManagedFields{
 				"default": fieldpath.NewVersionedSet(
 					_NS(
@@ -356,6 +361,7 @@ func TestUpdateNestedType(t *testing.T) {
 				  - a
 				  - c
 			`,
+			APIVersion: "v1",
 			Managed: fieldpath.ManagedFields{
 				"default": fieldpath.NewVersionedSet(
 					_NS(
@@ -397,6 +403,7 @@ func TestUpdateNestedType(t *testing.T) {
 				    a: "x"
 				    c: "z"
 			`,
+			APIVersion: "v1",
 			Managed: fieldpath.ManagedFields{
 				"default": fieldpath.NewVersionedSet(
 					_NS(
@@ -438,6 +445,7 @@ func TestUpdateNestedType(t *testing.T) {
 				    a: "x"
 				    c: "z"
 			`,
+			APIVersion: "v1",
 			Managed: fieldpath.ManagedFields{
 				"default": fieldpath.NewVersionedSet(
 					_NS(
@@ -479,6 +487,7 @@ func TestUpdateNestedType(t *testing.T) {
 				    d:
 				      c:
 			`,
+			APIVersion: "v1",
 			Managed: fieldpath.ManagedFields{
 				"default": fieldpath.NewVersionedSet(
 					_NS(

--- a/merge/preserve_unknown_test.go
+++ b/merge/preserve_unknown_test.go
@@ -24,7 +24,7 @@ import (
 	"sigs.k8s.io/structured-merge-diff/v3/typed"
 )
 
-var preserveUnknownParser = func() typed.ParseableType {
+var preserveUnknownParser = func() Parser {
 	parser, err := typed.NewParser(`types:
 - name: type
   map:
@@ -38,7 +38,7 @@ var preserveUnknownParser = func() typed.ParseableType {
 	if err != nil {
 		panic(err)
 	}
-	return parser.Type("type")
+	return SameVersionParser{T: parser.Type("type")}
 }()
 
 func TestPreserveUnknownFields(t *testing.T) {
@@ -66,6 +66,7 @@ func TestPreserveUnknownFields(t *testing.T) {
 				num: 6
 				unknown: new
 			`,
+			APIVersion: "v1",
 			Managed: fieldpath.ManagedFields{
 				"default": fieldpath.NewVersionedSet(
 					_NS(

--- a/merge/set_test.go
+++ b/merge/set_test.go
@@ -24,7 +24,7 @@ import (
 	"sigs.k8s.io/structured-merge-diff/v3/typed"
 )
 
-var setFieldsParser = func() typed.ParseableType {
+var setFieldsParser = func() Parser {
 	parser, err := typed.NewParser(`types:
 - name: sets
   map:
@@ -38,7 +38,7 @@ var setFieldsParser = func() typed.ParseableType {
 	if err != nil {
 		panic(err)
 	}
-	return parser.Type("sets")
+	return SameVersionParser{T: parser.Type("sets")}
 }()
 
 func TestUpdateSet(t *testing.T) {
@@ -73,6 +73,7 @@ func TestUpdateSet(t *testing.T) {
 				- c
 				- d
 			`,
+			APIVersion: "v1",
 			Managed: fieldpath.ManagedFields{
 				"default": fieldpath.NewVersionedSet(
 					_NS(
@@ -129,6 +130,7 @@ func TestUpdateSet(t *testing.T) {
 				- cprime
 				- d
 			`,
+			APIVersion: "v1",
 			Managed: fieldpath.ManagedFields{
 				"default": fieldpath.NewVersionedSet(
 					_NS(
@@ -193,6 +195,7 @@ func TestUpdateSet(t *testing.T) {
 				- cprime
 				- d
 			`,
+			APIVersion: "v1",
 			Managed: fieldpath.ManagedFields{
 				"default": fieldpath.NewVersionedSet(
 					_NS(
@@ -254,6 +257,7 @@ func TestUpdateSet(t *testing.T) {
 				- c
 				- d
 			`,
+			APIVersion: "v1",
 			Managed: fieldpath.ManagedFields{
 				"default": fieldpath.NewVersionedSet(
 					_NS(
@@ -314,6 +318,7 @@ func TestUpdateSet(t *testing.T) {
 				- c
 				- d
 			`,
+			APIVersion: "v1",
 			Managed: fieldpath.ManagedFields{
 				"default": fieldpath.NewVersionedSet(
 					_NS(
@@ -366,6 +371,7 @@ func TestUpdateSet(t *testing.T) {
 				- c
 				- b
 			`,
+			APIVersion: "v1",
 			Managed: fieldpath.ManagedFields{
 				"default": fieldpath.NewVersionedSet(
 					_NS(
@@ -422,6 +428,7 @@ func TestUpdateSet(t *testing.T) {
 				- c
 				- d
 			`,
+			APIVersion: "v1",
 			Managed: fieldpath.ManagedFields{
 				"default": fieldpath.NewVersionedSet(
 					_NS(
@@ -478,6 +485,7 @@ func TestUpdateSet(t *testing.T) {
 				- c
 				- d
 			`,
+			APIVersion: "v1",
 			Managed: fieldpath.ManagedFields{
 				"default": fieldpath.NewVersionedSet(
 					_NS(
@@ -519,6 +527,7 @@ func TestUpdateSet(t *testing.T) {
 				- a
 				- c
 			`,
+			APIVersion: "v1",
 			Managed: fieldpath.ManagedFields{
 				"default": fieldpath.NewVersionedSet(
 					_NS(
@@ -560,6 +569,7 @@ func TestUpdateSet(t *testing.T) {
 				- c
 				- e
 			`,
+			APIVersion: "v1",
 			Managed: fieldpath.ManagedFields{
 				"default": fieldpath.NewVersionedSet(
 					_NS(

--- a/merge/union_test.go
+++ b/merge/union_test.go
@@ -25,7 +25,7 @@ import (
 	"sigs.k8s.io/structured-merge-diff/v3/typed"
 )
 
-var unionFieldsParser = func() typed.ParseableType {
+var unionFieldsParser = func() Parser {
 	parser, err := typed.NewParser(`types:
 - name: unionFields
   map:
@@ -61,7 +61,7 @@ var unionFieldsParser = func() typed.ParseableType {
 	if err != nil {
 		panic(err)
 	}
-	return parser.Type("unionFields")
+	return SameVersionParser{T: parser.Type("unionFields")}
 }()
 
 func TestUnion(t *testing.T) {
@@ -81,6 +81,7 @@ func TestUnion(t *testing.T) {
 				numeric: 1
 				type: Numeric
 			`,
+			APIVersion: "v1",
 			Managed: fieldpath.ManagedFields{
 				"default": fieldpath.NewVersionedSet(
 					_NS(
@@ -116,6 +117,7 @@ func TestUnion(t *testing.T) {
 				string: "some string"
 				type: String
 			`,
+			APIVersion: "v1",
 			Managed: fieldpath.ManagedFields{
 				"controller": fieldpath.NewVersionedSet(
 					_NS(
@@ -165,6 +167,7 @@ func TestUnion(t *testing.T) {
 				numeric: 0
 				fieldB: "fieldB string"
 			`,
+			APIVersion: "v1",
 		},
 	}
 


### PR DESCRIPTION
This will make it possible to parse input objects with different
schemas, and test what happens if the schema changes, especially the
topology.

A few things need to happen in order to make this possible:

1. We need to be able to parse multiple different versions. A
ParseableType can only parse one type, so we need to pass in a parser
instead. The problem with the parser was that we needed a mapping to
know what was the name of the root type. Let's use the version name as
the root type. Now we can have multiple parseable type in the test.

2. Since most test actually use the same type with multiple different
version, we add a wrapper that let's you re-use the same type with
different versions.

3. DeducedType are usually all parsed the same for all versions, so
let's also create a helper for that.

4. Now we need to know which version of the object we want to compare to
at the end. We need to specify that version in each individual test, but
that's better becasue we don't have to necessarily compare in the
version of the last operation (implicit becomes explicit).