### PR TITLE
value.Equals should check types in both directions

### DIFF
--- a/value/less_test.go
+++ b/value/less_test.go
@@ -261,10 +261,19 @@ func TestValueLess(t *testing.T) {
 				if !Equals(a, b) {
 					t.Errorf("oops, a != b: %#v, %#v", tt.a, tt.b)
 				}
+				if !Equals(b, a) {
+					t.Errorf("oops, b != a: %#v, %#v", tt.b, tt.a)
+				}
 				if Less(a, b) {
 					t.Errorf("oops, a < b: %#v, %#v", tt.a, tt.b)
 				}
 			} else {
+				if Equals(a, b) {
+					t.Errorf("oops, a == b: %#v, %#v", tt.a, tt.b)
+				}
+				if Equals(b, a) {
+					t.Errorf("oops, b == a: %#v, %#v", tt.b, tt.a)
+				}
 				if !Less(a, b) {
 					t.Errorf("oops, a >= b: %#v, %#v", tt.a, tt.b)
 				}

--- a/value/value.go
+++ b/value/value.go
@@ -152,11 +152,15 @@ func Equals(lhs, rhs Value) bool {
 			return lhs.AsInt() == rhs.AsInt()
 		}
 		return false
+	} else if rhs.IsInt() {
+		return false
 	}
 	if lhs.IsString() {
 		if rhs.IsString() {
 			return lhs.AsString() == rhs.AsString()
 		}
+		return false
+	} else if rhs.IsString() {
 		return false
 	}
 	if lhs.IsBool() {
@@ -164,11 +168,15 @@ func Equals(lhs, rhs Value) bool {
 			return lhs.AsBool() == rhs.AsBool()
 		}
 		return false
+	} else if rhs.IsBool() {
+		return false
 	}
 	if lhs.IsList() {
 		if rhs.IsList() {
 			return ListEquals(lhs.AsList(), rhs.AsList())
 		}
+		return false
+	} else if rhs.IsList() {
 		return false
 	}
 	if lhs.IsMap() {
@@ -176,11 +184,15 @@ func Equals(lhs, rhs Value) bool {
 			return lhs.AsMap().Equals(rhs.AsMap())
 		}
 		return false
+	} else if rhs.IsMap() {
+		return false
 	}
 	if lhs.IsNull() {
 		if rhs.IsNull() {
 			return true
 		}
+		return false
+	} else if rhs.IsNull() {
 		return false
 	}
 	// No field is set, on either objects.


### PR DESCRIPTION
Currently, value.Equals doesn't check that the types are different in
both direction: it checks that if lhs is of type A, then rhs must also
be of type A), but it doesn't check that if lhs is not of type A but rhs
is, then they must be different.

Make it more obvious in the test that the types must always match, and fix
the test by checking in both direction.