### PR TITLE
Fix panic on pointer to embedded struct

### DIFF
--- a/value/reflectcache.go
+++ b/value/reflectcache.go
@@ -74,7 +74,7 @@ func (f *FieldCacheEntry) CanOmit(fieldVal reflect.Value) bool {
 func (f *FieldCacheEntry) GetFrom(structVal reflect.Value) reflect.Value {
 	// field might be nested within 'inline' structs
 	for _, elem := range f.fieldPath {
-		structVal = structVal.FieldByIndex(elem)
+		structVal = dereference(structVal).FieldByIndex(elem)
 	}
 	return structVal
 }
@@ -150,7 +150,11 @@ func buildStructCacheEntry(t reflect.Type, infos map[string]*FieldCacheEntry, fi
 			continue
 		}
 		if isInline {
-			buildStructCacheEntry(field.Type, infos, append(fieldPath, field.Index))
+			e := field.Type
+			if field.Type.Kind() == reflect.Ptr {
+				e = field.Type.Elem()
+			}
+			buildStructCacheEntry(e, infos, append(fieldPath, field.Index))
 			continue
 		}
 		info := &FieldCacheEntry{JsonName: jsonName, isOmitEmpty: isOmitempty, fieldPath: append(fieldPath, field.Index), fieldType: field.Type}

--- a/value/reflectcache.go
+++ b/value/reflectcache.go
@@ -70,7 +70,7 @@ func (f *FieldCacheEntry) CanOmit(fieldVal reflect.Value) bool {
 	return f.isOmitEmpty && (safeIsNil(fieldVal) || isZero(fieldVal))
 }
 
-// GetUsing returns the field identified by this FieldCacheEntry from the provided struct.
+// GetFrom returns the field identified by this FieldCacheEntry from the provided struct.
 func (f *FieldCacheEntry) GetFrom(structVal reflect.Value) reflect.Value {
 	// field might be nested within 'inline' structs
 	for _, elem := range f.fieldPath {

--- a/value/valuereflect_test.go
+++ b/value/valuereflect_test.go
@@ -237,6 +237,9 @@ type testOmitemptyStruct struct {
 	Noomit *string `json:"noomit"`
 	Omit   *string `json:"omit,omitempty"`
 }
+type testEmbeddedStruct struct {
+	*testBasicStruct `json:",inline"`
+}
 
 func TestReflectStruct(t *testing.T) {
 	cases := []struct {
@@ -280,6 +283,12 @@ func TestReflectStruct(t *testing.T) {
 			val:                  testOmitemptyStruct{Noomit: nil, Omit: nil},
 			expectedMap:          map[string]interface{}{"noomit": (*string)(nil)},
 			expectedUnstructured: map[string]interface{}{"noomit": nil},
+		},
+		{
+			name:                 "embedded",
+			val:                  testEmbeddedStruct{&testBasicStruct{I: 10, S: "string"}},
+			expectedMap:          map[string]interface{}{"int": int64(10), "S": "string"},
+			expectedUnstructured: map[string]interface{}{"int": int64(10), "S": "string"},
 		},
 	}
 


### PR DESCRIPTION
This PR converts an embedded struct into its original type if it is
a pointer.

Fixes: https://github.com/kubernetes-sigs/structured-merge-diff/issues/172