### PR TITLE
Optimize conversion to unstructured

### DIFF
--- a/value/fields.go
+++ b/value/fields.go
@@ -27,7 +27,7 @@ type Field struct {
 	Value Value
 }
 
-// FieldList is a list of key-value pairs. Each field is expectUpdated to
+// FieldList is a list of key-value pairs. Each field is expected to
 // have a different name.
 type FieldList []Field
 

--- a/value/listreflect.go
+++ b/value/listreflect.go
@@ -32,7 +32,7 @@ func (r listReflect) Length() int {
 
 func (r listReflect) At(i int) Value {
 	val := r.Value
-	return mustWrapValueReflect(val.Index(i))
+	return mustWrapValueReflect(val.Index(i), nil, nil)
 }
 
 func (r listReflect) Unstructured() interface{} {
@@ -79,7 +79,7 @@ func (r *listReflectRange) Item() (index int, value Value) {
 	if r.i >= r.list.Len() {
 		panic("Item() called on ListRange with no more items")
 	}
-	return r.i, r.vr.reuse(r.list.Index(r.i))
+	return r.i, r.vr.mustReuse(r.list.Index(r.i), nil, nil)
 }
 
 func (r *listReflectRange) Recycle() {

--- a/value/reflectcache.go
+++ b/value/reflectcache.go
@@ -1,0 +1,304 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package value
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"reflect"
+	"sync"
+	"sync/atomic"
+)
+
+// UnstructuredConverter defines how a type can be converted directly to unstructured.
+// Types that implement json.Marshaler may also optionally implement this interface to provide a more
+// direct and more efficient conversion. All types that choose to implement this interface must still
+// implement this same conversion via json.Marshaler.
+type UnstructuredConverter interface {
+	json.Marshaler // require that json.Marshaler is implemented
+
+	// ToUnstructured returns the unstructured representation.
+	ToUnstructured() interface{}
+}
+
+// TypeReflectCacheEntry keeps data gathered using reflection about how a type is converted to/from unstructured.
+type TypeReflectCacheEntry struct {
+	isJsonMarshaler        bool
+	ptrIsJsonMarshaler     bool
+	isJsonUnmarshaler      bool
+	ptrIsJsonUnmarshaler   bool
+	isStringConvertable    bool
+	ptrIsStringConvertable bool
+
+	structFields map[string]*FieldCacheEntry
+}
+
+// FieldCacheEntry keeps data gathered using reflection about how the field of a struct is converted to/from
+// unstructured.
+type FieldCacheEntry struct {
+	// isOmitEmpty is true if the field has the json 'omitempty' tag.
+	isOmitEmpty bool
+	// fieldPath is a list of field indices (see FieldByIndex) to lookup the value of
+	// a field in a reflect.Value struct. The field indices in the list form a path used
+	// to traverse through intermediary 'inline' fields.
+	fieldPath [][]int
+}
+
+// GetFrom returns the field identified by this FieldCacheEntry from the provided struct.
+func (f *FieldCacheEntry) GetFrom(structVal reflect.Value) reflect.Value {
+	// field might be nested within 'inline' structs
+	for _, elem := range f.fieldPath {
+		structVal = structVal.FieldByIndex(elem)
+	}
+	return structVal
+}
+
+var marshalerType = reflect.TypeOf(new(json.Marshaler)).Elem()
+var unmarshalerType = reflect.TypeOf(new(json.Unmarshaler)).Elem()
+var unstructuredConvertableType = reflect.TypeOf(new(UnstructuredConverter)).Elem()
+var defaultReflectCache = newReflectCache()
+
+// TypeReflectEntryOf returns the TypeReflectCacheEntry of the provided reflect.Type.
+func TypeReflectEntryOf(t reflect.Type) TypeReflectCacheEntry {
+	if record, ok := defaultReflectCache.get(t); ok {
+		return record
+	}
+	record := TypeReflectCacheEntry{
+		isJsonMarshaler:        t.Implements(marshalerType),
+		ptrIsJsonMarshaler:     reflect.PtrTo(t).Implements(marshalerType),
+		isJsonUnmarshaler:      reflect.PtrTo(t).Implements(unmarshalerType),
+		isStringConvertable:    t.Implements(unstructuredConvertableType),
+		ptrIsStringConvertable: reflect.PtrTo(t).Implements(unstructuredConvertableType),
+	}
+	if t.Kind() == reflect.Struct {
+		hints := map[string]*FieldCacheEntry{}
+		buildStructCacheEntry(t, hints, nil)
+		record.structFields = hints
+	}
+
+	defaultReflectCache.update(t, record)
+	return record
+}
+
+func buildStructCacheEntry(t reflect.Type, infos map[string]*FieldCacheEntry, fieldPath [][]int) {
+	for i := 0; i < t.NumField(); i++ {
+		field := t.Field(i)
+		jsonName, omit, isInline, isOmitempty := lookupJsonTags(field)
+		if omit {
+			continue
+		}
+		if isInline {
+			buildStructCacheEntry(field.Type, infos, append(fieldPath, field.Index))
+			continue
+		}
+		info := &FieldCacheEntry{isOmitEmpty: isOmitempty, fieldPath: append(fieldPath, field.Index)}
+		infos[jsonName] = info
+	}
+}
+
+// Fields returns a map of JSON field name to FieldCacheEntry for structs, or nil for non-structs.
+func (e TypeReflectCacheEntry) Fields() map[string]*FieldCacheEntry {
+	return e.structFields
+}
+
+// CanConvertToUnstructured returns true if this TypeReflectCacheEntry can convert values of its type to unstructured.
+func (e TypeReflectCacheEntry) CanConvertToUnstructured() bool {
+	return e.isJsonMarshaler || e.ptrIsJsonMarshaler || e.isStringConvertable || e.ptrIsStringConvertable
+}
+
+// ToUnstructured converts the provided value to unstructured and returns it.
+func (e TypeReflectCacheEntry) ToUnstructured(sv reflect.Value) (interface{}, error) {
+	// This is based on https://github.com/kubernetes/kubernetes/blob/82c9e5c814eb7acc6cc0a090c057294d0667ad66/staging/src/k8s.io/apimachinery/pkg/runtime/converter.go#L505
+	// and is intended to replace it.
+
+	// Check if the object has a custom string converter and use it if available, since it is much more efficient
+	// than round tripping through json.
+	if converter, ok := e.getUnstructuredConverter(sv); ok {
+		return converter.ToUnstructured(), nil
+	}
+	// Check if the object has a custom JSON marshaller/unmarshaller.
+	if marshaler, ok := e.getJsonMarshaler(sv); ok {
+		if sv.Kind() == reflect.Ptr && sv.IsNil() {
+			// We're done - we don't need to store anything.
+			return nil, nil
+		}
+
+		data, err := marshaler.MarshalJSON()
+		if err != nil {
+			return nil, err
+		}
+		switch {
+		case len(data) == 0:
+			return nil, fmt.Errorf("error decoding from json: empty value")
+
+		case bytes.Equal(data, nullBytes):
+			// We're done - we don't need to store anything.
+			return nil, nil
+
+		case bytes.Equal(data, trueBytes):
+			return true, nil
+
+		case bytes.Equal(data, falseBytes):
+			return false, nil
+
+		case data[0] == '"':
+			var result string
+			err := json.Unmarshal(data, &result)
+			if err != nil {
+				return nil, fmt.Errorf("error decoding string from json: %v", err)
+			}
+			return result, nil
+
+		case data[0] == '{':
+			result := make(map[string]interface{})
+			err := json.Unmarshal(data, &result)
+			if err != nil {
+				return nil, fmt.Errorf("error decoding object from json: %v", err)
+			}
+			return result, nil
+
+		case data[0] == '[':
+			result := make([]interface{}, 0)
+			err := json.Unmarshal(data, &result)
+			if err != nil {
+				return nil, fmt.Errorf("error decoding array from json: %v", err)
+			}
+			return result, nil
+
+		default:
+			var (
+				resultInt   int64
+				resultFloat float64
+				err         error
+			)
+			if err = json.Unmarshal(data, &resultInt); err == nil {
+				return resultInt, nil
+			} else if err = json.Unmarshal(data, &resultFloat); err == nil {
+				return resultFloat, nil
+			} else {
+				return nil, fmt.Errorf("error decoding number from json: %v", err)
+			}
+		}
+	}
+
+	return nil, fmt.Errorf("provided type cannot be converted: %v", sv.Type())
+}
+
+// CanConvertFromUnstructured returns true if this TypeReflectCacheEntry can convert objects of the type from unstructured.
+func (e TypeReflectCacheEntry) CanConvertFromUnstructured() bool {
+	return e.isJsonUnmarshaler
+}
+
+// FromUnstructured converts the provided source value from unstructured into the provided destination value.
+func (e TypeReflectCacheEntry) FromUnstructured(sv, dv reflect.Value) error {
+	// TODO: this could be made much more efficient using direct conversions like
+	// UnstructuredConverter.ToUnstructured provides.
+	st := dv.Type()
+	data, err := json.Marshal(sv.Interface())
+	if err != nil {
+		return fmt.Errorf("error encoding %s to json: %v", st.String(), err)
+	}
+	if unmarshaler, ok := e.getJsonUnmarshaler(dv); ok {
+		return unmarshaler.UnmarshalJSON(data)
+	}
+	return fmt.Errorf("unable to unmarshal %v into %v", sv.Type(), dv.Type())
+}
+
+var (
+	nullBytes  = []byte("null")
+	trueBytes  = []byte("true")
+	falseBytes = []byte("false")
+)
+
+func (e TypeReflectCacheEntry) getJsonMarshaler(v reflect.Value) (json.Marshaler, bool) {
+	if e.isJsonMarshaler {
+		return v.Interface().(json.Marshaler), true
+	}
+	if e.ptrIsJsonMarshaler {
+		// Check pointer receivers if v is not a pointer
+		if v.Kind() != reflect.Ptr && v.CanAddr() {
+			v = v.Addr()
+			return v.Interface().(json.Marshaler), true
+		}
+	}
+	return nil, false
+}
+
+func (e TypeReflectCacheEntry) getJsonUnmarshaler(v reflect.Value) (json.Unmarshaler, bool) {
+	if !e.isJsonUnmarshaler {
+		return nil, false
+	}
+	return v.Addr().Interface().(json.Unmarshaler), true
+}
+
+func (e TypeReflectCacheEntry) getUnstructuredConverter(v reflect.Value) (UnstructuredConverter, bool) {
+	if e.isStringConvertable {
+		return v.Interface().(UnstructuredConverter), true
+	}
+	if e.ptrIsStringConvertable {
+		// Check pointer receivers if v is not a pointer
+		if v.CanAddr() {
+			v = v.Addr()
+			return v.Interface().(UnstructuredConverter), true
+		}
+	}
+	return nil, false
+}
+
+type typeReflectCache struct {
+	// use an atomic and copy-on-write since there are a fixed (typically very small) number of structs compiled into any
+	// go program using this cache
+	value atomic.Value
+	// mu is held by writers when performing load/modify/store operations on the cache, readers do not need to hold a
+	// read-lock since the atomic value is always read-only
+	mu sync.Mutex
+}
+
+func newReflectCache() *typeReflectCache {
+	cache := &typeReflectCache{}
+	cache.value.Store(make(reflectCacheMap))
+	return cache
+}
+
+type reflectCacheMap map[reflect.Type]TypeReflectCacheEntry
+
+// get returns true and TypeReflectCacheEntry for the given type if the type is in the cache. Otherwise get returns false.
+func (c *typeReflectCache) get(t reflect.Type) (TypeReflectCacheEntry, bool) {
+	entry, ok := c.value.Load().(reflectCacheMap)[t]
+	return entry, ok
+}
+
+// update sets the TypeReflectCacheEntry for the given type via a copy-on-write update to the struct cache.
+func (c *typeReflectCache) update(t reflect.Type, m TypeReflectCacheEntry) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	currentCacheMap := c.value.Load().(reflectCacheMap)
+	if _, ok := currentCacheMap[t]; ok {
+		// Bail if the entry has been set while waiting for lock acquisition.
+		// This is safe since setting entries is idempotent.
+		return
+	}
+
+	newCacheMap := make(reflectCacheMap, len(currentCacheMap)+1)
+	for k, v := range currentCacheMap {
+		newCacheMap[k] = v
+	}
+	newCacheMap[t] = m
+	c.value.Store(newCacheMap)
+}

--- a/value/structreflect.go
+++ b/value/structreflect.go
@@ -19,113 +19,7 @@ package value
 import (
 	"fmt"
 	"reflect"
-	"sync"
-	"sync/atomic"
 )
-
-// reflectStructCache keeps track of json tag related data for structs and fields to speed up reflection.
-// TODO: This overlaps in functionality with the fieldCache in
-// https://github.com/kubernetes/kubernetes/blob/master/staging/src/k8s.io/apimachinery/pkg/runtime/converter.go#L57 but
-// is more efficient at lookup by json field name. The logic should be consolidated. Only one copy of the cache needs
-// to be kept for each running process.
-var (
-	reflectStructCache = newStructCache()
-)
-
-type structCache struct {
-	// use an atomic and copy-on-write since there are a fixed (typically very small) number of structs compiled into any
-	// go program using this cache
-	value atomic.Value
-	// mu is held by writers when performing load/modify/store operations on the cache, readers do not need to hold a
-	// read-lock since the atomic value is always read-only
-	mu sync.Mutex
-}
-
-type structCacheMap map[reflect.Type]structCacheEntry
-
-// structCacheEntry contains information about each struct field, keyed by json field name, that is expensive to
-// compute using reflection.
-type structCacheEntry map[string]*fieldCacheEntry
-
-// Get returns true and fieldCacheEntry for the given type if the type is in the cache. Otherwise Get returns false.
-func (c *structCache) Get(t reflect.Type) (map[string]*fieldCacheEntry, bool) {
-	entry, ok := c.value.Load().(structCacheMap)[t]
-	return entry, ok
-}
-
-// Set sets the fieldCacheEntry for the given type via a copy-on-write update to the struct cache.
-func (c *structCache) Set(t reflect.Type, m map[string]*fieldCacheEntry) {
-	c.mu.Lock()
-	defer c.mu.Unlock()
-
-	currentCacheMap := c.value.Load().(structCacheMap)
-
-	if _, ok := currentCacheMap[t]; ok {
-		// Bail if the entry has been set while waiting for lock acquisition.
-		// This is safe since setting entries is idempotent.
-		return
-	}
-
-	newCacheMap := make(structCacheMap, len(currentCacheMap)+1)
-	for k, v := range currentCacheMap {
-		newCacheMap[k] = v
-	}
-	newCacheMap[t] = m
-	c.value.Store(newCacheMap)
-}
-
-func newStructCache() *structCache {
-	cache := &structCache{}
-	cache.value.Store(make(structCacheMap))
-	return cache
-}
-
-type fieldCacheEntry struct {
-	// isOmitEmpty is true if the field has the json 'omitempty' tag.
-	isOmitEmpty bool
-	// fieldPath is the field indices (see FieldByIndex) to lookup the value of
-	// a field in a reflect.Value struct. A path of field indices is used
-	// to support traversing to a field field in struct fields that have the 'inline'
-	// json tag.
-	fieldPath [][]int
-}
-
-func (f *fieldCacheEntry) getFieldFromStruct(structVal reflect.Value) reflect.Value {
-	// field might be field within 'inline' structs
-	for _, elem := range f.fieldPath {
-		structVal = structVal.FieldByIndex(elem)
-	}
-	return structVal
-}
-
-func getStructCacheEntry(t reflect.Type) structCacheEntry {
-	if hints, ok := reflectStructCache.Get(t); ok {
-		return hints
-	}
-
-	hints := map[string]*fieldCacheEntry{}
-	buildStructCacheEntry(t, hints, nil)
-
-	reflectStructCache.Set(t, hints)
-	return hints
-}
-
-func buildStructCacheEntry(t reflect.Type, infos map[string]*fieldCacheEntry, fieldPath [][]int) {
-	for i := 0; i < t.NumField(); i++ {
-		field := t.Field(i)
-		jsonName, omit, isInline, isOmitempty := lookupJsonTags(field)
-		if omit {
-			continue
-		}
-		if isInline {
-			buildStructCacheEntry(field.Type, infos, append(fieldPath, field.Index))
-			continue
-		}
-		info := &fieldCacheEntry{isOmitEmpty: isOmitempty, fieldPath: append(fieldPath, field.Index)}
-		infos[jsonName] = info
-
-	}
-}
 
 type structReflect struct {
 	valueReflect
@@ -142,7 +36,7 @@ func (r structReflect) Length() int {
 
 func (r structReflect) Get(key string) (Value, bool) {
 	if val, ok, _ := r.findJsonNameField(key); ok {
-		return mustWrapValueReflect(val), true
+		return mustWrapValueReflect(val, nil, nil), true
 	}
 	return nil, false
 }
@@ -153,28 +47,28 @@ func (r structReflect) Has(key string) bool {
 }
 
 func (r structReflect) Set(key string, val Value) {
-	fieldEntry, ok := getStructCacheEntry(r.Value.Type())[key]
+	fieldEntry, ok := TypeReflectEntryOf(r.Value.Type()).Fields()[key]
 	if !ok {
 		panic(fmt.Sprintf("key %s may not be set on struct %T: field does not exist", key, r.Value.Interface()))
 	}
-	oldVal := fieldEntry.getFieldFromStruct(r.Value)
+	oldVal := fieldEntry.GetFrom(r.Value)
 	newVal := reflect.ValueOf(val.Unstructured())
 	r.update(fieldEntry, key, oldVal, newVal)
 }
 
 func (r structReflect) Delete(key string) {
-	fieldEntry, ok := getStructCacheEntry(r.Value.Type())[key]
+	fieldEntry, ok := TypeReflectEntryOf(r.Value.Type()).Fields()[key]
 	if !ok {
 		panic(fmt.Sprintf("key %s may not be deleted on struct %T: field does not exist", key, r.Value.Interface()))
 	}
-	oldVal := fieldEntry.getFieldFromStruct(r.Value)
+	oldVal := fieldEntry.GetFrom(r.Value)
 	if oldVal.Kind() != reflect.Ptr && !fieldEntry.isOmitEmpty {
 		panic(fmt.Sprintf("key %s may not be deleted on struct: %T: value is neither a pointer nor an omitempty field", key, r.Value.Interface()))
 	}
 	r.update(fieldEntry, key, oldVal, reflect.Zero(oldVal.Type()))
 }
 
-func (r structReflect) update(fieldEntry *fieldCacheEntry, key string, oldVal, newVal reflect.Value) {
+func (r structReflect) update(fieldEntry *FieldCacheEntry, key string, oldVal, newVal reflect.Value) {
 	if oldVal.CanSet() {
 		oldVal.Set(newVal)
 		return
@@ -187,7 +81,7 @@ func (r structReflect) update(fieldEntry *fieldCacheEntry, key string, oldVal, n
 			panic("ParentMapKey must not be nil if ParentMap is not nil")
 		}
 		replacement := reflect.New(r.Value.Type()).Elem()
-		fieldEntry.getFieldFromStruct(replacement).Set(newVal)
+		fieldEntry.GetFrom(replacement).Set(newVal)
 		r.ParentMap.SetMapIndex(*r.ParentMapKey, replacement)
 		return
 	}
@@ -201,13 +95,13 @@ func (r structReflect) Iterate(fn func(string, Value) bool) bool {
 	vr := reflectPool.Get().(*valueReflect)
 	defer vr.Recycle()
 	return eachStructField(r.Value, func(s string, value reflect.Value) bool {
-		return fn(s, vr.reuse(value))
+		return fn(s, vr.mustReuse(value, nil, nil))
 	})
 }
 
 func eachStructField(structVal reflect.Value, fn func(string, reflect.Value) bool) bool {
-	for jsonName, fieldCacheEntry := range getStructCacheEntry(structVal.Type()) {
-		fieldVal := fieldCacheEntry.getFieldFromStruct(structVal)
+	for jsonName, fieldCacheEntry := range TypeReflectEntryOf(structVal.Type()).Fields() {
+		fieldVal := fieldCacheEntry.GetFrom(structVal)
 		if fieldCacheEntry.isOmitEmpty && (safeIsNil(fieldVal) || isZero(fieldVal)) {
 			// omit it
 			continue
@@ -243,7 +137,7 @@ func (r structReflect) Equals(m Map) bool {
 		return true
 	}
 
-	structCacheEntry := getStructCacheEntry(r.Value.Type())
+	structCacheEntry := TypeReflectEntryOf(r.Value.Type()).Fields()
 	vr := reflectPool.Get().(*valueReflect)
 	defer vr.Recycle()
 	return m.Iterate(func(s string, value Value) bool {
@@ -251,26 +145,26 @@ func (r structReflect) Equals(m Map) bool {
 		if !ok {
 			return false
 		}
-		lhsVal := fieldCacheEntry.getFieldFromStruct(r.Value)
-		return Equals(vr.reuse(lhsVal), value)
+		lhsVal := fieldCacheEntry.GetFrom(r.Value)
+		return Equals(vr.mustReuse(lhsVal, nil, nil), value)
 	})
 }
 
 func (r structReflect) findJsonNameFieldAndNotEmpty(jsonName string) (reflect.Value, bool) {
-	structCacheEntry, ok := getStructCacheEntry(r.Value.Type())[jsonName]
+	structCacheEntry, ok := TypeReflectEntryOf(r.Value.Type()).Fields()[jsonName]
 	if !ok {
 		return reflect.Value{}, false
 	}
-	fieldVal := structCacheEntry.getFieldFromStruct(r.Value)
+	fieldVal := structCacheEntry.GetFrom(r.Value)
 	omit := structCacheEntry.isOmitEmpty && (safeIsNil(fieldVal) || isZero(fieldVal))
 	return fieldVal, !omit
 }
 
 func (r structReflect) findJsonNameField(jsonName string) (val reflect.Value, ok bool, omitEmpty bool) {
-	structCacheEntry, ok := getStructCacheEntry(r.Value.Type())[jsonName]
+	structCacheEntry, ok := TypeReflectEntryOf(r.Value.Type()).Fields()[jsonName]
 	if !ok {
 		return reflect.Value{}, false, false
 	}
-	fieldVal := structCacheEntry.getFieldFromStruct(r.Value)
+	fieldVal := structCacheEntry.GetFrom(r.Value)
 	return fieldVal, true, structCacheEntry.isOmitEmpty
 }


### PR DESCRIPTION
Extend the reflection cache introduced in https://github.com/kubernetes-sigs/structured-merge-diff/pull/136 to also track if a type implements `json.Marshal` and `json.Unmarshal`.

Changes:
- Avoid expensive `reflect.Implements` check on every object being converted by caching implements checks.
- Introduce a `UnstructuredConverter` interface that types like `Time` and `Quantity` can implement to directly convert to unstructured without going through JSON.

Net improvement is roughly 25% for CPU and 20% for allocations for `ObjectToTyped` and about 10% for CPU and allocations for `ToUnstructured`/ `FromUnstructured`.

This has been implemented such that `runtime.ToUnstructured` in `kubernetes/kubernetes` can be trivially modified to use this improvement simply by doing:

```
entry := value.TypeReflectEntryOf(sv.Type())
if entry.CanConvertToUnstructured() {
	v, err := entry.ToUnstructured(sv)
	if err != nil {
		return err
	}
	if v != nil {
		dv.Set(reflect.ValueOf(v))
	}
	return nil
}
```

We will adopt this change up in `kubernetes/kubernetes` in a follow up PR. We will use it instead of [the existing reflection cache in kubernetes for unstructured conversion](https://github.com/kubernetes/kubernetes/blob/dc090f80d14a04eecfe3e46bb5e9e17ed13b5356/staging/src/k8s.io/apimachinery/pkg/runtime/converter.go#L57) and get the performance boost for all `ToUnstructured`/ `FromUnstructured` conversions performed by kubernetes.

Example of using `UnstructuredConverter` to optimize a type:

```
func (t Time) ToUnstructured() interface{} {
	if t.IsZero() {
		return nil
	}
	buf := make([]byte, 0, len(time.RFC3339))
	buf = t.UTC().AppendFormat(buf, time.RFC3339)
	return string(buf)
}
```

We plan to initially adopt `UnstructuredConverter` for `Time` and `Quantity` since they are the most heavily used. We can incrementally optimize or other `json.Marshal` types like `IntToString` as needed.

Baseline:

```
BenchmarkConvertObjectToTyped/Pod/structured-12                    61731             97134 ns/op           11206 B/op        288 allocs/op
BenchmarkConvertObjectToTyped/Pod/unstructured-12                  43767            134630 ns/op           25996 B/op        473 allocs/op
BenchmarkConvertObjectToTyped/Node/structured-12                   29714            201174 ns/op           31905 B/op        737 allocs/op
BenchmarkConvertObjectToTyped/Node/unstructured-12                 23811            252946 ns/op           53644 B/op       1155 allocs/op
BenchmarkConvertObjectToTyped/Endpoints/structured-12               1952           3205514 ns/op          306575 B/op       7041 allocs/op
BenchmarkConvertObjectToTyped/Endpoints/unstructured-12             1524           4241015 ns/op          981595 B/op      16072 allocs/op
```

With optimizations enabled:

```
BenchmarkConvertObjectToTyped/Pod/structured-12                    83481             72445 ns/op            8677 B/op        232 allocs/op
 BenchmarkConvertObjectToTyped/Pod/unstructured-12                  49674            123063 ns/op           24211 B/op        443 allocs/op
 BenchmarkConvertObjectToTyped/Node/structured-12                   43626            136374 ns/op           21611 B/op        538 allocs/op
 BenchmarkConvertObjectToTyped/Node/unstructured-12                 27535            213865 ns/op           45515 B/op       1037 allocs/op
 BenchmarkConvertObjectToTyped/Endpoints/structured-12               2238           2595218 ns/op          306162 B/op       7035 allocs/op
 BenchmarkConvertObjectToTyped/Endpoints/unstructured-12             1515           3989870 ns/op          981368 B/op      16069 allocs/op
```

/sig api-machinery