### PR TITLE
WIP: Add example of testing compatibility change

### DIFF
--- a/internal/fixture/state.go
+++ b/internal/fixture/state.go
@@ -26,11 +26,32 @@ import (
 	"sigs.k8s.io/structured-merge-diff/v3/value"
 )
 
+// For the sake of tests, a parser is something that can retrieve a
+// ParseableType.
+type Parser interface {
+	Type(string) typed.ParseableType
+}
+
+// SameVersionParser can be used if all the versions are actually using the same type.
+type SameVersionParser struct {
+	T typed.ParseableType
+}
+
+func (p SameVersionParser) Type(_ string) typed.ParseableType {
+	return p.T
+}
+
+// DeducedParser is a parser that is deduced no matter what the version
+// specified.
+var DeducedParser = SameVersionParser{
+	T: typed.DeducedParseableType,
+}
+
 // State of the current test in terms of live object. One can check at
 // any time that Live and Managers match the expectations.
 type State struct {
 	Live     *typed.TypedValue
-	Parser   typed.ParseableType
+	Parser   Parser
 	Managers fieldpath.ManagedFields
 	Updater  *merge.Updater
 }
@@ -70,9 +91,9 @@ func FixTabsOrDie(in typed.YAMLObject) typed.YAMLObject {
 	return typed.YAMLObject(bytes.Join(lines, []byte{'\n'}))
 }
 
