### PR TITLE
Run non-required union tests last

### DIFF
--- a/internal/fixture/state.go
+++ b/internal/fixture/state.go
@@ -425,14 +425,6 @@ func (tc TestCase) TestWithConverter(parser typed.ParseableType, converter merge
 	}
 	if tc.RequiresUnions {
 		state.Updater.EnableUnionFeature()
-	} else {
-		// Also test it with unions on.
-		tc2 := tc
-		tc2.RequiresUnions = true
-		err := tc2.TestWithConverter(parser, converter)
-		if err != nil {
-			return fmt.Errorf("fails if unions are on: %v", err)
-		}
 	}
 	// We currently don't have any test that converts, we can take
 	// care of that later.
@@ -464,6 +456,16 @@ func (tc TestCase) TestWithConverter(parser typed.ParseableType, converter merge
 	for manager, set := range state.Managers {
 		if set.Set().Empty() {
 			return fmt.Errorf("expected Managers to have no empty sets, but found one managed by %v", manager)
+		}
+	}
+
+	if !tc.RequiresUnions {
+		// Re-run the test with unions on.
+		tc2 := tc
+		tc2.RequiresUnions = true
+		err := tc2.TestWithConverter(parser, converter)
+		if err != nil {
+			return fmt.Errorf("fails if unions are on: %v", err)
 		}
 	}
 


### PR DESCRIPTION
Currently, we run each test twice when unions aren't required: once with
and once without them enabled. Since we run with the union enabled
first, legitimate test failures are prepended with "fails when unions
are on" which is misleading since they may not be caused by unions.

Running union tests last removes that mis-leading prefix and makes it
clear if the problem comes from union or not.