### PR TITLE
Fix noop granular case for atomic<->granular schema changes

### DIFF
--- a/typed/reconcile_schema.go
+++ b/typed/reconcile_schema.go
@@ -258,12 +258,13 @@ func buildGranularFieldSet(path fieldpath.Path, value *TypedValue) (*fieldpath.S
 	if err != nil {
 		return nil, errorf("toFieldSet: %v", err)
 	}
-	result := fieldpath.NewSet(path)
-	resultAtPath := descendToPath(result, path)
 	if valueFieldSetAtPath, ok := fieldSetAtPath(valueFieldSet, path); ok {
+		result := fieldpath.NewSet(path)
+		resultAtPath := descendToPath(result, path)
 		*resultAtPath = *valueFieldSetAtPath
+		return result, nil
 	}
-	return result, nil
+	return nil, nil
 }
 
 func fieldSetAtPath(node *fieldpath.Set, path fieldpath.Path) (*fieldpath.Set, bool) {

--- a/typed/reconcile_schema_test.go
+++ b/typed/reconcile_schema_test.go
@@ -267,6 +267,29 @@ var reconcileCases = []reconcileTestCase{{
 		_P("unchanged", "numeric"),
 	),
 	fixedFields: nil, // indicates no change
+}, {
+	name:         "no-change-empty-granular",
+	rootTypeName: "v1",
+	oldSchema:    granularSchema("v1"),
+	newSchema:    granularSchema("v1"),
+	liveObject: typed.YAMLObject(`
+struct: {}
+list: []
+objectList:
+  - keyA: a1
+    keyB: b1
+stringMap: {}
+unchanged: {}
+`),
+	oldFields: _NS(
+		_P("struct"),
+		_P("list"),
+		_P("objectList"),
+		_P("objectList", _KBF("keyA", "a1", "keyB", "b1")),
+		_P("objectList", _KBF("keyA", "a1", "keyB", "b1"), "value"),
+		_P("unchanged"),
+	),
+	fixedFields: nil, // indicates no change
 }}
 
 func TestReconcileFieldSetWithSchema(t *testing.T) {


### PR DESCRIPTION
If the managed fields for a complex type has no children fields (e.g. `emptyrDir: {}`), and the live object has not fields, skip reconciliation with schemas entirely.

Fixes the integration test failure in k8s: https://prow.k8s.io/view/gs/kubernetes-jenkins/pr-logs/pull/93901/pull-kubernetes-integration/1311377692632813568. How I reproduced:

```bash
kubectl apply -f hack/testdata/retainKeys/deployment/deployment-before.yaml
kubectl apply -f hack/testdata/retainKeys/deployment/deployment-after.yaml
kubectl get deployment test-deployment-retainkeys -oyaml | grep "emptyDir"
```

Before this fix, `emptyDir: {}` would match in the fieldset because reconciliation created a replacement fieldset for the emptyDir that has both a Member and an empty Children list (created as a side effect of calling descendToPath), which prevented it from being properly removed when deployment-after.yaml was applied and the emptyDir was removed entirely and replaced with a  hostPath.