### PR TITLE
Add Conflicts.ToSet()

### DIFF
--- a/merge/conflict.go
+++ b/merge/conflict.go
@@ -95,6 +95,15 @@ func (c Conflicts) Equals(c2 Conflicts) bool {
 	return true
 }
 
+// ToSet aggregates conflicts for all managers into a single Set.
+func (c Conflicts) ToSet() *fieldpath.Set {
+	set := fieldpath.NewSet()
+	for _, conflict := range []Conflict(c) {
+		set.Insert(conflict.Path)
+	}
+	return set
+}
+
 // ConflictsFromManagers creates a list of conflicts given Managers sets.
 func ConflictsFromManagers(sets fieldpath.ManagedFields) Conflicts {
 	conflicts := []Conflict{}

--- a/merge/conflict_test.go
+++ b/merge/conflict_test.go
@@ -61,3 +61,34 @@ conflicts with "Bob":
 		t.Errorf("Got %v, wanted %v", got.Error(), wanted)
 	}
 }
+
+func TestToSet(t *testing.T) {
+	conflicts := merge.ConflictsFromManagers(fieldpath.ManagedFields{
+		"Bob": fieldpath.NewVersionedSet(
+			_NS(
+				_P("key"),
+				_P("list", _KBF("key", "a", "id", 2), "id"),
+			),
+			"v1",
+			false,
+		),
+		"Alice": fieldpath.NewVersionedSet(
+			_NS(
+				_P("value"),
+				_P("list", _KBF("key", "a", "id", 2), "key"),
+			),
+			"v1",
+			false,
+		),
+	})
+	expected := fieldpath.NewSet(
+		_P("key"),
+		_P("value"),
+		_P("list", _KBF("key", "a", "id", 2), "id"),
+		_P("list", _KBF("key", "a", "id", 2), "key"),
+	)
+	actual := conflicts.ToSet()
+	if !expected.Equals(actual) {
+		t.Fatalf("expected\n%v\n, but got\n%v\n", expected, actual)
+	}
+}


### PR DESCRIPTION
Adds a method to merge.Conflicts to convert all conflicts to a fieldpath.Set.

We use this in https://github.com/kubernetes/kubernetes/pull/84134 when comparing merge.Conflicts to another Set (a Set of allowed conflicts).