### PR TITLE
Optimize TypedValue.Compare for value reflector

### DIFF
--- a/typed/helpers.go
+++ b/typed/helpers.go
@@ -191,8 +191,10 @@ func keyedAssociativeListItemToPathElement(list *schema.List, index int, child v
 		return pe, errors.New("associative list with keys may not have non-map elements")
 	}
 	keyMap := value.FieldList{}
+	m := child.AsMap()
+	defer m.Recycle()
 	for _, fieldName := range list.Keys {
-		if val, ok := child.AsMap().Get(fieldName); ok {
+		if val, ok := m.Get(fieldName); ok {
 			keyMap = append(keyMap, value.Field{Name: fieldName, Value: val})
 		} else {
 			return pe, fmt.Errorf("associative list with keys has an element that omits key field %q", fieldName)

--- a/typed/merge.go
+++ b/typed/merge.go
@@ -148,18 +148,15 @@ func (w *mergingWalker) finishDescent(w2 *mergingWalker) {
 	*w.spareWalkers = append(*w.spareWalkers, w2)
 }
 
-func (w *mergingWalker) derefMap(prefix string, v value.Value, dest *value.Map) (errs ValidationErrors) {
-	// taking dest as input so that it can be called as a one-liner with
-	// append.
+func (w *mergingWalker) derefMap(prefix string, v value.Value) (value.Map, ValidationErrors) {
 	if v == nil {
-		return nil
+		return nil, nil
 	}
 	m, err := mapValue(v)
 	if err != nil {
-		return errorf("%v: %v", prefix, err)
+		return nil, errorf("%v: %v", prefix, err)
 	}
-	*dest = m
-	return nil
+	return m, nil
 }
 
 func (w *mergingWalker) visitListItems(t *schema.List, lhs, rhs value.List) (errs ValidationErrors) {
@@ -253,24 +250,26 @@ func (w *mergingWalker) visitListItems(t *schema.List, lhs, rhs value.List) (err
 	return errs
 }
 
-func (w *mergingWalker) derefList(prefix string, v value.Value, dest *value.List) (errs ValidationErrors) {
-	// taking dest as input so that it can be called as a one-liner with
-	// append.
+func (w *mergingWalker) derefList(prefix string, v value.Value) (value.List, ValidationErrors) {
 	if v == nil {
-		return nil
+		return nil, nil
 	}
 	l, err := listValue(v)
 	if err != nil {
-		return errorf("%v: %v", prefix, err)
+		return nil, errorf("%v: %v", prefix, err)
 	}
-	*dest = l
-	return nil
+	return l, nil
 }
 
 func (w *mergingWalker) doList(t *schema.List) (errs ValidationErrors) {
-	var lhs, rhs value.List
-	w.derefList("lhs: ", w.lhs, &lhs)
-	w.derefList("rhs: ", w.rhs, &rhs)
+	lhs, _ := w.derefList("lhs: ", w.lhs)
+	if lhs != nil {
+		defer lhs.Recycle()
+	}
+	rhs, _ := w.derefList("rhs: ", w.rhs)
+	if rhs != nil {
+		defer rhs.Recycle()
+	}
 
 	// If both lhs and rhs are empty/null, treat it as a
 	// leaf: this helps preserve the empty/null
@@ -311,31 +310,10 @@ func (w *mergingWalker) visitMapItem(t *schema.Map, out map[string]interface{}, 
 func (w *mergingWalker) visitMapItems(t *schema.Map, lhs, rhs value.Map) (errs ValidationErrors) {
 	out := map[string]interface{}{}
 
-	if lhs != nil {
-		lhs.Iterate(func(key string, val value.Value) bool {
-			var rval value.Value
-			if rhs != nil {
-				if item, ok := rhs.Get(key); ok {
-					rval = item
-					defer rval.Recycle()
-				}
-			}
-			errs = append(errs, w.visitMapItem(t, out, key, val, rval)...)
-			return true
-		})
-	}
-
-	if rhs != nil {
-		rhs.Iterate(func(key string, val value.Value) bool {
-			if lhs != nil {
-				if lhs.Has(key) {
-					return true
-				}
-			}
-			errs = append(errs, w.visitMapItem(t, out, key, nil, val)...)
-			return true
-		})
-	}
+	value.MapZip(lhs, rhs, value.Unordered, func(key string, lhsValue, rhsValue value.Value) bool {
+		errs = append(errs, w.visitMapItem(t, out, key, lhsValue, rhsValue)...)
+		return true
+	})
 	if len(out) > 0 {
 		i := interface{}(out)
 		w.out = &i
@@ -345,14 +323,18 @@ func (w *mergingWalker) visitMapItems(t *schema.Map, lhs, rhs value.Map) (errs V
 }
 
 func (w *mergingWalker) doMap(t *schema.Map) (errs ValidationErrors) {
-	var lhs, rhs value.Map
-	w.derefMap("lhs: ", w.lhs, &lhs)
-	w.derefMap("rhs: ", w.rhs, &rhs)
-
+	lhs, _ := w.derefMap("lhs: ", w.lhs)
+	if lhs != nil {
+		defer lhs.Recycle()
+	}
+	rhs, _ := w.derefMap("rhs: ", w.rhs)
+	if rhs != nil {
+		defer rhs.Recycle()
+	}
 	// If both lhs and rhs are empty/null, treat it as a
 	// leaf: this helps preserve the empty/null
 	// distinction.
-	emptyPromoteToLeaf := (lhs == nil || lhs.Length() == 0) && (rhs == nil || rhs.Length() == 0)
+	emptyPromoteToLeaf := (lhs == nil || lhs.Empty()) && (rhs == nil || rhs.Empty())
 
 	if t.ElementRelationship == schema.Atomic || emptyPromoteToLeaf {
 		w.doLeaf()

--- a/typed/remove.go
+++ b/typed/remove.go
@@ -43,7 +43,7 @@ func (w *removingWalker) doScalar(t *schema.Scalar) ValidationErrors {
 
 func (w *removingWalker) doList(t *schema.List) (errs ValidationErrors) {
 	l := w.value.AsList()
-
+	defer l.Recycle()
 	// If list is null, empty, or atomic just return
 	if l == nil || l.Length() == 0 || t.ElementRelationship == schema.Atomic {
 		return nil
@@ -73,9 +73,11 @@ func (w *removingWalker) doList(t *schema.List) (errs ValidationErrors) {
 
 func (w *removingWalker) doMap(t *schema.Map) ValidationErrors {
 	m := w.value.AsMap()
-
+	if m != nil {
+		defer m.Recycle()
+	}
 	// If map is null, empty, or atomic just return
-	if m == nil || m.Length() == 0 || t.ElementRelationship == schema.Atomic {
+	if m == nil || m.Empty() || t.ElementRelationship == schema.Atomic {
 		return nil
 	}
 

--- a/typed/tofieldset.go
+++ b/typed/tofieldset.go
@@ -144,7 +144,9 @@ func (v *toFieldSetWalker) visitMapItems(t *schema.Map, m value.Map) (errs Valid
 
 func (v *toFieldSetWalker) doMap(t *schema.Map) (errs ValidationErrors) {
 	m, _ := mapValue(v.value)
-
+	if m != nil {
+		defer m.Recycle()
+	}
 	if t.ElementRelationship == schema.Atomic {
 		v.set.Insert(v.path)
 		return nil

--- a/typed/validate.go
+++ b/typed/validate.go
@@ -179,11 +179,10 @@ func (v *validatingObjectWalker) doMap(t *schema.Map) (errs ValidationErrors) {
 	if err != nil {
 		return errorf(err.Error())
 	}
-
 	if m == nil {
 		return nil
 	}
-
+	defer m.Recycle()
 	errs = v.visitMapItems(t, m)
 
 	return errs

--- a/value/list.go
+++ b/value/list.go
@@ -25,6 +25,13 @@ type List interface {
 	At(int) Value
 	// Range returns a ListRange for iterating over the items in the list.
 	Range() ListRange
+
+	// Equals compares the two list, and return true if they are the same, false otherwise.
+	// Implementations can use ListEquals as a general implementation for this methods.
+	Equals(List) bool
+	// Recycle gives back this List once it is no longer needed. The
+	// value shouldn't be used after this call.
+	Recycle()
 }
 
 // ListRange represents a single iteration across the items of a list.
@@ -36,7 +43,7 @@ type ListRange interface {
 	// pointers to the value returned by Item() that escape the iteration loop since they become invalid once either
 	// Item() or Recycle() is called.
 	Item() (index int, value Value)
-	// Recycle returns a ListRange that is no longer needed. The value returned by Item() becomes invalid once this is
+	// Recycle gives back this ListRange once it is no longer needed. The value returned by Item() becomes invalid once this is
 	// called.
 	Recycle()
 }
@@ -56,6 +63,7 @@ func (_ *emptyRange) Item() (index int, value Value) {
 func (_ *emptyRange) Recycle() {}
 
 // ListEquals compares two lists lexically.
+// WARN: This is a naive implementation, calling lhs.Equals(rhs) is typically the most efficient.
 func ListEquals(lhs, rhs List) bool {
 	if lhs.Length() != rhs.Length() {
 		return false

--- a/value/listunstructured.go
+++ b/value/listunstructured.go
@@ -28,10 +28,18 @@ func (l listUnstructured) At(i int) Value {
 	return NewValueInterface(l[i])
 }
 
+func (l listUnstructured) Equals(other List) bool {
+	return ListEquals(&l, other)
+}
+
 var lurPool = sync.Pool{
 	New: func() interface{} {
 		return &listUnstructuredRange{vv: &valueUnstructured{}}
 	},
+}
+
+func (_ listUnstructured) Recycle() {
+
 }
 
 func (l listUnstructured) Range() ListRange {

--- a/value/map.go
+++ b/value/map.go
@@ -18,7 +18,6 @@ package value
 
 import (
 	"sort"
-	"strings"
 )
 
 // Map represents a Map or go structure.
@@ -40,6 +39,139 @@ type Map interface {
 	Iterate(func(key string, value Value) bool) bool
 	// Length returns the number of items in the map.
 	Length() int
+	// Empty returns true if the map is empty.
+	Empty() bool
+	// Zip iterates over the entries of two maps together. If both maps contain a value for a given key, fn is called
+	// with the values from both maps, otherwise it is called with the value of the map that contains the key and nil
+	// for the map that does not contain the key. Returning false in the closure prematurely stops the iteration.
+	Zip(other Map, order MapTraverseOrder, fn func(key string, lhs, rhs Value) bool) bool
+	// Recycle gives back this Map once it is no longer needed. The
+	// value shouldn't be used after this call.
+	Recycle()
+}
+
+// MapTraverseOrder defines the map traversal ordering available.
+type MapTraverseOrder int
+
+const (
+	// Unordered indicates that the map traversal has no ordering requirement.
+	Unordered = iota
+	// LexicalKeyOrder indicates that the map traversal is ordered by key, lexically.
+	LexicalKeyOrder
+)
+
+// MapZip iterates over the entries of two maps together. If both maps contain a value for a given key, fn is called
+// with the values from both maps, otherwise it is called with the value of the map that contains the key and nil
+// for the other map. Returning false in the closure prematurely stops the iteration.
+func MapZip(lhs, rhs Map, order MapTraverseOrder, fn func(key string, lhs, rhs Value) bool) bool {
+	if lhs != nil {
+		return lhs.Zip(rhs, order, fn)
+	}
+	if rhs != nil {
+		return rhs.Zip(lhs, order, func(key string, rhs, lhs Value) bool { // arg positions of lhs and rhs deliberately swapped
+			return fn(key, lhs, rhs)
+		})
+	}
+	return true
+}
+
+// defaultMapZip provides a default implementation of Zip for implementations that do not need to provide
+// their own optimized implementation.
+func defaultMapZip(lhs, rhs Map, order MapTraverseOrder, fn func(key string, lhs, rhs Value) bool) bool {
+	switch order {
+	case Unordered:
+		return unorderedMapZip(lhs, rhs, fn)
+	case LexicalKeyOrder:
+		return lexicalKeyOrderedMapZip(lhs, rhs, fn)
+	default:
+		panic("Unsupported map order")
+	}
+}
+
+func unorderedMapZip(lhs, rhs Map, fn func(key string, lhs, rhs Value) bool) bool {
+	if (lhs == nil || lhs.Empty()) && (rhs == nil || rhs.Empty()) {
+		return true
+	}
+
+	if lhs != nil {
+		ok := lhs.Iterate(func(key string, lhsValue Value) bool {
+			var rhsValue Value
+			if rhs != nil {
+				if item, ok := rhs.Get(key); ok {
+					rhsValue = item
+					defer rhsValue.Recycle()
+				}
+			}
+			return fn(key, lhsValue, rhsValue)
+		})
+		if !ok {
+			return false
+		}
+	}
+	if rhs != nil {
+		return rhs.Iterate(func(key string, rhsValue Value) bool {
+			if lhs == nil || !lhs.Has(key) {
+				return fn(key, nil, rhsValue)
+			}
+			return true
+		})
+	}
+	return true
+}
+
+func lexicalKeyOrderedMapZip(lhs, rhs Map, fn func(key string, lhs, rhs Value) bool) bool {
+	var lhsLength, rhsLength int
+	var orderedLength int // rough estimate of length of union of map keys
+	if lhs != nil {
+		lhsLength = lhs.Length()
+		orderedLength = lhsLength
+	}
+	if rhs != nil {
+		rhsLength = rhs.Length()
+		if rhsLength > orderedLength {
+			orderedLength = rhsLength
+		}
+	}
+	if lhsLength == 0 && rhsLength == 0 {
+		return true
+	}
+
+	ordered := make([]string, 0, orderedLength)
+	if lhs != nil {
+		lhs.Iterate(func(key string, _ Value) bool {
+			ordered = append(ordered, key)
+			return true
+		})
+	}
+	if rhs != nil {
+		rhs.Iterate(func(key string, _ Value) bool {
+			if lhs == nil || !lhs.Has(key) {
+				ordered = append(ordered, key)
+			}
+			return true
+		})
+	}
+	sort.Strings(ordered)
+	for _, key := range ordered {
+		var litem, ritem Value
+		if lhs != nil {
+			litem, _ = lhs.Get(key)
+		}
+		if rhs != nil {
+			ritem, _ = rhs.Get(key)
+		}
+		ok := fn(key, litem, ritem)
+		if litem != nil {
+			litem.Recycle()
+		}
+		if ritem != nil {
+			ritem.Recycle()
+		}
+		if !ok {
+			return false
+		}
+	}
+	return true
 }
 
 // MapLess compares two maps lexically.
@@ -49,68 +181,55 @@ func MapLess(lhs, rhs Map) bool {
 
 // MapCompare compares two maps lexically.
 func MapCompare(lhs, rhs Map) int {
-	lorder := make([]string, 0, lhs.Length())
-	lhs.Iterate(func(key string, _ Value) bool {
-		lorder = append(lorder, key)
-		return true
-	})
-	sort.Strings(lorder)
-	rorder := make([]string, 0, rhs.Length())
-	rhs.Iterate(func(key string, _ Value) bool {
-		rorder = append(rorder, key)
-		return true
-	})
-	sort.Strings(rorder)
-
-	i := 0
-	for {
-		if i >= len(lorder) && i >= len(rorder) {
-			// Maps are the same length and all items are equal.
-			return 0
-		}
-		if i >= len(lorder) {
-			// LHS is shorter.
-			return -1
-		}
-		if i >= len(rorder) {
-			// RHS is shorter.
-			return 1
-		}
-		if c := strings.Compare(lorder[i], rorder[i]); c != 0 {
-			return c
-		}
-		litem, _ := lhs.Get(lorder[i])
-		ritem, _ := rhs.Get(rorder[i])
-		c := Compare(litem, ritem)
-		if litem != nil {
-			litem.Recycle()
-		}
-		if ritem != nil {
-			ritem.Recycle()
-		}
-		if c != 0 {
-			return c
-		}
-		// The items are equal; continue.
-		i++
+	c := 0
+	var llength, rlength int
+	if lhs != nil {
+		llength = lhs.Length()
 	}
+	if rhs != nil {
+		rlength = rhs.Length()
+	}
+	if llength == 0 && rlength == 0 {
+		return 0
+	}
+	i := 0
+	MapZip(lhs, rhs, LexicalKeyOrder, func(key string, lhs, rhs Value) bool {
+		switch {
+		case i == llength:
+			c = -1
+		case i == rlength:
+			c = 1
+		case lhs == nil:
+			c = 1
+		case rhs == nil:
+			c = -1
+		default:
+			c = Compare(lhs, rhs)
+		}
+		i++
+		return c == 0
+	})
+	return c
 }
 
 // MapEquals returns true if lhs == rhs, false otherwise. This function
 // acts on generic types and should not be used by callers, but can help
 // implement Map.Equals.
-// WARN: This is a naive implementation, calling lhs.Equals(rhs) is typically far more efficient.
+// WARN: This is a naive implementation, calling lhs.Equals(rhs) is typically the most efficient.
 func MapEquals(lhs, rhs Map) bool {
+	if lhs == nil && rhs == nil {
+		return true
+	}
+	if lhs == nil || rhs == nil {
+		return false
+	}
 	if lhs.Length() != rhs.Length() {
 		return false
 	}
-	return lhs.Iterate(func(k string, v Value) bool {
-		vo, ok := rhs.Get(k)
-		if !ok {
+	return MapZip(lhs, rhs, Unordered, func(key string, lhs, rhs Value) bool {
+		if lhs == nil || rhs == nil {
 			return false
 		}
-		equal := Equals(v, vo)
-		vo.Recycle()
-		return equal
+		return Equals(lhs, rhs)
 	})
 }

--- a/value/mapunstructured.go
+++ b/value/mapunstructured.go
@@ -61,6 +61,10 @@ func (m mapUnstructuredInterface) Length() int {
 	return len(m)
 }
 
+func (m mapUnstructuredInterface) Empty() bool {
+	return len(m) == 0
+}
+
 func (m mapUnstructuredInterface) Equals(other Map) bool {
 	lhsLength := m.Length()
 	rhsLength := other.Length()
@@ -79,6 +83,14 @@ func (m mapUnstructuredInterface) Equals(other Map) bool {
 		}
 		return Equals(vv.reuse(lhsVal), value)
 	})
+}
+
+func (m mapUnstructuredInterface) Zip(other Map, order MapTraverseOrder, fn func(key string, lhs, rhs Value) bool) bool {
+	return defaultMapZip(m, other, order, fn)
+}
+
+func (m mapUnstructuredInterface) Recycle() {
+
 }
 
 type mapUnstructuredString map[string]interface{}
@@ -140,4 +152,16 @@ func (m mapUnstructuredString) Equals(other Map) bool {
 		}
 		return Equals(vv.reuse(lhsVal), value)
 	})
+}
+
+func (m mapUnstructuredString) Zip(other Map, order MapTraverseOrder, fn func(key string, lhs, rhs Value) bool) bool {
+	return defaultMapZip(m, other, order, fn)
+}
+
+func (m mapUnstructuredString) Recycle() {
+
+}
+
+func (m mapUnstructuredString) Empty() bool {
+	return len(m) == 0
 }

--- a/value/value.go
+++ b/value/value.go
@@ -71,7 +71,7 @@ type Value interface {
 	// doesn't allow it).
 	AsString() string
 
-	// Recycle returns a value of this type that is no longer needed. The
+	// Recycle gives back this Value once it is no longer needed. The
 	// value shouldn't be used after this call.
 	Recycle()
 
@@ -173,7 +173,11 @@ func Equals(lhs, rhs Value) bool {
 	}
 	if lhs.IsList() {
 		if rhs.IsList() {
-			return ListEquals(lhs.AsList(), rhs.AsList())
+			lhsList := lhs.AsList()
+			defer lhsList.Recycle()
+			rhsList := rhs.AsList()
+			defer rhsList.Recycle()
+			return lhsList.Equals(rhsList)
 		}
 		return false
 	} else if rhs.IsList() {
@@ -181,7 +185,11 @@ func Equals(lhs, rhs Value) bool {
 	}
 	if lhs.IsMap() {
 		if rhs.IsMap() {
-			return lhs.AsMap().Equals(rhs.AsMap())
+			lhsList := lhs.AsMap()
+			defer lhsList.Recycle()
+			rhsList := rhs.AsMap()
+			defer rhsList.Recycle()
+			return lhsList.Equals(rhsList)
 		}
 		return false
 	} else if rhs.IsMap() {
@@ -216,6 +224,7 @@ func ToString(v Value) string {
 	case v.IsList():
 		strs := []string{}
 		list := v.AsList()
+		defer list.Recycle()
 		for i := 0; i < list.Length(); i++ {
 			strs = append(strs, ToString(list.At(i)))
 		}
@@ -290,7 +299,11 @@ func Compare(lhs, rhs Value) int {
 		if !rhs.IsList() {
 			return -1
 		}
-		return ListCompare(lhs.AsList(), rhs.AsList())
+		lhsList := lhs.AsList()
+		defer lhsList.Recycle()
+		rhsList := rhs.AsList()
+		defer rhsList.Recycle()
+		return ListCompare(lhsList, rhsList)
 	} else if rhs.IsList() {
 		return 1
 	}
@@ -298,7 +311,11 @@ func Compare(lhs, rhs Value) int {
 		if !rhs.IsMap() {
 			return -1
 		}
-		return MapCompare(lhs.AsMap(), rhs.AsMap())
+		lhsMap := lhs.AsMap()
+		defer lhsMap.Recycle()
+		rhsMap := rhs.AsMap()
+		defer rhsMap.Recycle()
+		return MapCompare(lhsMap, rhsMap)
 	} else if rhs.IsMap() {
 		return 1
 	}


### PR DESCRIPTION
valueReflect uses 65% less CPU and 85% less allocations that valueUnstructured for ConvertToTyped, but for TypedValue.Compare it performs much worse:


**BEFORE:**
baseline: TypedValue.Compare using valueUnstructured
test variant: TypedValue.Compare using valueReflect
```
name               old time/op    new time/op    delta
Compare/Pod           100µs ± 3%     195µs ± 1%   +95.19%  (p=0.008 n=5+5)
Compare/Node          166µs ± 9%     280µs ± 0%   +68.38%  (p=0.008 n=5+5)
Compare/Endpoints    1.10ms ± 5%    0.02ms ± 2%   -98.39%  (p=0.008 n=5+5)

name               old alloc/op   new alloc/op   delta
Compare/Pod          11.3kB ± 0%    21.8kB ± 0%   +92.83%  (p=0.016 n=5+4)
Compare/Node         17.1kB ± 0%    40.7kB ± 0%  +137.37%  (p=0.008 n=5+5)
Compare/Endpoints    65.5kB ± 0%     2.6kB ± 0%   -96.03%  (p=0.008 n=5+5)

name               old allocs/op  new allocs/op  delta
Compare/Pod             391 ± 0%       573 ± 0%   +46.55%  (p=0.008 n=5+5)
Compare/Node            577 ± 0%      1101 ± 0%   +90.81%  (p=0.008 n=5+5)
Compare/Endpoints     2.05k ± 0%     0.07k ± 0%   -96.58%  (p=0.008 n=5+5)
```

This optimizes valueReflect for TypedValue.Compare by:
- Optimizing equals checks for lists
- Introducing a Map.Zip function that is used by typed.merge, typed.compare, map equality and map compare operations
- Optimizing Map.Zip for valueReflect
- Recycling all value.Map and value.List objects since these are not free for valueReflect

With these changes, valueReflect still underperforms valueUnstructured (except for endpoints, where it really shines), but is is considerably closer.

**AFTER:**
```
name               old time/op    new time/op    delta
Compare/Pod           100µs ± 3%     127µs ± 3%  +26.95%  (p=0.008 n=5+5)
Compare/Node          166µs ± 9%     188µs ± 4%  +13.01%  (p=0.008 n=5+5)
Compare/Endpoints    1.10ms ± 5%    0.01ms ± 6%  -98.98%  (p=0.008 n=5+5)

name               old alloc/op   new alloc/op   delta
Compare/Pod          11.3kB ± 0%    14.2kB ± 0%  +25.66%  (p=0.016 n=5+4)
Compare/Node         17.1kB ± 0%    25.4kB ± 0%  +48.19%  (p=0.008 n=5+5)
Compare/Endpoints    65.5kB ± 0%     1.7kB ± 0%  -97.37%  (p=0.008 n=5+5)

name               old allocs/op  new allocs/op  delta
Compare/Pod             391 ± 0%       433 ± 0%  +10.74%  (p=0.008 n=5+5)
Compare/Node            577 ± 0%       795 ± 0%  +37.78%  (p=0.008 n=5+5)
Compare/Endpoints     2.05k ± 0%     0.05k ± 0%  -97.36%  (p=0.008 n=5+5)
```

For the portion of the Update changed by introducing server side apply, where ConvertToTyped and TypedValue.Compare are called in series, the net gain is still a substantial win, with ~52% less CPU and 60% less allocations.