### PR TITLE
always drop manager on conversion errors

### DIFF
--- a/merge/update.go
+++ b/merge/update.go
@@ -62,19 +62,13 @@ func (s *Updater) update(oldObject, newObject *typed.TypedValue, version fieldpa
 			var err error
 			versionedOldObject, err := s.Converter.Convert(oldObject, managerSet.APIVersion())
 			if err != nil {
-				if s.Converter.IsMissingVersionError(err) {
-					delete(managers, manager)
-					continue
-				}
-				return nil, nil, fmt.Errorf("failed to convert old object: %v", err)
+				delete(managers, manager)
+				continue
 			}
 			versionedNewObject, err := s.Converter.Convert(newObject, managerSet.APIVersion())
 			if err != nil {
-				if s.Converter.IsMissingVersionError(err) {
-					delete(managers, manager)
-					continue
-				}
-				return nil, nil, fmt.Errorf("failed to convert new object: %v", err)
+				delete(managers, manager)
+				continue
 			}
 			compare, err = versionedOldObject.Compare(versionedNewObject)
 			if err != nil {


### PR DESCRIPTION
We decided to drop managers that fail conversions in any case.

Relates to: https://github.com/kubernetes/kubernetes/issues/90904

/sig api-machinery
/wg api-expression
/assign @apelisse 
/cc @apelisse @liggitt 