-func (s *State) checkInit() error {
+func (s *State) checkInit(version fieldpath.APIVersion) error {
 	if s.Live == nil {
-		obj, err := s.Parser.FromUnstructured(nil)
+		obj, err := s.Parser.Type(string(version)).FromUnstructured(nil)
 		if err != nil {
 			return fmt.Errorf("failed to create new empty object: %v", err)
 		}
@@ -82,7 +103,7 @@ func (s *State) checkInit() error {
 }
 
 func (s *State) UpdateObject(tv *typed.TypedValue, version fieldpath.APIVersion, manager string) error {
-	err := s.checkInit()
+	err := s.checkInit(version)
 	if err != nil {
 		return err
 	}
@@ -102,7 +123,7 @@ func (s *State) UpdateObject(tv *typed.TypedValue, version fieldpath.APIVersion,
 
 // Update the current state with the passed in object
 func (s *State) Update(obj typed.YAMLObject, version fieldpath.APIVersion, manager string) error {
-	tv, err := s.Parser.FromYAML(FixTabsOrDie(obj))
+	tv, err := s.Parser.Type(string(version)).FromYAML(FixTabsOrDie(obj))
 	if err != nil {
 		return err
 	}
@@ -110,7 +131,7 @@ func (s *State) Update(obj typed.YAMLObject, version fieldpath.APIVersion, manag
 }
 
 func (s *State) ApplyObject(tv *typed.TypedValue, version fieldpath.APIVersion, manager string, force bool) error {
-	err := s.checkInit()
+	err := s.checkInit(version)
 	if err != nil {
 		return err
 	}
@@ -130,7 +151,7 @@ func (s *State) ApplyObject(tv *typed.TypedValue, version fieldpath.APIVersion, 
 
 // Apply the passed in object to the current state
 func (s *State) Apply(obj typed.YAMLObject, version fieldpath.APIVersion, manager string, force bool) error {
-	tv, err := s.Parser.FromYAML(FixTabsOrDie(obj))
+	tv, err := s.Parser.Type(string(version)).FromYAML(FixTabsOrDie(obj))
 	if err != nil {
 		return err
 	}
@@ -139,16 +160,20 @@ func (s *State) Apply(obj typed.YAMLObject, version fieldpath.APIVersion, manage
 
 // CompareLive takes a YAML string and returns the comparison with the
 // current live object or an error.
-func (s *State) CompareLive(obj typed.YAMLObject) (*typed.Comparison, error) {
+func (s *State) CompareLive(obj typed.YAMLObject, version fieldpath.APIVersion) (*typed.Comparison, error) {
 	obj = FixTabsOrDie(obj)
-	if err := s.checkInit(); err != nil {
+	if err := s.checkInit(version); err != nil {
 		return nil, err
 	}
-	tv, err := s.Parser.FromYAML(obj)
+	tv, err := s.Parser.Type(string(version)).FromYAML(obj)
 	if err != nil {
 		return nil, err
 	}
-	return s.Live.Compare(tv)
+	live, err := s.Updater.Converter.Convert(s.Live, version)
+	if err != nil {
+		return nil, err
+	}
+	return live.Compare(tv)
 }
 
 // dummyConverter doesn't convert, it just returns the same exact object, as long as a version is provided.
@@ -171,7 +196,7 @@ func (dummyConverter) IsMissingVersionError(err error) bool {
 // Operation is a step that will run when building a table-driven test.
 type Operation interface {
 	run(*State) error
-	preprocess(typed.ParseableType) (Operation, error)
+	preprocess(Parser) (Operation, error)
 }
 
 func hasConflict(conflicts merge.Conflicts, conflict merge.Conflict) bool {
@@ -214,8 +239,8 @@ func (a Apply) run(state *State) error {
 	return p.run(state)
 }
 
-func (a Apply) preprocess(parser typed.ParseableType) (Operation, error) {
-	tv, err := parser.FromYAML(FixTabsOrDie(a.Object))
+func (a Apply) preprocess(parser Parser) (Operation, error) {
+	tv, err := parser.Type(string(a.APIVersion)).FromYAML(FixTabsOrDie(a.Object))
 	if err != nil {
 		return nil, err
 	}
@@ -260,7 +285,7 @@ func (a ApplyObject) run(state *State) error {
 	return nil
 }
 
-func (a ApplyObject) preprocess(parser typed.ParseableType) (Operation, error) {
+func (a ApplyObject) preprocess(parser Parser) (Operation, error) {
 	return a, nil
 }
 
@@ -278,8 +303,8 @@ func (f ForceApply) run(state *State) error {
 	return state.Apply(f.Object, f.APIVersion, f.Manager, true)
 }
 
-func (f ForceApply) preprocess(parser typed.ParseableType) (Operation, error) {
-	tv, err := parser.FromYAML(FixTabsOrDie(f.Object))
+func (f ForceApply) preprocess(parser Parser) (Operation, error) {
+	tv, err := parser.Type(string(f.APIVersion)).FromYAML(FixTabsOrDie(f.Object))
 	if err != nil {
 		return nil, err
 	}
@@ -304,7 +329,7 @@ func (f ForceApplyObject) run(state *State) error {
 	return state.ApplyObject(f.Object, f.APIVersion, f.Manager, true)
 }
 
-func (f ForceApplyObject) preprocess(parser typed.ParseableType) (Operation, error) {
+func (f ForceApplyObject) preprocess(parser Parser) (Operation, error) {
 	return f, nil
 }
 
@@ -322,8 +347,8 @@ func (u Update) run(state *State) error {
 	return state.Update(u.Object, u.APIVersion, u.Manager)
 }
 
-func (u Update) preprocess(parser typed.ParseableType) (Operation, error) {
-	tv, err := parser.FromYAML(FixTabsOrDie(u.Object))
+func (u Update) preprocess(parser Parser) (Operation, error) {
+	tv, err := parser.Type(string(u.APIVersion)).FromYAML(FixTabsOrDie(u.Object))
 	if err != nil {
 		return nil, err
 	}
@@ -348,7 +373,7 @@ func (u UpdateObject) run(state *State) error {
 	return state.UpdateObject(u.Object, u.APIVersion, u.Manager)
 }
 
-func (f UpdateObject) preprocess(parser typed.ParseableType) (Operation, error) {
+func (f UpdateObject) preprocess(parser Parser) (Operation, error) {
 	return f, nil
 }
 
@@ -364,6 +389,9 @@ type TestCase struct {
 	// Object, if not empty, is the object as it's expected to
 	// be after all the operations are run.
 	Object typed.YAMLObject
+	// APIVersion should be set if the object is non-empty and
+	// describes the version of the object to compare to.
+	APIVersion fieldpath.APIVersion
 	// Managed, if not nil, is the ManagedFields as expected
 	// after all operations are run.
 	Managed fieldpath.ManagedFields
@@ -372,18 +400,18 @@ type TestCase struct {
 }
 
 // Test runs the test-case using the given parser and a dummy converter.
-func (tc TestCase) Test(parser typed.ParseableType) error {
+func (tc TestCase) Test(parser Parser) error {
 	return tc.TestWithConverter(parser, &dummyConverter{})
 }
 
 // Bench runs the test-case using the given parser and a dummy converter, but
 // doesn't check exit conditions--see the comment for BenchWithConverter.
-func (tc TestCase) Bench(parser typed.ParseableType) error {
+func (tc TestCase) Bench(parser Parser) error {
 	return tc.BenchWithConverter(parser, &dummyConverter{})
 }
 
 // Preprocess all the operations by parsing the yaml before-hand.
-func (tc TestCase) PreprocessOperations(parser typed.ParseableType) error {
+func (tc TestCase) PreprocessOperations(parser Parser) error {
 	for i := range tc.Ops {
 		op, err := tc.Ops[i].preprocess(parser)
 		if err != nil {
@@ -398,7 +426,7 @@ func (tc TestCase) PreprocessOperations(parser typed.ParseableType) error {
 // but doesn't do any comparison operations aftewards; you should probably run
 // TestWithConverter once and reset the benchmark, to make sure the test case
 // actually passes..
-func (tc TestCase) BenchWithConverter(parser typed.ParseableType, converter merge.Converter) error {
+func (tc TestCase) BenchWithConverter(parser Parser, converter merge.Converter) error {
 	state := State{
 		Updater: &merge.Updater{Converter: converter},
 		Parser:  parser,
@@ -418,7 +446,7 @@ func (tc TestCase) BenchWithConverter(parser typed.ParseableType, converter merg
 }
 
 // TestWithConverter runs the test-case using the given parser and converter.
-func (tc TestCase) TestWithConverter(parser typed.ParseableType, converter merge.Converter) error {
+func (tc TestCase) TestWithConverter(parser Parser, converter merge.Converter) error {
 	state := State{
 		Updater: &merge.Updater{Converter: converter},
 		Parser:  parser,
@@ -434,8 +462,6 @@ func (tc TestCase) TestWithConverter(parser typed.ParseableType, converter merge
 			return fmt.Errorf("fails if unions are on: %v", err)
 		}
 	}
-	// We currently don't have any test that converts, we can take
-	// care of that later.
 	for i, ops := range tc.Ops {
 		err := ops.run(&state)
 		if err != nil {
@@ -445,7 +471,7 @@ func (tc TestCase) TestWithConverter(parser typed.ParseableType, converter merge
 
 	// If LastObject was specified, compare it with LiveState
 	if tc.Object != typed.YAMLObject("") {
-		comparison, err := state.CompareLive(tc.Object)
+		comparison, err := state.CompareLive(tc.Object, tc.APIVersion)
 		if err != nil {
 			return fmt.Errorf("failed to compare live with config: %v", err)
 		}

--- a/merge/compatibility_test.go
+++ b/merge/compatibility_test.go
@@ -1,0 +1,161 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package merge_test
+
+import (
+	"testing"
+
+	"sigs.k8s.io/structured-merge-diff/v3/fieldpath"
+	. "sigs.k8s.io/structured-merge-diff/v3/internal/fixture"
+	"sigs.k8s.io/structured-merge-diff/v3/typed"
+)
+
+var atomicListParser = func() typed.ParseableType {
+	parser, err := typed.NewParser(`types:
+- name: associative
+  map:
+    fields:
+      - name: list
+        type:
+          namedType: associativeList
+- name: atomic
+  map:
+    fields:
+      - name: list
+        type:
+          namedType: atomicList
+- name: associativeList
+  list:
+    elementType:
+      namedType: myElement
+    elementRelationship: associative
+    keys:
+    - name
+- name: atomicList
+  list:
+    elementType:
+      namedType: myElement
+    elementRelationship: atomic
+- name: myElement
+  map:
+    fields:
+    - name: name
+      type:
+        scalar: string
+    - name: value
+      type:
+        scalar: numeric
+`)
+	if err != nil {
+		panic(err)
+	}
+	return parser.Type("type")
+}()
+
+func TestListsTopologyChange(t *testing.T) {
+	tests := map[string]TestCase{
+		"broken_atomic_doesnt_own_former_associative": {
+			Ops: []Operation{
+				Update{
+					Manager: "one",
+					Object: `
+						list:
+						- name: a
+						  value: 1
+					`,
+					APIVersion: "associative",
+				},
+				Update{
+					Manager: "other",
+					Object: `
+						list:
+						- name: b
+						  value: 2
+					`,
+					APIVersion: "atomic",
+				},
+			},
+			Managed: fieldpath.ManagedFields{
+				"one": fieldpath.NewVersionedSet(
+					_NS(
+						_P("list"),
+					),
+					"associative",
+					false,
+				),
+				"other": fieldpath.NewVersionedSet(
+					_NS(
+						_P("list", _KBF("name", "b")),
+						_P("list", _KBF("name", "b"), "name"),
+						_P("list", _KBF("name", "b"), "value"),
+					),
+					"atomic",
+					false,
+				),
+			},
+		},
+		"broken_associative_doesnt_own_former_atomic": {
+			Ops: []Operation{
+				Update{
+					Manager: "one",
+					Object: `
+						list:
+						- name: a
+						  value: 1
+					`,
+					APIVersion: "atomic",
+				},
+				Update{
+					Manager: "other",
+					Object: `
+						list:
+						- name: b
+						  value: 2
+					`,
+					APIVersion: "associative",
+				},
+			},
+
+			Managed: fieldpath.ManagedFields{
+				"one": fieldpath.NewVersionedSet(
+					_NS(
+						_P("list"),
+					),
+					"atomic",
+					false,
+				),
+				"other": fieldpath.NewVersionedSet(
+					_NS(
+						_P("list", _KBF("name", "b")),
+						_P("list", _KBF("name", "b"), "name"),
+						_P("list", _KBF("name", "b"), "value"),
+					),
+					"associative",
+					false,
+				),
+			},
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			if err := test.Test(associativeListParser); err != nil {
+				t.Fatal(err)
+			}
+		})
+	}
+}

--- a/merge/deduced_test.go
+++ b/merge/deduced_test.go
@@ -22,7 +22,6 @@ import (
 	"sigs.k8s.io/structured-merge-diff/v3/fieldpath"
 	. "sigs.k8s.io/structured-merge-diff/v3/internal/fixture"
 	"sigs.k8s.io/structured-merge-diff/v3/merge"
-	"sigs.k8s.io/structured-merge-diff/v3/typed"
 )
 
 func TestDeduced(t *testing.T) {
@@ -52,6 +51,7 @@ func TestDeduced(t *testing.T) {
 				string: "string"
 				bool: false
 			`,
+			APIVersion: "v1",
 			Managed: fieldpath.ManagedFields{
 				"default": fieldpath.NewVersionedSet(
 					_NS(
@@ -95,6 +95,7 @@ func TestDeduced(t *testing.T) {
 				string: "string"
 				bool: true
 			`,
+			APIVersion: "v1",
 			Managed: fieldpath.ManagedFields{
 				"default": fieldpath.NewVersionedSet(
 					_NS(
@@ -156,6 +157,7 @@ func TestDeduced(t *testing.T) {
 				string: "user string"
 				bool: true
 			`,
+			APIVersion: "v1",
 			Managed: fieldpath.ManagedFields{
 				"default": fieldpath.NewVersionedSet(
 					_NS(
@@ -195,6 +197,7 @@ func TestDeduced(t *testing.T) {
 			Object: `
 				string: "new string"
 			`,
+			APIVersion: "v1",
 			Managed: fieldpath.ManagedFields{
 				"default": fieldpath.NewVersionedSet(
 					_NS(
@@ -225,6 +228,7 @@ func TestDeduced(t *testing.T) {
 			Object: `
 				string: "new string"
 			`,
+			APIVersion: "v1",
 			Managed: fieldpath.ManagedFields{
 				"controller": fieldpath.NewVersionedSet(
 					_NS(
@@ -265,6 +269,7 @@ func TestDeduced(t *testing.T) {
 				- c
 				- b
 			`,
+			APIVersion: "v1",
 			Managed: fieldpath.ManagedFields{
 				"default": fieldpath.NewVersionedSet(
 					_NS(_P("list")),
@@ -312,6 +317,7 @@ func TestDeduced(t *testing.T) {
 				- b
 				- c
 			`,
+			APIVersion: "v1",
 			Managed: fieldpath.ManagedFields{
 				"default": fieldpath.NewVersionedSet(
 					_NS(_P("list")),
@@ -335,8 +341,9 @@ func TestDeduced(t *testing.T) {
 					Object:     ``,
 				},
 			},
-			Object:  ``,
-			Managed: fieldpath.ManagedFields{},
+			Object:     ``,
+			APIVersion: "v1",
+			Managed:    fieldpath.ManagedFields{},
 		},
 		"apply_update_apply_nested": {
 			Ops: []Operation{
@@ -430,6 +437,7 @@ func TestDeduced(t *testing.T) {
 				      value: 1
 				g: 5
 			`,
+			APIVersion: "v1",
 		},
 		"apply_update_apply_nested_different_version": {
 			Ops: []Operation{
@@ -523,12 +531,13 @@ func TestDeduced(t *testing.T) {
 				      value: 1
 				g: 5
 			`,
+			APIVersion: "v1",
 		},
 	}
 
 	for name, test := range tests {
 		t.Run(name, func(t *testing.T) {
-			if err := test.Test(typed.DeducedParseableType); err != nil {
+			if err := test.Test(DeducedParser); err != nil {
 				t.Fatal(err)
 			}
 		})
@@ -580,6 +589,7 @@ func BenchmarkDeducedSimple(b *testing.B) {
 				string: "user string"
 				bool: true
 			`,
+		APIVersion: "v1",
 		Managed: fieldpath.ManagedFields{
 			"default": fieldpath.NewVersionedSet(
 				_NS(
@@ -599,16 +609,16 @@ func BenchmarkDeducedSimple(b *testing.B) {
 	}
 
 	// Make sure this passes...
-	if err := test.Test(typed.DeducedParseableType); err != nil {
+	if err := test.Test(DeducedParser); err != nil {
 		b.Fatal(err)
 	}
 
-	test.PreprocessOperations(typed.DeducedParseableType)
+	test.PreprocessOperations(DeducedParser)
 
 	b.ReportAllocs()
 	b.ResetTimer()
 	for n := 0; n < b.N; n++ {
-		if err := test.Bench(typed.DeducedParseableType); err != nil {
+		if err := test.Bench(DeducedParser); err != nil {
 			b.Fatal(err)
 		}
 	}
@@ -707,19 +717,20 @@ func BenchmarkDeducedNested(b *testing.B) {
 				      value: 1
 				g: 5
 			`,
+		APIVersion: "v1",
 	}
 
 	// Make sure this passes...
-	if err := test.Test(typed.DeducedParseableType); err != nil {
+	if err := test.Test(DeducedParser); err != nil {
 		b.Fatal(err)
 	}
 
-	test.PreprocessOperations(typed.DeducedParseableType)
+	test.PreprocessOperations(DeducedParser)
 
 	b.ReportAllocs()
 	b.ResetTimer()
 	for n := 0; n < b.N; n++ {
-		if err := test.Bench(typed.DeducedParseableType); err != nil {
+		if err := test.Bench(DeducedParser); err != nil {
 			b.Fatal(err)
 		}
 	}
@@ -818,19 +829,20 @@ func BenchmarkDeducedNestedAcrossVersion(b *testing.B) {
 			      value: 1
 			g: 5
 		`,
+		APIVersion: "v1",
 	}
 
 	// Make sure this passes...
-	if err := test.Test(typed.DeducedParseableType); err != nil {
+	if err := test.Test(DeducedParser); err != nil {
 		b.Fatal(err)
 	}
 
-	test.PreprocessOperations(typed.DeducedParseableType)
+	test.PreprocessOperations(DeducedParser)
 
 	b.ReportAllocs()
 	b.ResetTimer()
 	for n := 0; n < b.N; n++ {
-		if err := test.Bench(typed.DeducedParseableType); err != nil {
+		if err := test.Bench(DeducedParser); err != nil {
 			b.Fatal(err)
 		}
 	}

--- a/merge/key_test.go
+++ b/merge/key_test.go
@@ -24,7 +24,7 @@ import (
 	"sigs.k8s.io/structured-merge-diff/v3/typed"
 )
 
-var associativeListParser = func() typed.ParseableType {
+var associativeListParser = func() Parser {
 	parser, err := typed.NewParser(`types:
 - name: type
   map:
@@ -52,7 +52,7 @@ var associativeListParser = func() typed.ParseableType {
 	if err != nil {
 		panic(err)
 	}
-	return parser.Type("type")
+	return SameVersionParser{T: parser.Type("type")}
 }()
 
 func TestUpdateAssociativeLists(t *testing.T) {
@@ -83,6 +83,7 @@ func TestUpdateAssociativeLists(t *testing.T) {
 				- name: b
 				  value: 2
 			`,
+			APIVersion: "v1",
 			Managed: fieldpath.ManagedFields{
 				"default": fieldpath.NewVersionedSet(
 					_NS(

--- a/merge/leaf_test.go
+++ b/merge/leaf_test.go
@@ -25,7 +25,7 @@ import (
 	"sigs.k8s.io/structured-merge-diff/v3/typed"
 )
 
-var leafFieldsParser = func() typed.ParseableType {
+var leafFieldsParser = func() Parser {
 	parser, err := typed.NewParser(`types:
 - name: leafFields
   map:
@@ -42,7 +42,7 @@ var leafFieldsParser = func() typed.ParseableType {
 	if err != nil {
 		panic(err)
 	}
-	return parser.Type("leafFields")
+	return SameVersionParser{T: parser.Type("leafFields")}
 }()
 
 func TestUpdateLeaf(t *testing.T) {
@@ -72,6 +72,7 @@ func TestUpdateLeaf(t *testing.T) {
 				string: "string"
 				bool: false
 			`,
+			APIVersion: "v1",
 			Managed: fieldpath.ManagedFields{
 				"default": fieldpath.NewVersionedSet(
 					_NS(
@@ -107,6 +108,7 @@ func TestUpdateLeaf(t *testing.T) {
 				string: "string"
 				bool: false
 			`,
+			APIVersion: "v1",
 			Managed: fieldpath.ManagedFields{
 				"default": fieldpath.NewVersionedSet(
 					_NS(
@@ -150,6 +152,7 @@ func TestUpdateLeaf(t *testing.T) {
 				string: "string"
 				bool: true
 			`,
+			APIVersion: "v1",
 			Managed: fieldpath.ManagedFields{
 				"default": fieldpath.NewVersionedSet(
 					_NS(
@@ -200,6 +203,7 @@ func TestUpdateLeaf(t *testing.T) {
 				string: "string"
 				bool: true
 			`,
+			APIVersion: "v1",
 			Managed: fieldpath.ManagedFields{
 				"default": fieldpath.NewVersionedSet(
 					_NS(
@@ -261,6 +265,7 @@ func TestUpdateLeaf(t *testing.T) {
 				string: "user string"
 				bool: true
 			`,
+			APIVersion: "v1",
 			Managed: fieldpath.ManagedFields{
 				"default": fieldpath.NewVersionedSet(
 					_NS(
@@ -322,6 +327,7 @@ func TestUpdateLeaf(t *testing.T) {
 				string: "user string"
 				bool: true
 			`,
+			APIVersion: "v1",
 			Managed: fieldpath.ManagedFields{
 				"default": fieldpath.NewVersionedSet(
 					_NS(
@@ -363,6 +369,7 @@ func TestUpdateLeaf(t *testing.T) {
 				string: "new string"
 				bool: false
 			`,
+			APIVersion: "v1",
 			Managed: fieldpath.ManagedFields{
 				"default": fieldpath.NewVersionedSet(
 					_NS(
@@ -397,6 +404,7 @@ func TestUpdateLeaf(t *testing.T) {
 				string: "new string"
 				bool: false
 			`,
+			APIVersion: "v1",
 			Managed: fieldpath.ManagedFields{
 				"default": fieldpath.NewVersionedSet(
 					_NS(
@@ -427,6 +435,7 @@ func TestUpdateLeaf(t *testing.T) {
 			Object: `
 				string: "new string"
 			`,
+			APIVersion: "v1",
 			Managed: fieldpath.ManagedFields{
 				"controller": fieldpath.NewVersionedSet(
 					_NS(
@@ -455,7 +464,8 @@ func TestUpdateLeaf(t *testing.T) {
 			Object: `
 				string: "string"
 			`,
-			Managed: fieldpath.ManagedFields{},
+			APIVersion: "v1",
+			Managed:    fieldpath.ManagedFields{},
 		},
 	}
 
@@ -513,6 +523,7 @@ func BenchmarkLeafConflictAcrossVersion(b *testing.B) {
 			string: "user string"
 			bool: true
 		`,
+		APIVersion: "v1",
 		Managed: fieldpath.ManagedFields{
 			"default": fieldpath.NewVersionedSet(
 				_NS(

--- a/merge/multiple_appliers_test.go
+++ b/merge/multiple_appliers_test.go
@@ -64,6 +64,7 @@ func TestMultipleAppliersSet(t *testing.T) {
 				- name: a
 				- name: c
 			`,
+			APIVersion: "v1",
 			Managed: fieldpath.ManagedFields{
 				"apply-one": fieldpath.NewVersionedSet(
 					_NS(
@@ -109,6 +110,7 @@ func TestMultipleAppliersSet(t *testing.T) {
 				- name: a
 				  value: 0
 			`,
+			APIVersion: "v1",
 			Managed: fieldpath.ManagedFields{
 				"apply-one": fieldpath.NewVersionedSet(
 					_NS(
@@ -159,6 +161,7 @@ func TestMultipleAppliersSet(t *testing.T) {
 				- name: a
 				  value: 0
 			`,
+			APIVersion: "v1",
 			Managed: fieldpath.ManagedFields{
 				"apply-one": fieldpath.NewVersionedSet(
 					_NS(
@@ -207,6 +210,7 @@ func TestMultipleAppliersSet(t *testing.T) {
 				- name: c
 				- name: d
 			`,
+			APIVersion: "v1",
 			Managed: fieldpath.ManagedFields{
 				"apply-one": fieldpath.NewVersionedSet(
 					_NS(
@@ -280,6 +284,7 @@ func TestMultipleAppliersNestedType(t *testing.T) {
 				  value:
 				  - d
 			`,
+			APIVersion: "v1",
 			Managed: fieldpath.ManagedFields{
 				"apply-one": fieldpath.NewVersionedSet(
 					_NS(
@@ -353,6 +358,7 @@ func TestMultipleAppliersNestedType(t *testing.T) {
 				  - d
 				  - e
 			`,
+			APIVersion: "v1",
 			Managed: fieldpath.ManagedFields{
 				"apply-one": fieldpath.NewVersionedSet(
 					_NS(
@@ -432,6 +438,7 @@ func TestMultipleAppliersNestedType(t *testing.T) {
 				  value:
 				  - b
 			`,
+			APIVersion: "v1",
 			Managed: fieldpath.ManagedFields{
 				"apply-one": fieldpath.NewVersionedSet(
 					_NS(
@@ -504,6 +511,7 @@ func TestMultipleAppliersNestedType(t *testing.T) {
 				  value:
 				  - b
 			`,
+			APIVersion: "v1",
 			Managed: fieldpath.ManagedFields{
 				"apply-one": fieldpath.NewVersionedSet(
 					_NS(
@@ -563,6 +571,7 @@ func TestMultipleAppliersNestedType(t *testing.T) {
 				  value:
 				  - d
 			`,
+			APIVersion: "v1",
 			Managed: fieldpath.ManagedFields{
 				"apply-one": fieldpath.NewVersionedSet(
 					_NS(
@@ -668,6 +677,7 @@ func TestMultipleAppliersNestedType(t *testing.T) {
 				        f:
 				          g:
 			`,
+			APIVersion: "v1",
 			Managed: fieldpath.ManagedFields{
 				"apply-two": fieldpath.NewVersionedSet(
 					_NS(
@@ -785,6 +795,7 @@ func TestMultipleAppliersDeducedType(t *testing.T) {
 				      f:
 				        g:
 			`,
+			APIVersion: "v1",
 			Managed: fieldpath.ManagedFields{
 				"apply-two": fieldpath.NewVersionedSet(
 					_NS(
@@ -816,7 +827,7 @@ func TestMultipleAppliersDeducedType(t *testing.T) {
 
 	for name, test := range tests {
 		t.Run(name, func(t *testing.T) {
-			if err := test.Test(typed.DeducedParseableType); err != nil {
+			if err := test.Test(DeducedParser); err != nil {
 				t.Fatal(err)
 			}
 		})
@@ -879,6 +890,7 @@ func TestMultipleAppliersRealConversion(t *testing.T) {
 				      eeee:
 				        ffff:
 			`,
+			APIVersion: "v4",
 			Managed: fieldpath.ManagedFields{
 				"apply-two": fieldpath.NewVersionedSet(
 					_NS(
@@ -937,6 +949,7 @@ func TestMultipleAppliersRealConversion(t *testing.T) {
 				  aaa:
 				  ccc:
 			`,
+			APIVersion: "v3",
 			Managed: fieldpath.ManagedFields{
 				"controller": fieldpath.NewVersionedSet(
 					_NS(
@@ -969,7 +982,7 @@ func TestMultipleAppliersRealConversion(t *testing.T) {
 
 // repeatingConverter repeats a single letterkey v times, where v is the version.
 type repeatingConverter struct {
-	typed.ParseableType
+	parser Parser
 }
 
 var _ merge.Converter = repeatingConverter{}
@@ -1004,7 +1017,7 @@ func (r repeatingConverter) Convert(v *typed.TypedValue, version fieldpath.APIVe
 			str2 = fmt.Sprintf("%v\n%v%v:", str2, spaces, c)
 		}
 	}
-	v2, err := r.ParseableType.FromYAML(typed.YAMLObject(str2))
+	v2, err := r.parser.Type(string(version)).FromYAML(typed.YAMLObject(str2))
 	if err != nil {
 		return nil, err
 	}
@@ -1083,6 +1096,7 @@ func BenchmarkMultipleApplierRecursiveRealConversion(b *testing.B) {
 			      eeee:
 			        ffff:
 		`,
+		APIVersion: "v4",
 		Managed: fieldpath.ManagedFields{
 			"apply-two": fieldpath.NewVersionedSet(
 				_NS(

--- a/merge/nested_test.go
+++ b/merge/nested_test.go
@@ -24,7 +24,7 @@ import (
 	"sigs.k8s.io/structured-merge-diff/v3/typed"
 )
 
-var nestedTypeParser = func() typed.ParseableType {
+var nestedTypeParser = func() Parser {
 	parser, err := typed.NewParser(`types:
 - name: type
   map:
@@ -101,7 +101,7 @@ var nestedTypeParser = func() typed.ParseableType {
 	if err != nil {
 		panic(err)
 	}
-	return parser.Type("type")
+	return SameVersionParser{T: parser.Type("type")}
 }()
 
 func TestUpdateNestedType(t *testing.T) {
@@ -138,6 +138,7 @@ func TestUpdateNestedType(t *testing.T) {
 				  - a
 				  - c
 			`,
+			APIVersion: "v1",
 			Managed: fieldpath.ManagedFields{
 				"default": fieldpath.NewVersionedSet(
 					_NS(
@@ -183,6 +184,7 @@ func TestUpdateNestedType(t *testing.T) {
 				  - a
 				  - c
 			`,
+			APIVersion: "v1",
 			Managed: fieldpath.ManagedFields{
 				"default": fieldpath.NewVersionedSet(
 					_NS(
@@ -228,6 +230,7 @@ func TestUpdateNestedType(t *testing.T) {
 				    a: "x"
 				    c: "z"
 			`,
+			APIVersion: "v1",
 			Managed: fieldpath.ManagedFields{
 				"default": fieldpath.NewVersionedSet(
 					_NS(
@@ -273,6 +276,7 @@ func TestUpdateNestedType(t *testing.T) {
 				    a: "x"
 				    c: "z"
 			`,
+			APIVersion: "v1",
 			Managed: fieldpath.ManagedFields{
 				"default": fieldpath.NewVersionedSet(
 					_NS(
@@ -315,6 +319,7 @@ func TestUpdateNestedType(t *testing.T) {
 				  - a
 				  - c
 			`,
+			APIVersion: "v1",
 			Managed: fieldpath.ManagedFields{
 				"default": fieldpath.NewVersionedSet(
 					_NS(
@@ -356,6 +361,7 @@ func TestUpdateNestedType(t *testing.T) {
 				  - a
 				  - c
 			`,
+			APIVersion: "v1",
 			Managed: fieldpath.ManagedFields{
 				"default": fieldpath.NewVersionedSet(
 					_NS(
@@ -397,6 +403,7 @@ func TestUpdateNestedType(t *testing.T) {
 				    a: "x"
 				    c: "z"
 			`,
+			APIVersion: "v1",
 			Managed: fieldpath.ManagedFields{
 				"default": fieldpath.NewVersionedSet(
 					_NS(
@@ -438,6 +445,7 @@ func TestUpdateNestedType(t *testing.T) {
 				    a: "x"
 				    c: "z"
 			`,
+			APIVersion: "v1",
 			Managed: fieldpath.ManagedFields{
 				"default": fieldpath.NewVersionedSet(
 					_NS(
@@ -479,6 +487,7 @@ func TestUpdateNestedType(t *testing.T) {
 				    d:
 				      c:
 			`,
+			APIVersion: "v1",
 			Managed: fieldpath.ManagedFields{
 				"default": fieldpath.NewVersionedSet(
 					_NS(

--- a/merge/preserve_unknown_test.go
+++ b/merge/preserve_unknown_test.go
@@ -24,7 +24,7 @@ import (
 	"sigs.k8s.io/structured-merge-diff/v3/typed"
 )
 
-var preserveUnknownParser = func() typed.ParseableType {
+var preserveUnknownParser = func() Parser {
 	parser, err := typed.NewParser(`types:
 - name: type
   map:
@@ -38,7 +38,7 @@ var preserveUnknownParser = func() typed.ParseableType {
 	if err != nil {
 		panic(err)
 	}
-	return parser.Type("type")
+	return SameVersionParser{T: parser.Type("type")}
 }()
 
 func TestPreserveUnknownFields(t *testing.T) {
@@ -66,6 +66,7 @@ func TestPreserveUnknownFields(t *testing.T) {
 				num: 6
 				unknown: new
 			`,
+			APIVersion: "v1",
 			Managed: fieldpath.ManagedFields{
 				"default": fieldpath.NewVersionedSet(
 					_NS(

--- a/merge/set_test.go
+++ b/merge/set_test.go
@@ -24,7 +24,7 @@ import (
 	"sigs.k8s.io/structured-merge-diff/v3/typed"
 )
 
-var setFieldsParser = func() typed.ParseableType {
+var setFieldsParser = func() Parser {
 	parser, err := typed.NewParser(`types:
 - name: sets
   map:
@@ -38,7 +38,7 @@ var setFieldsParser = func() typed.ParseableType {
 	if err != nil {
 		panic(err)
 	}
-	return parser.Type("sets")
+	return SameVersionParser{T: parser.Type("sets")}
 }()
 
 func TestUpdateSet(t *testing.T) {
@@ -73,6 +73,7 @@ func TestUpdateSet(t *testing.T) {
 				- c
 				- d
 			`,
+			APIVersion: "v1",
 			Managed: fieldpath.ManagedFields{
 				"default": fieldpath.NewVersionedSet(
 					_NS(
@@ -129,6 +130,7 @@ func TestUpdateSet(t *testing.T) {
 				- cprime
 				- d
 			`,
+			APIVersion: "v1",
 			Managed: fieldpath.ManagedFields{
 				"default": fieldpath.NewVersionedSet(
 					_NS(
@@ -193,6 +195,7 @@ func TestUpdateSet(t *testing.T) {
 				- cprime
 				- d
 			`,
+			APIVersion: "v1",
 			Managed: fieldpath.ManagedFields{
 				"default": fieldpath.NewVersionedSet(
 					_NS(
@@ -254,6 +257,7 @@ func TestUpdateSet(t *testing.T) {
 				- c
 				- d
 			`,
+			APIVersion: "v1",
 			Managed: fieldpath.ManagedFields{
 				"default": fieldpath.NewVersionedSet(
 					_NS(
@@ -314,6 +318,7 @@ func TestUpdateSet(t *testing.T) {
 				- c
 				- d
 			`,
+			APIVersion: "v1",
 			Managed: fieldpath.ManagedFields{
 				"default": fieldpath.NewVersionedSet(
 					_NS(
@@ -366,6 +371,7 @@ func TestUpdateSet(t *testing.T) {
 				- c
 				- b
 			`,
+			APIVersion: "v1",
 			Managed: fieldpath.ManagedFields{
 				"default": fieldpath.NewVersionedSet(
 					_NS(
@@ -422,6 +428,7 @@ func TestUpdateSet(t *testing.T) {
 				- c
 				- d
 			`,
+			APIVersion: "v1",
 			Managed: fieldpath.ManagedFields{
 				"default": fieldpath.NewVersionedSet(
 					_NS(
@@ -478,6 +485,7 @@ func TestUpdateSet(t *testing.T) {
 				- c
 				- d
 			`,
+			APIVersion: "v1",
 			Managed: fieldpath.ManagedFields{
 				"default": fieldpath.NewVersionedSet(
 					_NS(
@@ -519,6 +527,7 @@ func TestUpdateSet(t *testing.T) {
 				- a
 				- c
 			`,
+			APIVersion: "v1",
 			Managed: fieldpath.ManagedFields{
 				"default": fieldpath.NewVersionedSet(
 					_NS(
@@ -560,6 +569,7 @@ func TestUpdateSet(t *testing.T) {
 				- c
 				- e
 			`,
+			APIVersion: "v1",
 			Managed: fieldpath.ManagedFields{
 				"default": fieldpath.NewVersionedSet(
 					_NS(

--- a/merge/union_test.go
+++ b/merge/union_test.go
@@ -25,7 +25,7 @@ import (
 	"sigs.k8s.io/structured-merge-diff/v3/typed"
 )
 
-var unionFieldsParser = func() typed.ParseableType {
+var unionFieldsParser = func() Parser {
 	parser, err := typed.NewParser(`types:
 - name: unionFields
   map:
@@ -61,7 +61,7 @@ var unionFieldsParser = func() typed.ParseableType {
 	if err != nil {
 		panic(err)
 	}
-	return parser.Type("unionFields")
+	return SameVersionParser{T: parser.Type("unionFields")}
 }()
 
 func TestUnion(t *testing.T) {
@@ -81,6 +81,7 @@ func TestUnion(t *testing.T) {
 				numeric: 1
 				type: Numeric
 			`,
+			APIVersion: "v1",
 			Managed: fieldpath.ManagedFields{
 				"default": fieldpath.NewVersionedSet(
 					_NS(
@@ -116,6 +117,7 @@ func TestUnion(t *testing.T) {
 				string: "some string"
 				type: String
 			`,
+			APIVersion: "v1",
 			Managed: fieldpath.ManagedFields{
 				"controller": fieldpath.NewVersionedSet(
 					_NS(
@@ -165,6 +167,7 @@ func TestUnion(t *testing.T) {
 				numeric: 0
 				fieldB: "fieldB string"
 			`,
+			APIVersion: "v1",
 		},
 	}
 


### PR DESCRIPTION
This creates an example of a compatibility test. It's not great, but we get it mostly for free.

In this case it would show that going from atomic to associative (and vice-versa) is bad because we wouldn't be able to "resolve" the managed fields from one to the other. Even though, maybe we can fix the code to do the right thing.

I'm still not completely convinced that this test does the right thing so I have to think a little bit about it.

cc @mariantalla @lavalamp @jennybuckley 