### PR TITLE
Use freelists instead of sync.Pool for value object recycling

### DIFF
--- a/typed/helpers.go
+++ b/typed/helpers.go
@@ -154,7 +154,7 @@ func handleAtom(a schema.Atom, tr schema.TypeRef, ah atomHandler) ValidationErro
 }
 
 // Returns the list, or an error. Reminder: nil is a valid list and might be returned.
-func listValue(val value.Value) (value.List, error) {
+func listValue(a value.Allocator, val value.Value) (value.List, error) {
 	if val.IsNull() {
 		// Null is a valid list.
 		return nil, nil
@@ -162,11 +162,11 @@ func listValue(val value.Value) (value.List, error) {
 	if !val.IsList() {
 		return nil, fmt.Errorf("expected list, got %v", val)
 	}
-	return val.AsList(), nil
+	return val.AsListUsing(a), nil
 }
 
 // Returns the map, or an error. Reminder: nil is a valid map and might be returned.
-func mapValue(val value.Value) (value.Map, error) {
+func mapValue(a value.Allocator, val value.Value) (value.Map, error) {
 	if val == nil {
 		return nil, fmt.Errorf("expected map, got nil")
 	}
@@ -177,10 +177,10 @@ func mapValue(val value.Value) (value.Map, error) {
 	if !val.IsMap() {
 		return nil, fmt.Errorf("expected map, got %v", val)
 	}
-	return val.AsMap(), nil
+	return val.AsMapUsing(a), nil
 }
 
-func keyedAssociativeListItemToPathElement(list *schema.List, index int, child value.Value) (fieldpath.PathElement, error) {
+func keyedAssociativeListItemToPathElement(a value.Allocator, list *schema.List, index int, child value.Value) (fieldpath.PathElement, error) {
 	pe := fieldpath.PathElement{}
 	if child.IsNull() {
 		// For now, the keys are required which means that null entries
@@ -191,8 +191,8 @@ func keyedAssociativeListItemToPathElement(list *schema.List, index int, child v
 		return pe, errors.New("associative list with keys may not have non-map elements")
 	}
 	keyMap := value.FieldList{}
-	m := child.AsMap()
-	defer m.Recycle()
+	m := child.AsMapUsing(a)
+	defer a.Free(m)
 	for _, fieldName := range list.Keys {
 		if val, ok := m.Get(fieldName); ok {
 			keyMap = append(keyMap, value.Field{Name: fieldName, Value: val})
@@ -225,10 +225,10 @@ func setItemToPathElement(list *schema.List, index int, child value.Value) (fiel
 	}
 }
 
-func listItemToPathElement(list *schema.List, index int, child value.Value) (fieldpath.PathElement, error) {
+func listItemToPathElement(a value.Allocator, list *schema.List, index int, child value.Value) (fieldpath.PathElement, error) {
 	if list.ElementRelationship == schema.Associative {
 		if len(list.Keys) > 0 {
-			return keyedAssociativeListItemToPathElement(list, index, child)
+			return keyedAssociativeListItemToPathElement(a, list, index, child)
 		}
 
 		// If there's no keys, then we must be a set of primitives.

--- a/typed/remove.go
+++ b/typed/remove.go
@@ -20,17 +20,19 @@ import (
 )
 
 type removingWalker struct {
-	value    value.Value
-	out      interface{}
-	schema   *schema.Schema
-	toRemove *fieldpath.Set
+	value     value.Value
+	out       interface{}
+	schema    *schema.Schema
+	toRemove  *fieldpath.Set
+	allocator value.Allocator
 }
 
 func removeItemsWithSchema(val value.Value, toRemove *fieldpath.Set, schema *schema.Schema, typeRef schema.TypeRef) value.Value {
 	w := &removingWalker{
-		value:    val,
-		schema:   schema,
-		toRemove: toRemove,
+		value:     val,
+		schema:    schema,
+		toRemove:  toRemove,
+		allocator: value.NewFreelistAllocator(),
 	}
 	resolveSchema(schema, typeRef, val, w)
 	return value.NewValueInterface(w.out)
@@ -42,20 +44,20 @@ func (w *removingWalker) doScalar(t *schema.Scalar) ValidationErrors {
 }
 
 func (w *removingWalker) doList(t *schema.List) (errs ValidationErrors) {
-	l := w.value.AsList()
-	defer l.Recycle()
+	l := w.value.AsListUsing(w.allocator)
+	defer w.allocator.Free(l)
 	// If list is null, empty, or atomic just return
 	if l == nil || l.Length() == 0 || t.ElementRelationship == schema.Atomic {
 		return nil
 	}
 
 	var newItems []interface{}
-	iter := l.Range()
-	defer iter.Recycle()
+	iter := l.RangeUsing(w.allocator)
+	defer w.allocator.Free(iter)
 	for iter.Next() {
 		i, item := iter.Item()
 		// Ignore error because we have already validated this list
-		pe, _ := listItemToPathElement(t, i, item)
+		pe, _ := listItemToPathElement(w.allocator, t, i, item)
 		path, _ := fieldpath.MakePath(pe)
 		if w.toRemove.Has(path) {
 			continue
@@ -72,9 +74,9 @@ func (w *removingWalker) doList(t *schema.List) (errs ValidationErrors) {
 }
 
 func (w *removingWalker) doMap(t *schema.Map) ValidationErrors {
-	m := w.value.AsMap()
+	m := w.value.AsMapUsing(w.allocator)
 	if m != nil {
-		defer m.Recycle()
+		defer w.allocator.Free(m)
 	}
 	// If map is null, empty, or atomic just return
 	if m == nil || m.Empty() || t.ElementRelationship == schema.Atomic {

--- a/typed/tofieldset.go
+++ b/typed/tofieldset.go
@@ -34,6 +34,7 @@ func (tv TypedValue) toFieldSetWalker() *toFieldSetWalker {
 	v.schema = tv.schema
 	v.typeRef = tv.typeRef
 	v.set = &fieldpath.Set{}
+	v.allocator = value.NewFreelistAllocator()
 	return v
 }
 
@@ -55,6 +56,7 @@ type toFieldSetWalker struct {
 
 	// Allocate only as many walkers as needed for the depth by storing them here.
 	spareWalkers *[]*toFieldSetWalker
+	allocator    value.Allocator
 }
 
 func (v *toFieldSetWalker) prepareDescent(pe fieldpath.PathElement, tr schema.TypeRef) *toFieldSetWalker {
@@ -94,7 +96,7 @@ func (v *toFieldSetWalker) doScalar(t *schema.Scalar) ValidationErrors {
 func (v *toFieldSetWalker) visitListItems(t *schema.List, list value.List) (errs ValidationErrors) {
 	for i := 0; i < list.Length(); i++ {
 		child := list.At(i)
-		pe, _ := listItemToPathElement(t, i, child)
+		pe, _ := listItemToPathElement(v.allocator, t, i, child)
 		v2 := v.prepareDescent(pe, t.ElementType)
 		v2.value = child
 		errs = append(errs, v2.toFieldSet()...)
@@ -106,8 +108,10 @@ func (v *toFieldSetWalker) visitListItems(t *schema.List, list value.List) (errs
 }
 
 func (v *toFieldSetWalker) doList(t *schema.List) (errs ValidationErrors) {
-	list, _ := listValue(v.value)
-
+	list, _ := listValue(v.allocator, v.value)
+	if list != nil {
+		defer v.allocator.Free(list)
+	}
 	if t.ElementRelationship == schema.Atomic {
 		v.set.Insert(v.path)
 		return nil
@@ -143,9 +147,9 @@ func (v *toFieldSetWalker) visitMapItems(t *schema.Map, m value.Map) (errs Valid
 }
 
 func (v *toFieldSetWalker) doMap(t *schema.Map) (errs ValidationErrors) {
-	m, _ := mapValue(v.value)
+	m, _ := mapValue(v.allocator, v.value)
 	if m != nil {
-		defer m.Recycle()
+		defer v.allocator.Free(m)
 	}
 	if t.ElementRelationship == schema.Atomic {
 		v.set.Insert(v.path)

--- a/typed/typed.go
+++ b/typed/typed.go
@@ -238,6 +238,9 @@ func merge(lhs, rhs *TypedValue, rule, postRule mergeRule) (*TypedValue, error) 
 	mw.typeRef = lhs.typeRef
 	mw.rule = rule
 	mw.postItemHook = postRule
+	if mw.allocator == nil {
+		mw.allocator = value.NewFreelistAllocator()
+	}
 
 	errs := mw.merge(nil)
 	if len(errs) > 0 {

--- a/typed/validate.go
+++ b/typed/validate.go
@@ -33,6 +33,9 @@ func (tv TypedValue) walker() *validatingObjectWalker {
 	v.value = tv.value
 	v.schema = tv.schema
 	v.typeRef = tv.typeRef
+	if v.allocator == nil {
+		v.allocator = value.NewFreelistAllocator()
+	}
 	return v
 }
 
@@ -49,6 +52,7 @@ type validatingObjectWalker struct {
 
 	// Allocate only as many walkers as needed for the depth by storing them here.
 	spareWalkers *[]*validatingObjectWalker
+	allocator    value.Allocator
 }
 
 func (v *validatingObjectWalker) prepareDescent(tr schema.TypeRef) *validatingObjectWalker {
@@ -112,13 +116,14 @@ func (v *validatingObjectWalker) doScalar(t *schema.Scalar) ValidationErrors {
 func (v *validatingObjectWalker) visitListItems(t *schema.List, list value.List) (errs ValidationErrors) {
 	observedKeys := fieldpath.MakePathElementSet(list.Length())
 	for i := 0; i < list.Length(); i++ {
-		child := list.At(i)
+		child := list.AtUsing(v.allocator, i)
+		defer v.allocator.Free(child)
 		var pe fieldpath.PathElement
 		if t.ElementRelationship != schema.Associative {
 			pe.Index = &i
 		} else {
 			var err error
-			pe, err = listItemToPathElement(t, i, child)
+			pe, err = listItemToPathElement(v.allocator, t, i, child)
 			if err != nil {
 				errs = append(errs, errorf("element %v: %v", i, err.Error())...)
 				// If we can't construct the path element, we can't
@@ -140,7 +145,7 @@ func (v *validatingObjectWalker) visitListItems(t *schema.List, list value.List)
 }
 
 func (v *validatingObjectWalker) doList(t *schema.List) (errs ValidationErrors) {
-	list, err := listValue(v.value)
+	list, err := listValue(v.allocator, v.value)
 	if err != nil {
 		return errorf(err.Error())
 	}
@@ -149,13 +154,14 @@ func (v *validatingObjectWalker) doList(t *schema.List) (errs ValidationErrors) 
 		return nil
 	}
 
+	defer v.allocator.Free(list)
 	errs = v.visitListItems(t, list)
 
 	return errs
 }
 
 func (v *validatingObjectWalker) visitMapItems(t *schema.Map, m value.Map) (errs ValidationErrors) {
-	m.Iterate(func(key string, val value.Value) bool {
+	m.IterateUsing(v.allocator, func(key string, val value.Value) bool {
 		pe := fieldpath.PathElement{FieldName: &key}
 		tr := t.ElementType
 		if sf, ok := t.FindField(key); ok {
@@ -175,14 +181,14 @@ func (v *validatingObjectWalker) visitMapItems(t *schema.Map, m value.Map) (errs
 }
 
 func (v *validatingObjectWalker) doMap(t *schema.Map) (errs ValidationErrors) {
-	m, err := mapValue(v.value)
+	m, err := mapValue(v.allocator, v.value)
 	if err != nil {
 		return errorf(err.Error())
 	}
 	if m == nil {
 		return nil
 	}
-	defer m.Recycle()
+	defer v.allocator.Free(m)
 	errs = v.visitMapItems(t, m)
 
 	return errs

--- a/value/allocator.go
+++ b/value/allocator.go
@@ -1,0 +1,203 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package value
+
+// Allocator provides a value object allocation strategy.
+// Value objects can be allocated by passing an allocator to the "Using"
+// receiver functions on the value interfaces, e.g. Map.ZipUsing(allocator, ...).
+// Value objects returned from "Using" functions should be given back to the allocator
+// once longer needed by calling Allocator.Free(Value).
+type Allocator interface {
+	// Free gives the allocator back any value objects returned by the "Using"
+	// receiver functions on the value interfaces.
+	// interface{} may be any of: Value, Map, List or Range.
+	Free(interface{})
+
+	// The unexported functions are for "Using" receiver functions of the value types
+	// to request what they need from the allocator.
+	allocValueUnstructured() *valueUnstructured
+	allocListUnstructuredRange() *listUnstructuredRange
+	allocValueReflect() *valueReflect
+	allocMapReflect() *mapReflect
+	allocStructReflect() *structReflect
+	allocListReflect() *listReflect
+	allocListReflectRange() *listReflectRange
+}
+
+// HeapAllocator simply allocates objects to the heap. It is the default
+// allocator used receiver functions on the value interfaces that do not accept
+// an allocator and should be used whenever allocating objects that will not
+// be given back to an allocator by calling Allocator.Free(Value).
+var HeapAllocator = &heapAllocator{}
+
+type heapAllocator struct{}
+
+func (p *heapAllocator) allocValueUnstructured() *valueUnstructured {
+	return &valueUnstructured{}
+}
+
+func (p *heapAllocator) allocListUnstructuredRange() *listUnstructuredRange {
+	return &listUnstructuredRange{vv: &valueUnstructured{}}
+}
+
+func (p *heapAllocator) allocValueReflect() *valueReflect {
+	return &valueReflect{}
+}
+
+func (p *heapAllocator) allocStructReflect() *structReflect {
+	return &structReflect{}
+}
+
+func (p *heapAllocator) allocMapReflect() *mapReflect {
+	return &mapReflect{}
+}
+
+func (p *heapAllocator) allocListReflect() *listReflect {
+	return &listReflect{}
+}
+
+func (p *heapAllocator) allocListReflectRange() *listReflectRange {
+	return &listReflectRange{vr: &valueReflect{}}
+}
+
+func (p *heapAllocator) Free(_ interface{}) {}
+
+// NewFreelistAllocator creates freelist based allocator.
+// This allocator provides fast allocation and freeing of short lived value objects.
+//
+// The freelists are bounded in size by freelistMaxSize. If more than this amount of value objects is
+// allocated at once, the excess will be returned to the heap for garbage collection when freed.
+//
+// This allocator is unsafe and must not be accessed concurrently by goroutines.
+//
+// This allocator works well for traversal of value data trees. Typical usage is to acquire
+// a freelist at the beginning of the traversal and use it through out
+// for all temporary value access.
+func NewFreelistAllocator() Allocator {
+	return &freelistAllocator{
+		valueUnstructured: &freelist{new: func() interface{} {
+			return &valueUnstructured{}
+		}},
+		listUnstructuredRange: &freelist{new: func() interface{} {
+			return &listUnstructuredRange{vv: &valueUnstructured{}}
+		}},
+		valueReflect: &freelist{new: func() interface{} {
+			return &valueReflect{}
+		}},
+		mapReflect: &freelist{new: func() interface{} {
+			return &mapReflect{}
+		}},
+		structReflect: &freelist{new: func() interface{} {
+			return &structReflect{}
+		}},
+		listReflect: &freelist{new: func() interface{} {
+			return &listReflect{}
+		}},
+		listReflectRange: &freelist{new: func() interface{} {
+			return &listReflectRange{vr: &valueReflect{}}
+		}},
+	}
+}
+
+// Bound memory usage of freelists. This prevents the processing of very large lists from leaking memory.
+// This limit is large enough for endpoints objects containing 1000 IP address entries. Freed objects
+// that don't fit into the freelist are orphaned on the heap to be garbage collected.
+const freelistMaxSize = 1000
+
+type freelistAllocator struct {
+	valueUnstructured     *freelist
+	listUnstructuredRange *freelist
+	valueReflect          *freelist
+	mapReflect            *freelist
+	structReflect         *freelist
+	listReflect           *freelist
+	listReflectRange      *freelist
+}
+
+type freelist struct {
+	list []interface{}
+	new  func() interface{}
+}
+
+func (f *freelist) allocate() interface{} {
+	var w2 interface{}
+	if n := len(f.list); n > 0 {
+		w2, f.list = f.list[n-1], f.list[:n-1]
+	} else {
+		w2 = f.new()
+	}
+	return w2
+}
+
+func (f *freelist) free(v interface{}) {
+	if len(f.list) < freelistMaxSize {
+		f.list = append(f.list, v)
+	}
+}
+
+func (w *freelistAllocator) Free(value interface{}) {
+	switch v := value.(type) {
+	case *valueUnstructured:
+		v.Value = nil // don't hold references to unstructured objects
+		w.valueUnstructured.free(v)
+	case *listUnstructuredRange:
+		v.vv.Value = nil // don't hold references to unstructured objects
+		w.listUnstructuredRange.free(v)
+	case *valueReflect:
+		v.ParentMapKey = nil
+		v.ParentMap = nil
+		w.valueReflect.free(v)
+	case *mapReflect:
+		w.mapReflect.free(v)
+	case *structReflect:
+		w.structReflect.free(v)
+	case *listReflect:
+		w.listReflect.free(v)
+	case *listReflectRange:
+		v.vr.ParentMapKey = nil
+		v.vr.ParentMap = nil
+		w.listReflectRange.free(v)
+	}
+}
+
+func (w *freelistAllocator) allocValueUnstructured() *valueUnstructured {
+	return w.valueUnstructured.allocate().(*valueUnstructured)
+}
+
+func (w *freelistAllocator) allocListUnstructuredRange() *listUnstructuredRange {
+	return w.listUnstructuredRange.allocate().(*listUnstructuredRange)
+}
+
+func (w *freelistAllocator) allocValueReflect() *valueReflect {
+	return w.valueReflect.allocate().(*valueReflect)
+}
+
+func (w *freelistAllocator) allocStructReflect() *structReflect {
+	return w.structReflect.allocate().(*structReflect)
+}
+
+func (w *freelistAllocator) allocMapReflect() *mapReflect {
+	return w.mapReflect.allocate().(*mapReflect)
+}
+
+func (w *freelistAllocator) allocListReflect() *listReflect {
+	return w.listReflect.allocate().(*listReflect)
+}
+
+func (w *freelistAllocator) allocListReflectRange() *listReflectRange {
+	return w.listReflectRange.allocate().(*listReflectRange)
+}

--- a/value/map.go
+++ b/value/map.go
@@ -26,6 +26,11 @@ type Map interface {
 	Set(key string, val Value)
 	// Get returns the value for the given key, if present, or (nil, false) otherwise.
 	Get(key string) (Value, bool)
+	// GetUsing uses the provided allocator and returns the value for the given key,
+	// if present, or (nil, false) otherwise.
+	// The returned Value should be given back to the Allocator when no longer needed
+	// by calling Allocator.Free(Value).
+	GetUsing(a Allocator, key string) (Value, bool)
 	// Has returns true if the key is present, or false otherwise.
 	Has(key string) bool
 	// Delete removes the key from the map.
@@ -33,10 +38,17 @@ type Map interface {
 	// Equals compares the two maps, and return true if they are the same, false otherwise.
 	// Implementations can use MapEquals as a general implementation for this methods.
 	Equals(other Map) bool
+	// EqualsUsing uses the provided allocator and compares the two maps, and return true if
+	// they are the same, false otherwise. Implementations can use MapEqualsUsing as a general
+	// implementation for this methods.
+	EqualsUsing(a Allocator, other Map) bool
 	// Iterate runs the given function for each key/value in the
 	// map. Returning false in the closure prematurely stops the
 	// iteration.
 	Iterate(func(key string, value Value) bool) bool
+	// IterateUsing uses the provided allocator and runs the given function for each key/value
+	// in the map. Returning false in the closure prematurely stops the iteration.
+	IterateUsing(Allocator, func(key string, value Value) bool) bool
 	// Length returns the number of items in the map.
 	Length() int
 	// Empty returns true if the map is empty.
@@ -45,9 +57,11 @@ type Map interface {
 	// with the values from both maps, otherwise it is called with the value of the map that contains the key and nil
 	// for the map that does not contain the key. Returning false in the closure prematurely stops the iteration.
 	Zip(other Map, order MapTraverseOrder, fn func(key string, lhs, rhs Value) bool) bool
-	// Recycle gives back this Map once it is no longer needed. The
-	// value shouldn't be used after this call.
-	Recycle()
+	// ZipUsing uses the provided allocator and iterates over the entries of two maps together. If both maps
+	// contain a value for a given key, fn is called with the values from both maps, otherwise it is called with
+	// the value of the map that contains the key and nil for the map that does not contain the key. Returning
+	// false in the closure prematurely stops the iteration.
+	ZipUsing(a Allocator, other Map, order MapTraverseOrder, fn func(key string, lhs, rhs Value) bool) bool
 }
 
 // MapTraverseOrder defines the map traversal ordering available.
@@ -64,11 +78,19 @@ const (
 // with the values from both maps, otherwise it is called with the value of the map that contains the key and nil
 // for the other map. Returning false in the closure prematurely stops the iteration.
 func MapZip(lhs, rhs Map, order MapTraverseOrder, fn func(key string, lhs, rhs Value) bool) bool {
+	return MapZipUsing(HeapAllocator, lhs, rhs, order, fn)
+}
+
+// MapZipUsing uses the provided allocator and iterates over the entries of two maps together. If both maps
+// contain a value for a given key, fn is called with the values from both maps, otherwise it is called with
+// the value of the map that contains the key and nil for the other map. Returning false in the closure
+// prematurely stops the iteration.
+func MapZipUsing(a Allocator, lhs, rhs Map, order MapTraverseOrder, fn func(key string, lhs, rhs Value) bool) bool {
 	if lhs != nil {
-		return lhs.Zip(rhs, order, fn)
+		return lhs.ZipUsing(a, rhs, order, fn)
 	}
 	if rhs != nil {
-		return rhs.Zip(lhs, order, func(key string, rhs, lhs Value) bool { // arg positions of lhs and rhs deliberately swapped
+		return rhs.ZipUsing(a, lhs, order, func(key string, rhs, lhs Value) bool { // arg positions of lhs and rhs deliberately swapped
 			return fn(key, lhs, rhs)
 		})
 	}
@@ -77,29 +99,29 @@ func MapZip(lhs, rhs Map, order MapTraverseOrder, fn func(key string, lhs, rhs V
 
 // defaultMapZip provides a default implementation of Zip for implementations that do not need to provide
 // their own optimized implementation.
-func defaultMapZip(lhs, rhs Map, order MapTraverseOrder, fn func(key string, lhs, rhs Value) bool) bool {
+func defaultMapZip(a Allocator, lhs, rhs Map, order MapTraverseOrder, fn func(key string, lhs, rhs Value) bool) bool {
 	switch order {
 	case Unordered:
-		return unorderedMapZip(lhs, rhs, fn)
+		return unorderedMapZip(a, lhs, rhs, fn)
 	case LexicalKeyOrder:
-		return lexicalKeyOrderedMapZip(lhs, rhs, fn)
+		return lexicalKeyOrderedMapZip(a, lhs, rhs, fn)
 	default:
 		panic("Unsupported map order")
 	}
 }
 
-func unorderedMapZip(lhs, rhs Map, fn func(key string, lhs, rhs Value) bool) bool {
+func unorderedMapZip(a Allocator, lhs, rhs Map, fn func(key string, lhs, rhs Value) bool) bool {
 	if (lhs == nil || lhs.Empty()) && (rhs == nil || rhs.Empty()) {
 		return true
 	}
 
 	if lhs != nil {
-		ok := lhs.Iterate(func(key string, lhsValue Value) bool {
+		ok := lhs.IterateUsing(a, func(key string, lhsValue Value) bool {
 			var rhsValue Value
 			if rhs != nil {
-				if item, ok := rhs.Get(key); ok {
+				if item, ok := rhs.GetUsing(a, key); ok {
 					rhsValue = item
-					defer rhsValue.Recycle()
+					defer a.Free(rhsValue)
 				}
 			}
 			return fn(key, lhsValue, rhsValue)
@@ -109,7 +131,7 @@ func unorderedMapZip(lhs, rhs Map, fn func(key string, lhs, rhs Value) bool) boo
 		}
 	}
 	if rhs != nil {
-		return rhs.Iterate(func(key string, rhsValue Value) bool {
+		return rhs.IterateUsing(a, func(key string, rhsValue Value) bool {
 			if lhs == nil || !lhs.Has(key) {
 				return fn(key, nil, rhsValue)
 			}
@@ -119,7 +141,7 @@ func unorderedMapZip(lhs, rhs Map, fn func(key string, lhs, rhs Value) bool) boo
 	return true
 }
 
-func lexicalKeyOrderedMapZip(lhs, rhs Map, fn func(key string, lhs, rhs Value) bool) bool {
+func lexicalKeyOrderedMapZip(a Allocator, lhs, rhs Map, fn func(key string, lhs, rhs Value) bool) bool {
 	var lhsLength, rhsLength int
 	var orderedLength int // rough estimate of length of union of map keys
 	if lhs != nil {
@@ -138,13 +160,13 @@ func lexicalKeyOrderedMapZip(lhs, rhs Map, fn func(key string, lhs, rhs Value) b
 
 	ordered := make([]string, 0, orderedLength)
 	if lhs != nil {
-		lhs.Iterate(func(key string, _ Value) bool {
+		lhs.IterateUsing(a, func(key string, _ Value) bool {
 			ordered = append(ordered, key)
 			return true
 		})
 	}
 	if rhs != nil {
-		rhs.Iterate(func(key string, _ Value) bool {
+		rhs.IterateUsing(a, func(key string, _ Value) bool {
 			if lhs == nil || !lhs.Has(key) {
 				ordered = append(ordered, key)
 			}
@@ -155,17 +177,17 @@ func lexicalKeyOrderedMapZip(lhs, rhs Map, fn func(key string, lhs, rhs Value) b
 	for _, key := range ordered {
 		var litem, ritem Value
 		if lhs != nil {
-			litem, _ = lhs.Get(key)
+			litem, _ = lhs.GetUsing(a, key)
 		}
 		if rhs != nil {
-			ritem, _ = rhs.Get(key)
+			ritem, _ = rhs.GetUsing(a, key)
 		}
 		ok := fn(key, litem, ritem)
 		if litem != nil {
-			litem.Recycle()
+			a.Free(litem)
 		}
 		if ritem != nil {
-			ritem.Recycle()
+			a.Free(ritem)
 		}
 		if !ok {
 			return false
@@ -181,6 +203,11 @@ func MapLess(lhs, rhs Map) bool {
 
 // MapCompare compares two maps lexically.
 func MapCompare(lhs, rhs Map) int {
+	return MapCompareUsing(HeapAllocator, lhs, rhs)
+}
+
+// MapCompareUsing uses the provided allocator and compares two maps lexically.
+func MapCompareUsing(a Allocator, lhs, rhs Map) int {
 	c := 0
 	var llength, rlength int
 	if lhs != nil {
@@ -193,7 +220,7 @@ func MapCompare(lhs, rhs Map) int {
 		return 0
 	}
 	i := 0
-	MapZip(lhs, rhs, LexicalKeyOrder, func(key string, lhs, rhs Value) bool {
+	MapZipUsing(a, lhs, rhs, LexicalKeyOrder, func(key string, lhs, rhs Value) bool {
 		switch {
 		case i == llength:
 			c = -1
@@ -204,7 +231,7 @@ func MapCompare(lhs, rhs Map) int {
 		case rhs == nil:
 			c = -1
 		default:
-			c = Compare(lhs, rhs)
+			c = CompareUsing(a, lhs, rhs)
 		}
 		i++
 		return c == 0
@@ -217,6 +244,14 @@ func MapCompare(lhs, rhs Map) int {
 // implement Map.Equals.
 // WARN: This is a naive implementation, calling lhs.Equals(rhs) is typically the most efficient.
 func MapEquals(lhs, rhs Map) bool {
+	return MapEqualsUsing(HeapAllocator, lhs, rhs)
+}
+
+// MapEqualsUsing uses the provided allocator and returns true if lhs == rhs,
+// false otherwise. This function acts on generic types and should not be used
+// by callers, but can help implement Map.Equals.
+// WARN: This is a naive implementation, calling lhs.EqualsUsing(allocator, rhs) is typically the most efficient.
+func MapEqualsUsing(a Allocator, lhs, rhs Map) bool {
 	if lhs == nil && rhs == nil {
 		return true
 	}
@@ -226,10 +261,10 @@ func MapEquals(lhs, rhs Map) bool {
 	if lhs.Length() != rhs.Length() {
 		return false
 	}
-	return MapZip(lhs, rhs, Unordered, func(key string, lhs, rhs Value) bool {
+	return MapZipUsing(a, lhs, rhs, Unordered, func(key string, lhs, rhs Value) bool {
 		if lhs == nil || rhs == nil {
 			return false
 		}
-		return Equals(lhs, rhs)
+		return EqualsUsing(a, lhs, rhs)
 	})
 }

--- a/value/mapunstructured.go
+++ b/value/mapunstructured.go
@@ -23,10 +23,14 @@ func (m mapUnstructuredInterface) Set(key string, val Value) {
 }
 
 func (m mapUnstructuredInterface) Get(key string) (Value, bool) {
+	return m.GetUsing(HeapAllocator, key)
+}
+
+func (m mapUnstructuredInterface) GetUsing(a Allocator, key string) (Value, bool) {
 	if v, ok := m[key]; !ok {
 		return nil, false
 	} else {
-		return NewValueInterface(v), true
+		return a.allocValueUnstructured().reuse(v), true
 	}
 }
 
@@ -40,11 +44,15 @@ func (m mapUnstructuredInterface) Delete(key string) {
 }
 
 func (m mapUnstructuredInterface) Iterate(fn func(key string, value Value) bool) bool {
+	return m.IterateUsing(HeapAllocator, fn)
+}
+
+func (m mapUnstructuredInterface) IterateUsing(a Allocator, fn func(key string, value Value) bool) bool {
 	if len(m) == 0 {
 		return true
 	}
-	vv := viPool.Get().(*valueUnstructured)
-	defer vv.Recycle()
+	vv := a.allocValueUnstructured()
+	defer a.Free(vv)
 	for k, v := range m {
 		if ks, ok := k.(string); !ok {
 			continue
@@ -66,6 +74,10 @@ func (m mapUnstructuredInterface) Empty() bool {
 }
 
 func (m mapUnstructuredInterface) Equals(other Map) bool {
+	return m.EqualsUsing(HeapAllocator, other)
+}
+
+func (m mapUnstructuredInterface) EqualsUsing(a Allocator, other Map) bool {
 	lhsLength := m.Length()
 	rhsLength := other.Length()
 	if lhsLength != rhsLength {
@@ -74,8 +86,8 @@ func (m mapUnstructuredInterface) Equals(other Map) bool {
 	if lhsLength == 0 {
 		return true
 	}
-	vv := viPool.Get().(*valueUnstructured)
-	defer vv.Recycle()
+	vv := a.allocValueUnstructured()
+	defer a.Free(vv)
 	return other.Iterate(func(key string, value Value) bool {
 		lhsVal, ok := m[key]
 		if !ok {
@@ -86,11 +98,11 @@ func (m mapUnstructuredInterface) Equals(other Map) bool {
 }
 
 func (m mapUnstructuredInterface) Zip(other Map, order MapTraverseOrder, fn func(key string, lhs, rhs Value) bool) bool {
-	return defaultMapZip(m, other, order, fn)
+	return m.ZipUsing(HeapAllocator, other, order, fn)
 }
 
-func (m mapUnstructuredInterface) Recycle() {
-
+func (m mapUnstructuredInterface) ZipUsing(a Allocator, other Map, order MapTraverseOrder, fn func(key string, lhs, rhs Value) bool) bool {
+	return defaultMapZip(a, m, other, order, fn)
 }
 
 type mapUnstructuredString map[string]interface{}
@@ -100,10 +112,13 @@ func (m mapUnstructuredString) Set(key string, val Value) {
 }
 
 func (m mapUnstructuredString) Get(key string) (Value, bool) {
+	return m.GetUsing(HeapAllocator, key)
+}
+func (m mapUnstructuredString) GetUsing(a Allocator, key string) (Value, bool) {
 	if v, ok := m[key]; !ok {
 		return nil, false
 	} else {
-		return NewValueInterface(v), true
+		return a.allocValueUnstructured().reuse(v), true
 	}
 }
 
@@ -117,11 +132,15 @@ func (m mapUnstructuredString) Delete(key string) {
 }
 
 func (m mapUnstructuredString) Iterate(fn func(key string, value Value) bool) bool {
+	return m.IterateUsing(HeapAllocator, fn)
+}
+
+func (m mapUnstructuredString) IterateUsing(a Allocator, fn func(key string, value Value) bool) bool {
 	if len(m) == 0 {
 		return true
 	}
-	vv := viPool.Get().(*valueUnstructured)
-	defer vv.Recycle()
+	vv := a.allocValueUnstructured()
+	defer a.Free(vv)
 	for k, v := range m {
 		if !fn(k, vv.reuse(v)) {
 			return false
@@ -135,6 +154,10 @@ func (m mapUnstructuredString) Length() int {
 }
 
 func (m mapUnstructuredString) Equals(other Map) bool {
+	return m.EqualsUsing(HeapAllocator, other)
+}
+
+func (m mapUnstructuredString) EqualsUsing(a Allocator, other Map) bool {
 	lhsLength := m.Length()
 	rhsLength := other.Length()
 	if lhsLength != rhsLength {
@@ -143,8 +166,8 @@ func (m mapUnstructuredString) Equals(other Map) bool {
 	if lhsLength == 0 {
 		return true
 	}
-	vv := viPool.Get().(*valueUnstructured)
-	defer vv.Recycle()
+	vv := a.allocValueUnstructured()
+	defer a.Free(vv)
 	return other.Iterate(func(key string, value Value) bool {
 		lhsVal, ok := m[key]
 		if !ok {
@@ -155,11 +178,11 @@ func (m mapUnstructuredString) Equals(other Map) bool {
 }
 
 func (m mapUnstructuredString) Zip(other Map, order MapTraverseOrder, fn func(key string, lhs, rhs Value) bool) bool {
-	return defaultMapZip(m, other, order, fn)
+	return m.ZipUsing(HeapAllocator, other, order, fn)
 }
 
-func (m mapUnstructuredString) Recycle() {
-
+func (m mapUnstructuredString) ZipUsing(a Allocator, other Map, order MapTraverseOrder, fn func(key string, lhs, rhs Value) bool) bool {
+	return defaultMapZip(a, m, other, order, fn)
 }
 
 func (m mapUnstructuredString) Empty() bool {

--- a/value/reflectcache.go
+++ b/value/reflectcache.go
@@ -70,7 +70,7 @@ func (f *FieldCacheEntry) CanOmit(fieldVal reflect.Value) bool {
 	return f.isOmitEmpty && (safeIsNil(fieldVal) || isZero(fieldVal))
 }
 
-// GetFrom returns the field identified by this FieldCacheEntry from the provided struct.
+// GetUsing returns the field identified by this FieldCacheEntry from the provided struct.
 func (f *FieldCacheEntry) GetFrom(structVal reflect.Value) reflect.Value {
 	// field might be nested within 'inline' structs
 	for _, elem := range f.fieldPath {

--- a/value/valuereflect_test.go
+++ b/value/valuereflect_test.go
@@ -635,7 +635,6 @@ func TestReflectList(t *testing.T) {
 			}
 
 			iter := m.Range()
-			defer iter.Recycle()
 			iterateResult = make([]interface{}, l)
 			for iter.Next() {
 				i, val := iter.Item()

--- a/value/valueunstructured.go
+++ b/value/valueunstructured.go
@@ -18,22 +18,14 @@ package value
 
 import (
 	"fmt"
-	"sync"
 )
-
-var viPool = sync.Pool{
-	New: func() interface{} {
-		return &valueUnstructured{}
-	},
-}
 
 // NewValueInterface creates a Value backed by an "interface{}" type,
 // typically an unstructured object in Kubernetes world.
 // interface{} must be one of: map[string]interface{}, map[interface{}]interface{}, []interface{}, int types, float types,
 // string or boolean. Nested interface{} must also be one of these types.
 func NewValueInterface(v interface{}) Value {
-	vi := viPool.Get().(*valueUnstructured)
-	return Value(vi.reuse(v))
+	return Value(HeapAllocator.allocValueUnstructured().reuse(v))
 }
 
 type valueUnstructured struct {
@@ -57,6 +49,10 @@ func (v valueUnstructured) IsMap() bool {
 }
 
 func (v valueUnstructured) AsMap() Map {
+	return v.AsMapUsing(HeapAllocator)
+}
+
+func (v valueUnstructured) AsMapUsing(_ Allocator) Map {
 	if v.Value == nil {
 		panic("invalid nil")
 	}
@@ -78,6 +74,10 @@ func (v valueUnstructured) IsList() bool {
 }
 
 func (v valueUnstructured) AsList() List {
+	return v.AsListUsing(HeapAllocator)
+}
+
+func (v valueUnstructured) AsListUsing(_ Allocator) List {
 	return listUnstructured(v.Value.([]interface{}))
 }
 
@@ -171,10 +171,6 @@ func (v valueUnstructured) AsBool() bool {
 
 func (v valueUnstructured) IsNull() bool {
 	return v.Value == nil
-}
-
-func (v *valueUnstructured) Recycle() {
-	viPool.Put(v)
 }
 
 func (v valueUnstructured) Unstructured() interface{} {


### PR DESCRIPTION
Remove use of `sync.Pool` entirely and add a `Allocator` interface that works like so:

```
allocator := value.NewFreelistAllocator()
val := m.GetUsing(allocator, "key")
...
// when done with the object:
allocator.Free(val)
```

The freelists themselves are pooled. The typical usage is to get a freelist from a pool when starting a traversal (e.g. validationWalker or mergeWalker) and then returned at the end of the traversal.

Callers that don't opt in to use the allocator by calling the "Using" functions get heap allocation by default.

The eliminates the contention observed by `sync.Pool` particularly when concurrency is high.

Test: Compare cpu=32 RunParallel benchmark that calls ObjectToTyped and then Compare, just like updater.Update does
Baseline: master + https://github.com/kubernetes-sigs/structured-merge-diff/pull/153

```
name                               old time/op    new time/op    delta
Compare/Pod/structured-32            64.6µs ± 8%    44.5µs ± 5%  -31.17%  (p=0.008 n=5+5)
Compare/Pod/unstructured-32          74.9µs ± 7%    66.0µs ±43%     ~     (p=0.151 n=5+5)
Compare/Node/structured-32            110µs ±11%      82µs ± 3%  -25.38%  (p=0.008 n=5+5)
Compare/Node/unstructured-32          126µs ± 5%     105µs ± 6%  -16.28%  (p=0.008 n=5+5)
Compare/Endpoints/structured-32      1.00ms ± 9%    0.85ms ± 6%  -14.92%  (p=0.008 n=5+5)
Compare/Endpoints/unstructured-32    2.04ms ± 5%    1.87ms ± 6%   -8.12%  (p=0.008 n=5+5)

name                               old alloc/op   new alloc/op   delta
Compare/Pod/structured-32            26.1kB ± 0%    26.5kB ± 0%   +1.42%  (p=0.008 n=5+5)
Compare/Pod/unstructured-32          59.6kB ± 0%    60.2kB ± 0%   +0.97%  (p=0.008 n=5+5)
Compare/Node/structured-32           54.3kB ± 0%    54.4kB ± 0%   +0.21%  (p=0.008 n=5+5)
Compare/Node/unstructured-32          106kB ± 0%     110kB ± 0%   +4.24%  (p=0.008 n=5+5)
Compare/Endpoints/structured-32       349kB ± 0%     332kB ± 0%   -4.84%  (p=0.008 n=5+5)
Compare/Endpoints/unstructured-32    2.04MB ± 0%    2.10MB ± 0%   +2.87%  (p=0.008 n=5+5)

name                               old allocs/op  new allocs/op  delta
Compare/Pod/structured-32               799 ± 0%       809 ± 0%   +1.25%  (p=0.008 n=5+5)
Compare/Pod/unstructured-32           1.23k ± 0%     1.26k ± 0%   +2.19%  (p=0.008 n=5+5)
Compare/Node/structured-32            1.62k ± 0%     1.63k ± 0%   +0.43%  (p=0.016 n=4+5)
Compare/Node/unstructured-32          2.45k ± 0%     2.62k ± 0%   +7.19%  (p=0.008 n=5+5)
Compare/Endpoints/structured-32       8.20k ± 0%     8.20k ± 0%     ~     (p=0.333 n=5+5)
Compare/Endpoints/unstructured-32     32.4k ± 0%     37.0k ± 0%  +14.03%  (p=0.008 n=5+5)
```

/sig api-machinery
cc @apelisse @jennybuckley @lavalamp 