### PR TITLE
Optimize sync.Pool usage and value.Equals implementations

### DIFF
--- a/fieldpath/fromvalue.go
+++ b/fieldpath/fromvalue.go
@@ -55,11 +55,13 @@ func (w *objectWalker) walk() {
 	case w.value.IsList():
 		// If the list were atomic, we'd break here, but we don't have
 		// a schema, so we can't tell.
-		list := w.value.AsList()
-		for i := 0; i < list.Length(); i++ {
+		iter := w.value.AsList().Range()
+		defer iter.Recycle()
+		for iter.Next() {
+			i, value := iter.Item()
 			w2 := *w
-			w2.path = append(w.path, GuessBestListPathElement(i, list.At(i)))
-			w2.value = list.At(i)
+			w2.path = append(w.path, GuessBestListPathElement(i, value))
+			w2.value = value
 			w2.walk()
 		}
 		return

--- a/typed/remove.go
+++ b/typed/remove.go
@@ -50,8 +50,10 @@ func (w *removingWalker) doList(t *schema.List) (errs ValidationErrors) {
 	}
 
 	var newItems []interface{}
-	for i := 0; i < l.Length(); i++ {
-		item := l.At(i)
+	iter := l.Range()
+	defer iter.Recycle()
+	for iter.Next() {
+		i, item := iter.Item()
 		// Ignore error because we have already validated this list
 		pe, _ := listItemToPathElement(t, i, item)
 		path, _ := fieldpath.MakePath(pe)

--- a/value/list.go
+++ b/value/list.go
@@ -41,6 +41,20 @@ type ListRange interface {
 	Recycle()
 }
 
+var EmptyRange = &emptyRange{}
+
+type emptyRange struct{}
+
+func (_ *emptyRange) Next() bool {
+	return false
+}
+
+func (_ *emptyRange) Item() (index int, value Value) {
+	panic("Item called on empty ListRange")
+}
+
+func (_ *emptyRange) Recycle() {}
+
 // ListEquals compares two lists lexically.
 func ListEquals(lhs, rhs List) bool {
 	if lhs.Length() != rhs.Length() {

--- a/value/listreflect.go
+++ b/value/listreflect.go
@@ -16,7 +16,10 @@ limitations under the License.
 
 package value
 
-import "reflect"
+import (
+	"reflect"
+	"sync"
+)
 
 type listReflect struct {
 	Value reflect.Value
@@ -41,32 +44,44 @@ func (r listReflect) Unstructured() interface{} {
 	return result
 }
 
+var lrrPool = sync.Pool{
+	New: func() interface{} {
+		return &listReflectRange{vr: &valueReflect{}}
+	},
+}
+
 func (r listReflect) Range() ListRange {
-	return &listReflectRange{r.Value, newTempValuePooler(), -1, r.Value.Len()}
+	length := r.Value.Len()
+	if length == 0 {
+		return EmptyRange
+	}
+	rr := lrrPool.Get().(*listReflectRange)
+	rr.list = r.Value
+	rr.i = -1
+	return rr
 }
 
 type listReflectRange struct {
-	val    reflect.Value
-	pooler *tempValuePooler
-	i      int
-	length int
+	list reflect.Value
+	vr   *valueReflect
+	i    int
 }
 
 func (r *listReflectRange) Next() bool {
 	r.i += 1
-	return r.i < r.length
+	return r.i < r.list.Len()
 }
 
 func (r *listReflectRange) Item() (index int, value Value) {
 	if r.i < 0 {
 		panic("Item() called before first calling Next()")
 	}
-	if r.i >= r.length {
+	if r.i >= r.list.Len() {
 		panic("Item() called on ListRange with no more items")
 	}
-	return r.i, r.pooler.NewValueReflect(r.val.Index(r.i))
+	return r.i, r.vr.reuse(r.list.Index(r.i))
 }
 
 func (r *listReflectRange) Recycle() {
-	r.pooler.Recycle()
+	lrrPool.Put(r)
 }

--- a/value/listreflect.go
+++ b/value/listreflect.go
@@ -40,3 +40,33 @@ func (r listReflect) Unstructured() interface{} {
 	}
 	return result
 }
+
+func (r listReflect) Range() ListRange {
+	return &listReflectRange{r.Value, newTempValuePooler(), -1, r.Value.Len()}
+}
+
+type listReflectRange struct {
+	val    reflect.Value
+	pooler *tempValuePooler
+	i      int
+	length int
+}
+
+func (r *listReflectRange) Next() bool {
+	r.i += 1
+	return r.i < r.length
+}
+
+func (r *listReflectRange) Item() (index int, value Value) {
+	if r.i < 0 {
+		panic("Item() called before first calling Next()")
+	}
+	if r.i >= r.length {
+		panic("Item() called on ListRange with no more items")
+	}
+	return r.i, r.pooler.NewValueReflect(r.val.Index(r.i))
+}
+
+func (r *listReflectRange) Recycle() {
+	r.pooler.Recycle()
+}

--- a/value/listunstructured.go
+++ b/value/listunstructured.go
@@ -16,6 +16,8 @@ limitations under the License.
 
 package value
 
+import "sync"
+
 type listUnstructured []interface{}
 
 func (l listUnstructured) Length() int {
@@ -26,40 +28,43 @@ func (l listUnstructured) At(i int) Value {
 	return NewValueInterface(l[i])
 }
 
+var lurPool = sync.Pool{
+	New: func() interface{} {
+		return &listUnstructuredRange{vv: &valueUnstructured{}}
+	},
+}
+
 func (l listUnstructured) Range() ListRange {
 	if len(l) == 0 {
-		return &listUnstructuredRange{l, nil, -1, 0}
+		return EmptyRange
 	}
-	vv := viPool.Get().(*valueUnstructured)
-	return &listUnstructuredRange{l, vv, -1, len(l)}
+	r := lurPool.Get().(*listUnstructuredRange)
+	r.list = l
+	r.i = -1
+	return r
 }
 
 type listUnstructuredRange struct {
-	list   listUnstructured
-	vv     *valueUnstructured
-	i      int
-	length int
+	list listUnstructured
+	vv   *valueUnstructured
+	i    int
 }
 
 func (r *listUnstructuredRange) Next() bool {
 	r.i += 1
-	return r.i < r.length
+	return r.i < len(r.list)
 }
 
 func (r *listUnstructuredRange) Item() (index int, value Value) {
 	if r.i < 0 {
 		panic("Item() called before first calling Next()")
 	}
-	if r.i >= r.length {
+	if r.i >= len(r.list) {
 		panic("Item() called on ListRange with no more items")
 	}
-
-	r.vv.Value = r.list[r.i]
-	return r.i, r.vv
+	return r.i, r.vv.reuse(r.list[r.i])
 }
 
 func (r *listUnstructuredRange) Recycle() {
-	if r.vv != nil {
-		r.vv.Recycle()
-	}
+	lurPool.Put(r)
 }

--- a/value/map.go
+++ b/value/map.go
@@ -99,6 +99,7 @@ func MapCompare(lhs, rhs Map) int {
 // MapEquals returns true if lhs == rhs, false otherwise. This function
 // acts on generic types and should not be used by callers, but can help
 // implement Map.Equals.
+// WARN: This is a naive implementation, calling lhs.Equals(rhs) is typically far more efficient.
 func MapEquals(lhs, rhs Map) bool {
 	if lhs.Length() != rhs.Length() {
 		return false

--- a/value/map.go
+++ b/value/map.go
@@ -111,9 +111,6 @@ func MapEquals(lhs, rhs Map) bool {
 		}
 		equal := Equals(v, vo)
 		vo.Recycle()
-		if !equal {
-			return false
-		}
-		return true
+		return equal
 	})
 }

--- a/value/map.go
+++ b/value/map.go
@@ -81,11 +81,16 @@ func MapCompare(lhs, rhs Map) int {
 		}
 		litem, _ := lhs.Get(lorder[i])
 		ritem, _ := rhs.Get(rorder[i])
-		if c := Compare(litem, ritem); c != 0 {
+		c := Compare(litem, ritem)
+		if litem != nil {
+			litem.Recycle()
+		}
+		if ritem != nil {
+			ritem.Recycle()
+		}
+		if c != 0 {
 			return c
 		}
-		litem.Recycle()
-		ritem.Recycle()
 		// The items are equal; continue.
 		i++
 	}
@@ -103,11 +108,11 @@ func MapEquals(lhs, rhs Map) bool {
 		if !ok {
 			return false
 		}
-		if !Equals(v, vo) {
-			vo.Recycle()
+		equal := Equals(v, vo)
+		vo.Recycle()
+		if !equal {
 			return false
 		}
-		vo.Recycle()
 		return true
 	})
 }

--- a/value/mapreflect.go
+++ b/value/mapreflect.go
@@ -16,7 +16,9 @@ limitations under the License.
 
 package value
 
-import "reflect"
+import (
+	"reflect"
+)
 
 type mapReflect struct {
 	valueReflect
@@ -61,10 +63,10 @@ func (r mapReflect) toMapKey(key string) reflect.Value {
 }
 
 func (r mapReflect) Iterate(fn func(string, Value) bool) bool {
+	vp := newTempValuePooler()
+	defer vp.Recycle()
 	return eachMapEntry(r.Value, func(s string, value reflect.Value) bool {
-		mapVal := mustWrapValueReflect(value)
-		defer mapVal.Recycle()
-		return fn(s, mapVal)
+		return fn(s, vp.NewValueReflect(value))
 	})
 }
 

--- a/value/mapunstructured.go
+++ b/value/mapunstructured.go
@@ -40,16 +40,19 @@ func (m mapUnstructuredInterface) Delete(key string) {
 }
 
 func (m mapUnstructuredInterface) Iterate(fn func(key string, value Value) bool) bool {
+	if len(m) == 0 {
+		return true
+	}
+	vv := viPool.Get().(*valueUnstructured)
+	defer vv.Recycle()
 	for k, v := range m {
 		if ks, ok := k.(string); !ok {
 			continue
 		} else {
-			vv := NewValueInterface(v)
+			vv.Value = v
 			if !fn(ks, vv) {
-				vv.Recycle()
 				return false
 			}
-			vv.Recycle()
 		}
 	}
 	return true
@@ -63,6 +66,11 @@ func (m mapUnstructuredInterface) Equals(other Map) bool {
 	if m.Length() != other.Length() {
 		return false
 	}
+	if len(m) == 0 {
+		return true
+	}
+	vv := viPool.Get().(*valueUnstructured)
+	defer vv.Recycle()
 	for k, v := range m {
 		ks, ok := k.(string)
 		if !ok {
@@ -72,14 +80,12 @@ func (m mapUnstructuredInterface) Equals(other Map) bool {
 		if !ok {
 			return false
 		}
-		vv := NewValueInterface(v)
+		vv.Value = v
 		if !Equals(vv, vo) {
-			vv.Recycle()
 			vo.Recycle()
 			return false
 		}
 		vo.Recycle()
-		vv.Recycle()
 	}
 	return true
 }
@@ -108,13 +114,16 @@ func (m mapUnstructuredString) Delete(key string) {
 }
 
 func (m mapUnstructuredString) Iterate(fn func(key string, value Value) bool) bool {
+	if len(m) == 0 {
+		return true
+	}
+	vv := viPool.Get().(*valueUnstructured)
+	defer vv.Recycle()
 	for k, v := range m {
-		vv := NewValueInterface(v)
+		vv.Value = v
 		if !fn(k, vv) {
-			vv.Recycle()
 			return false
 		}
-		vv.Recycle()
 	}
 	return true
 }
@@ -127,19 +136,22 @@ func (m mapUnstructuredString) Equals(other Map) bool {
 	if m.Length() != other.Length() {
 		return false
 	}
+	if len(m) == 0 {
+		return true
+	}
+	vv := viPool.Get().(*valueUnstructured)
+	defer vv.Recycle()
 	for k, v := range m {
 		vo, ok := other.Get(k)
 		if !ok {
 			return false
 		}
-		vv := NewValueInterface(v)
+		vv.Value = v
 		if !Equals(vv, vo) {
 			vo.Recycle()
-			vv.Recycle()
 			return false
 		}
 		vo.Recycle()
-		vv.Recycle()
 	}
 	return true
 }

--- a/value/value.go
+++ b/value/value.go
@@ -203,8 +203,9 @@ func ToString(v Value) string {
 		return fmt.Sprintf("%v", v.AsBool())
 	case v.IsList():
 		strs := []string{}
-		for i := 0; i < v.AsList().Length(); i++ {
-			strs = append(strs, ToString(v.AsList().At(i)))
+		list := v.AsList()
+		for i := 0; i < list.Length(); i++ {
+			strs = append(strs, ToString(list.At(i)))
 		}
 		return "[" + strings.Join(strs, ",") + "]"
 	case v.IsMap():

--- a/value/valuereflect.go
+++ b/value/valuereflect.go
@@ -52,7 +52,8 @@ func wrapValueReflect(parentMap, parentMapKey *reflect.Value, value reflect.Valu
 	// TODO: conversion of json.Marshaller interface types is expensive. This can be mostly optimized away by
 	// introducing conversion functions that do not require going through JSON and using those here.
 	if marshaler, ok := getMarshaler(value); ok {
-		return toUnstructured(marshaler, value)
+		vv := viPool.Get().(*valueUnstructured)
+		return toUnstructured(vv, marshaler, value)
 	}
 	value = dereference(value)
 	val := reflectPool.Get().(*valueReflect)
@@ -259,7 +260,7 @@ var (
 	falseBytes = []byte("false")
 )
 
-func toUnstructured(marshaler json.Marshaler, sv reflect.Value) (Value, error) {
+func toUnstructured(into *valueUnstructured, marshaler json.Marshaler, sv reflect.Value) (Value, error) {
 	data, err := marshaler.MarshalJSON()
 	if err != nil {
 		return nil, err
@@ -270,13 +271,13 @@ func toUnstructured(marshaler json.Marshaler, sv reflect.Value) (Value, error) {
 
 	case bytes.Equal(data, nullBytes):
 		// We're done - we don't need to store anything.
-		return NewValueInterface(nil), nil
+		into.Value = nil
 
 	case bytes.Equal(data, trueBytes):
-		return NewValueInterface(true), nil
+		into.Value = true
 
 	case bytes.Equal(data, falseBytes):
-		return NewValueInterface(false), nil
+		into.Value = false
 
 	case data[0] == '"':
 		var result string
@@ -284,7 +285,7 @@ func toUnstructured(marshaler json.Marshaler, sv reflect.Value) (Value, error) {
 		if err != nil {
 			return nil, fmt.Errorf("error decoding string from json: %v", err)
 		}
-		return NewValueInterface(result), nil
+		into.Value = result
 
 	case data[0] == '{':
 		result := make(map[string]interface{})
@@ -292,7 +293,7 @@ func toUnstructured(marshaler json.Marshaler, sv reflect.Value) (Value, error) {
 		if err != nil {
 			return nil, fmt.Errorf("error decoding object from json: %v", err)
 		}
-		return NewValueInterface(result), nil
+		into.Value = result
 
 	case data[0] == '[':
 		result := make([]interface{}, 0)
@@ -300,7 +301,7 @@ func toUnstructured(marshaler json.Marshaler, sv reflect.Value) (Value, error) {
 		if err != nil {
 			return nil, fmt.Errorf("error decoding array from json: %v", err)
 		}
-		return NewValueInterface(result), nil
+		into.Value = result
 
 	default:
 		var (
@@ -309,11 +310,74 @@ func toUnstructured(marshaler json.Marshaler, sv reflect.Value) (Value, error) {
 			err         error
 		)
 		if err = json.Unmarshal(data, &resultInt); err == nil {
-			return NewValueInterface(resultInt), nil
+			into.Value = resultInt
+			return into, nil
 		}
 		if err = json.Unmarshal(data, &resultFloat); err == nil {
-			return NewValueInterface(resultFloat), nil
+			into.Value = resultFloat
+			return into, nil
 		}
 		return nil, fmt.Errorf("error decoding number from json: %v", err)
 	}
+	return into, nil
+}
+
+// tempValuePooler manages sync.Pool usage for reflect iterators that need either a temporary valueReflect or a
+// valueUnstructured for each iterator callback invocation. Directly reusing value objects for each iterator callback
+// invocation is much more efficient than using getting and putting objects to a sync.Pool.
+type tempValuePooler struct {
+	vr *valueReflect
+	vu *valueUnstructured
+}
+
+func newTempValuePooler() *tempValuePooler {
+	return &tempValuePooler{}
+}
+
+func (ir *tempValuePooler) pooledValueReflect() *valueReflect {
+	if ir.vr == nil {
+		ir.vr = reflectPool.Get().(*valueReflect)
+	}
+	return ir.vr
+}
+
+func (ir *tempValuePooler) pooledValueInterface() *valueUnstructured {
+	if ir.vu == nil {
+		ir.vu = viPool.Get().(*valueUnstructured)
+	}
+	return ir.vu
+}
+
+// Recycle calls Recycle on all underlying pooled value objects.
+func (ir *tempValuePooler) Recycle() {
+	if ir.vr != nil {
+		ir.vr.Recycle()
+	}
+	if ir.vu != nil {
+		ir.vu.Recycle()
+	}
+}
+
+// NewValueReflect returns a Value wrapping the given reflect.Value. The returned Value is valid only temporarily.
+// The returned Value becomes invalid on the next NewValueReflect call.
+func (ir *tempValuePooler) NewValueReflect(value reflect.Value) Value {
+	if marshaler, ok := getMarshaler(value); ok {
+		vi := ir.pooledValueInterface()
+		marshaled, err := toUnstructured(vi, marshaler, value)
+		if err != nil {
+			panic(err)
+		}
+		return marshaled
+	}
+	vr := ir.pooledValueReflect()
+	vr.Value = dereference(value)
+	return vr
+}
+
+// NewValueInterface returns a Value wrapping the given interface{}.  The returned Value is valid only temporarily.
+// // The returned Value becomes invalid on the next NewValueInterface call.
+func (ir *tempValuePooler) NewValueInterface(value interface{}) Value {
+	vi := ir.pooledValueInterface()
+	vi.Value = value
+	return vi
 }

--- a/value/valuereflect_test.go
+++ b/value/valuereflect_test.go
@@ -552,6 +552,7 @@ func TestReflectList(t *testing.T) {
 			if m.Length() != tc.length {
 				t.Errorf("expected list to be of length %d but got %d", tc.length, m.Length())
 			}
+
 			l := m.Length()
 			iterateResult := make([]interface{}, l)
 			for i := 0; i < l; i++ {
@@ -560,6 +561,18 @@ func TestReflectList(t *testing.T) {
 			if !reflect.DeepEqual(iterateResult, tc.expectedIterate) {
 				t.Errorf("expected iterate to produce %#v but got %#v", tc.expectedIterate, iterateResult)
 			}
+
+			iter := m.Range()
+			iter.Recycle()
+			iterateResult = make([]interface{}, l)
+			for iter.Next() {
+				i, val := iter.Item()
+				iterateResult[i] = val.AsString()
+			}
+			if !reflect.DeepEqual(iterateResult, tc.expectedIterate) {
+				t.Errorf("expected iterate to produce %#v but got %#v", tc.expectedIterate, iterateResult)
+			}
+
 			unstructured := rv.Unstructured()
 			if !reflect.DeepEqual(unstructured, tc.expectedUnstructured) {
 				t.Errorf("expected iterate to produce %#v but got %#v", tc.expectedUnstructured, unstructured)

--- a/value/valueunstructured.go
+++ b/value/valueunstructured.go
@@ -33,12 +33,17 @@ var viPool = sync.Pool{
 // string or boolean. Nested interface{} must also be one of these types.
 func NewValueInterface(v interface{}) Value {
 	vi := viPool.Get().(*valueUnstructured)
-	vi.Value = v
-	return Value(vi)
+	return Value(vi.reuse(v))
 }
 
 type valueUnstructured struct {
 	Value interface{}
+}
+
+// reuse replaces the value of the valueUnstructured.
+func (vi *valueUnstructured) reuse(value interface{}) Value {
+	vi.Value = value
+	return vi
 }
 
 func (v valueUnstructured) IsMap() bool {


### PR DESCRIPTION
- Avoid using `sync.Pool` for iteration loops where we can simply reuse an object directly.
- Introduce `List.Range` to make manage object reuse when looping over lists
- Use `List.Range` to optimize `ListEqual` and `ListCompare`

Benchmarks:
- `sync.Pool` change improves `BenchmarkConvertObjectToTyped` by ~20% for CPU

/sig api-machinery
/cc @apelisse @jennybuckley 