### PR TITLE
Remove fields that are omitted from applied configurations if there are no other owners

### DIFF
--- a/merge/leaf_test.go
+++ b/merge/leaf_test.go
@@ -378,6 +378,42 @@ func TestUpdateLeaf(t *testing.T) {
 				),
 			},
 		},
+		"update_apply_omits": {
+			Ops: []Operation{
+				Apply{
+					Manager:    "default",
+					APIVersion: "v1",
+					Object: `
+						numeric: 2
+					`,
+				},
+				Update{
+					Manager:    "controller",
+					APIVersion: "v1",
+					Object: `
+						numeric: 1
+					`,
+				},
+				Apply{
+					Manager:    "default",
+					APIVersion: "v1",
+					Object:     ``,
+				},
+			},
+			Object: `
+						numeric: 1
+			`,
+			APIVersion: "v1",
+			Managed: fieldpath.ManagedFields{
+				"controller": fieldpath.NewVersionedSet(
+					_NS(
+						_P("numeric"),
+					),
+					"v1",
+					false,
+				),
+			},
+		},
 		"apply_twice_remove_different_version": {
 			Ops: []Operation{
 				Apply{

--- a/merge/leaf_test.go
+++ b/merge/leaf_test.go
@@ -345,7 +345,7 @@ func TestUpdateLeaf(t *testing.T) {
 				),
 			},
 		},
-		"apply_twice_dangling": {
+		"apply_twice_remove": {
 			Ops: []Operation{
 				Apply{
 					Manager:    "default",
@@ -365,9 +365,7 @@ func TestUpdateLeaf(t *testing.T) {
 				},
 			},
 			Object: `
-				numeric: 1
 				string: "new string"
-				bool: false
 			`,
 			APIVersion: "v1",
 			Managed: fieldpath.ManagedFields{
@@ -380,7 +378,7 @@ func TestUpdateLeaf(t *testing.T) {
 				),
 			},
 		},
-		"apply_twice_dangling_different_version": {
+		"apply_twice_remove_different_version": {
 			Ops: []Operation{
 				Apply{
 					Manager:    "default",
@@ -400,9 +398,7 @@ func TestUpdateLeaf(t *testing.T) {
 				},
 			},
 			Object: `
-				numeric: 1
 				string: "new string"
-				bool: false
 			`,
 			APIVersion: "v1",
 			Managed: fieldpath.ManagedFields{
@@ -462,7 +458,6 @@ func TestUpdateLeaf(t *testing.T) {
 				},
 			},
 			Object: `
-				string: "string"
 			`,
 			APIVersion: "v1",
 			Managed:    fieldpath.ManagedFields{},

--- a/merge/multiple_appliers_test.go
+++ b/merge/multiple_appliers_test.go
@@ -1304,10 +1304,74 @@ func TestMultipleAppliersRealConversion(t *testing.T) {
 				),
 			},
 		},
-		"applier_updater_shared_ownership_real_conversion": {
+		"appliers_remove_from_controller_real_conversion": {
+			// Ensures that an applier can delete associative map items it created after a controller
+			// modifies them.
 			Ops: []Operation{
+				Apply{
+					Manager: "apply",
+					Object: `
+						mapOfMapsRecursive:
+						  aaa:
+						    bbb:
+					`,
+					APIVersion: "v3",
+				},
 				Update{
 					Manager: "controller",
+					Object: `
+						mapOfMapsRecursive:
+						  a:
+						    b:
+						      c:
+					`,
+					APIVersion: "v1",
+				},
+				Apply{
+					Manager: "apply",
+					Object: `
+						mapOfMapsRecursive:
+						  aa:
+						    bb:
+						  cc:
+						    dd:
+					`,
+					APIVersion: "v2",
+				},
+				Apply{
+					Manager: "apply",
+					Object: `
+						mapOfMapsRecursive:
+						  aaa:
+						  ccc:
+					`,
+					APIVersion: "v3",
+				},
+			},
+			Object: `
+				mapOfMapsRecursive:
+				  aaa:
+				  ccc:
+			`,
+			APIVersion: "v3",
+			Managed: fieldpath.ManagedFields{
+				"apply": fieldpath.NewVersionedSet(
+					_NS(
+						_P("mapOfMapsRecursive", "aaa"),
+						_P("mapOfMapsRecursive", "ccc"),
+					),
+					"v3",
+					false,
+				),
+			},
+		},
+		"applier_updater_shared_ownership_real_conversion": {
+			// Ensures that when an updater creates maps that they are not deleted when
+			// an applier shares ownership in them and then later removes them from its applied
+			// configuration
+			Ops: []Operation{
+				Update{
+					Manager: "updater",
 					Object: `
 						mapOfMapsRecursive:
 						  a:
@@ -1346,7 +1410,7 @@ func TestMultipleAppliersRealConversion(t *testing.T) {
 			`,
 			APIVersion: "v3",
 			Managed: fieldpath.ManagedFields{
-				"controller": fieldpath.NewVersionedSet(
+				"updater": fieldpath.NewVersionedSet(
 					_NS(
 						_P("mapOfMapsRecursive"),
 						_P("mapOfMapsRecursive", "a"),

--- a/merge/multiple_appliers_test.go
+++ b/merge/multiple_appliers_test.go
@@ -27,6 +27,7 @@ import (
 	. "sigs.k8s.io/structured-merge-diff/v3/internal/fixture"
 	"sigs.k8s.io/structured-merge-diff/v3/merge"
 	"sigs.k8s.io/structured-merge-diff/v3/typed"
+	"sigs.k8s.io/structured-merge-diff/v3/value"
 )
 
 func TestMultipleAppliersSet(t *testing.T) {
@@ -237,6 +238,300 @@ func TestMultipleAppliersSet(t *testing.T) {
 	for name, test := range tests {
 		t.Run(name, func(t *testing.T) {
 			if err := test.Test(associativeListParser); err != nil {
+				t.Fatal(err)
+			}
+		})
+	}
+}
+
+var structMultiversionParser = func() Parser {
+	parser, err := typed.NewParser(`types:
+- name: v1
+  map:
+    fields:
+      - name: struct
+        type:
+          namedType: struct
+      - name: version
+        type:
+          scalar: string
+- name: struct
+  map:
+    fields:
+      - name: name
+        type:
+          scalar: string
+      - name: scalarField_v1
+        type:
+          scalar: string
+      - name: complexField_v1
+        type:
+          namedType: complex
+- name: complex
+  map:
+    fields:
+      - name: name
+        type:
+          scalar: string
+- name: v2
+  map:
+    fields:
+      - name: struct
+        type:
+          namedType: struct_v2
+      - name: version
+        type:
+          scalar: string
+- name: struct_v2
+  map:
+    fields:
+      - name: name
+        type:
+          scalar: string
+      - name: scalarField_v2
+        type:
+          scalar: string
+      - name: complexField_v2
+        type:
+          namedType: complex_v2
+- name: complex_v2
+  map:
+    fields:
+      - name: name
+        type:
+          scalar: string
+- name: v3
+  map:
+    fields:
+      - name: struct
+        type:
+          namedType: struct_v3
+      - name: version
+        type:
+          scalar: string
+- name: struct_v3
+  map:
+    fields:
+      - name: name
+        type:
+          scalar: string
+      - name: scalarField_v3
+        type:
+          scalar: string
+      - name: complexField_v3
+        type:
+          namedType: complex_v3
+- name: complex_v3
+  map:
+    fields:
+      - name: name
+        type:
+          scalar: string
+`)
+	if err != nil {
+		panic(err)
+	}
+	return parser
+}()
+
+func TestMultipleAppliersFieldUnsetting(t *testing.T) {
+	versions := []fieldpath.APIVersion{"v1", "v2", "v3"}
+	for _, v1 := range versions {
+		for _, v2 := range versions {
+			for _, v3 := range versions {
+				t.Run(fmt.Sprintf("%s-%s-%s", v1, v2, v3), func(t *testing.T) {
+					testMultipleAppliersFieldUnsetting(t, v1, v2, v3)
+				})
+			}
+		}
+	}
+}
+
+func testMultipleAppliersFieldUnsetting(t *testing.T, v1, v2, v3 fieldpath.APIVersion) {
+	tests := map[string]TestCase{
+		"unset_scalar_sole_owner": {
+			Ops: []Operation{
+				Apply{
+					Manager:    "apply-one",
+					APIVersion: v1,
+					Object: typed.YAMLObject(fmt.Sprintf(`
+						struct:
+						  name: a
+						  scalarField_%s: a
+					`, v1)),
+				},
+				Apply{
+					Manager:    "apply-one",
+					APIVersion: v2,
+					Object: `
+						struct:
+						  name: a
+					`,
+				},
+			},
+			Object: `
+				struct:
+				  name: a
+			`,
+			APIVersion: v3,
+			Managed: fieldpath.ManagedFields{
+				"apply-one": fieldpath.NewVersionedSet(
+					_NS(
+						_P("struct", "name"),
+					),
+					v2,
+					false,
+				),
+			},
+		},
+		"unset_scalar_shared_owner": {
+			Ops: []Operation{
+				Apply{
+					Manager:    "apply-one",
+					APIVersion: v1,
+					Object: typed.YAMLObject(fmt.Sprintf(`
+						struct:
+						  name: a
+						  scalarField_%s: a
+					`, v1)),
+				},
+				Apply{
+					Manager:    "apply-two",
+					APIVersion: v2,
+					Object: typed.YAMLObject(fmt.Sprintf(`
+						struct:
+						  scalarField_%s: a
+					`, v2)),
+				},
+				Apply{
+					Manager:    "apply-one",
+					APIVersion: v3,
+					Object: `
+						struct:
+						  name: a
+					`,
+				},
+			},
+			Object: typed.YAMLObject(fmt.Sprintf(`
+				struct:
+				  name: a
+				  scalarField_%s: a
+			`, v3)),
+			APIVersion: v3,
+			Managed: fieldpath.ManagedFields{
+				"apply-one": fieldpath.NewVersionedSet(
+					_NS(
+						_P("struct", "name"),
+					),
+					v3,
+					true,
+				),
+				"apply-two": fieldpath.NewVersionedSet(
+					_NS(
+						_P("struct", fmt.Sprintf("scalarField_%s", v2)),
+					),
+					v2,
+					false,
+				),
+			},
+		},
+		"unset_complex_sole_owner": {
+			Ops: []Operation{
+				Apply{
+					Manager:    "apply-one",
+					APIVersion: v1,
+					Object: typed.YAMLObject(fmt.Sprintf(`
+						struct:
+						  name: a
+						  complexField_%s:
+						    name: b
+					`, v1)),
+				},
+				Apply{
+					Manager:    "apply-one",
+					APIVersion: v2,
+					Object: `
+						struct:
+						  name: a
+					`,
+				},
+			},
+			Object: typed.YAMLObject(fmt.Sprintf(`
+				struct:
+				  name: a
+				  complexField_%s: null
+			`, v3)),
+			APIVersion: v3,
+			Managed: fieldpath.ManagedFields{
+				"apply-one": fieldpath.NewVersionedSet(
+					_NS(
+						_P("struct", "name"),
+					),
+					v2,
+					false,
+				),
+			},
+		},
+		"unset_complex_shared_owner": {
+			Ops: []Operation{
+				Apply{
+					Manager:    "apply-one",
+					APIVersion: v1,
+					Object: typed.YAMLObject(fmt.Sprintf(`
+						struct:
+						  name: a
+						  complexField_%s:
+						    name: b
+					`, v1)),
+				},
+				Apply{
+					Manager:    "apply-two",
+					APIVersion: v2,
+					Object: typed.YAMLObject(fmt.Sprintf(`
+						struct:
+						  complexField_%s:
+						    name: b
+					`, v2)),
+				},
+				Apply{
+					Manager:    "apply-one",
+					APIVersion: v3,
+					Object: `
+						struct:
+						  name: a
+					`,
+				},
+			},
+			Object: typed.YAMLObject(fmt.Sprintf(`
+				struct:
+				  name: a
+				  complexField_%s:
+				    name: b
+			`, v3)),
+			APIVersion: v3,
+			Managed: fieldpath.ManagedFields{
+				"apply-one": fieldpath.NewVersionedSet(
+					_NS(
+						_P("struct", "name"),
+					),
+					v3,
+					false,
+				),
+				"apply-two": fieldpath.NewVersionedSet(
+					_NS(
+						_P("struct", fmt.Sprintf("complexField_%s", v2), "name"),
+					),
+					v2,
+					false,
+				),
+			},
+		},
+	}
+
+	converter := renamingConverter{structMultiversionParser}
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			if err := test.TestWithConverter(structMultiversionParser, converter); err != nil {
 				t.Fatal(err)
 			}
 		})
@@ -1038,6 +1333,53 @@ func countLeadingSpace(line string) int {
 
 // Convert implements merge.Converter
 func (r repeatingConverter) IsMissingVersionError(err error) bool {
+	return err == missingVersionError
+}
+
+// renamingConverter renames fields by substituting the version suffix of the field name. E.g.
+// converting a map  with a field named "name_v1" from v1 to v2 renames the field to "name_v2".
+// Fields without a version suffix are not converted; they are the same in all versions.
+// When parsing, this converter will look for the type by using the APIVersion of the
+// object it's trying to parse. If trying to parse a "v1" object, a corresponding "v1" type
+// should exist in the schema of the provided parser.
+type renamingConverter struct {
+	parser Parser
+}
+
+// Convert implements merge.Converter
+func (r renamingConverter) Convert(v *typed.TypedValue, version fieldpath.APIVersion) (*typed.TypedValue, error) {
+	inVersion := fieldpath.APIVersion(*v.TypeRef().NamedType)
+	outType := r.parser.Type(string(version))
+	return outType.FromUnstructured(renameFields(v.AsValue(), string(inVersion), string(version)))
+}
+
+func renameFields(v value.Value, oldSuffix, newSuffix string) interface{} {
+	if v.IsMap() {
+		out := map[string]interface{}{}
+		v.AsMap().Iterate(func(key string, value value.Value) bool {
+			if strings.HasSuffix(key, oldSuffix) {
+				out[strings.TrimSuffix(key, oldSuffix)+newSuffix] = renameFields(value, oldSuffix, newSuffix)
+			} else {
+				out[key] = renameFields(value, oldSuffix, newSuffix)
+			}
+			return true
+		})
+		return out
+	}
+	if v.IsList() {
+		var out []interface{}
+		ri := v.AsList().Range()
+		for ri.Next() {
+			_, v := ri.Item()
+			out = append(out, renameFields(v, oldSuffix, newSuffix))
+		}
+		return out
+	}
+	return v.Unstructured()
+}
+
+// Convert implements merge.Converter
+func (r renamingConverter) IsMissingVersionError(err error) bool {
 	return err == missingVersionError
 }
 

--- a/merge/update.go
+++ b/merge/update.go
@@ -212,7 +212,7 @@ func shallowCopyManagers(managers fieldpath.ManagedFields) fieldpath.ManagedFiel
 	return newManagers
 }
 
-// prune will remove a list or map item, iff:
+// prune will remove a field, list or map item, iff:
 // * applyingManager applied it last time
 // * applyingManager didn't apply it this time
 // * no other applier claims to manage it
@@ -240,7 +240,7 @@ func (s *Updater) prune(merged *typed.TypedValue, managers fieldpath.ManagedFiel
 	return s.Converter.Convert(pruned, managers[applyingManager].APIVersion())
 }
 
-// addBackOwnedItems adds back any list and map items that were removed by prune,
+// addBackOwnedItems adds back any fields, list and map items that were removed by prune,
 // but other appliers (or the current applier's new config) claim to own.
 func (s *Updater) addBackOwnedItems(merged, pruned *typed.TypedValue, managedFields fieldpath.ManagedFields, applyingManager string) (*typed.TypedValue, error) {
 	var err error
@@ -281,9 +281,9 @@ func (s *Updater) addBackOwnedItems(merged, pruned *typed.TypedValue, managedFie
 	return pruned, nil
 }
 
-// addBackDanglingItems makes sure that the only items removed by prune are items that were
-// previously owned by the currently applying manager. This will add back unowned items and items
-// which are owned by Updaters that shouldn't be removed.
+// addBackDanglingItems makes sure that the fields list and map items removed by prune were
+// previously owned by the currently applying manager. This will add back fields list and map items
+// that are unowned or that are owned by Updaters and shouldn't be removed.
 func (s *Updater) addBackDanglingItems(merged, pruned *typed.TypedValue, lastSet fieldpath.VersionedSet) (*typed.TypedValue, error) {
 	convertedPruned, err := s.Converter.Convert(pruned, lastSet.APIVersion())
 	if err != nil {

--- a/merge/update.go
+++ b/merge/update.go
@@ -241,17 +241,15 @@ func (s *Updater) prune(merged *typed.TypedValue, managers fieldpath.ManagedFiel
 }
 
 // addBackOwnedItems adds back any fields, list and map items that were removed by prune,
-// but other appliers (or the current applier's new config) claim to own.
+// but other appliers or updaters (or the current applier's new config) claim to own.
 func (s *Updater) addBackOwnedItems(merged, pruned *typed.TypedValue, managedFields fieldpath.ManagedFields, applyingManager string) (*typed.TypedValue, error) {
 	var err error
 	managedAtVersion := map[fieldpath.APIVersion]*fieldpath.Set{}
 	for _, managerSet := range managedFields {
-		if managerSet.Applied() {
-			if _, ok := managedAtVersion[managerSet.APIVersion()]; !ok {
-				managedAtVersion[managerSet.APIVersion()] = fieldpath.NewSet()
-			}
-			managedAtVersion[managerSet.APIVersion()] = managedAtVersion[managerSet.APIVersion()].Union(managerSet.Set())
+		if _, ok := managedAtVersion[managerSet.APIVersion()]; !ok {
+			managedAtVersion[managerSet.APIVersion()] = fieldpath.NewSet()
 		}
+		managedAtVersion[managerSet.APIVersion()] = managedAtVersion[managerSet.APIVersion()].Union(managerSet.Set())
 	}
 	for version, managed := range managedAtVersion {
 		merged, err = s.Converter.Convert(merged, version)

--- a/typed/remove.go
+++ b/typed/remove.go
@@ -95,10 +95,9 @@ func (w *removingWalker) doMap(t *schema.Map) ValidationErrors {
 		fieldType := t.ElementType
 		if ft, ok := fieldTypes[k]; ok {
 			fieldType = ft
-		} else {
-			if w.toRemove.Has(path) {
-				return true
-			}
+		}
+		if w.toRemove.Has(path) {
+			return true
 		}
 		if subset := w.toRemove.WithPrefix(pe); !subset.Empty() {
 			val = removeItemsWithSchema(val, subset, w.schema, fieldType)

--- a/typed/typed.go
+++ b/typed/typed.go
@@ -61,6 +61,11 @@ type TypedValue struct {
 	schema  *schema.Schema
 }
 
+// TypeRef is the type of the value.
+func (tv TypedValue) TypeRef() schema.TypeRef {
+	return tv.typeRef
+}
+
 // AsValue removes the type from the TypedValue and only keeps the value.
 func (tv TypedValue) AsValue() value.Value {
 	return tv.value


### PR DESCRIPTION
Implements the first part of the [WG Apply: Unsetting fields design](https://docs.google.com/document/d/11gUQY7Qvs1m53RTWzDzbOcDUZYMNRQCBQbTukpxmpSg/edit#heading=h.a715f9g8o54d):

Omitting a shared field from an applied configuration:
- Applier gives up ownership but the field remains unchanged.

Omit an exclusively owned field from an applied configuration:
- Optional field: field is removed or defaulted.
- Required field: the apply operation will fail with a validation error.

This makes fields consistent with how associative list/map items already behave.

Added a test converter that renames fields (e.g. conversion of v1 to v2 renames "field_v1"  to "field_v2") and used it to ensure that fields are unset when the unset is applied at a different version than the previous apply.

cc @apelisse @jennybuckley @lavalamp 