### PR TITLE
Fix remove structures

### DIFF
--- a/fieldpath/set_test.go
+++ b/fieldpath/set_test.go
@@ -21,6 +21,9 @@ import (
 	"fmt"
 	"math/rand"
 	"testing"
+
+	"gopkg.in/yaml.v2"
+	"sigs.k8s.io/structured-merge-diff/v4/schema"
 )
 
 type randomPathAlphabet []PathElement
@@ -536,6 +539,86 @@ func TestSetDifference(t *testing.T) {
 			}
 			if result := c.a.RecursiveDifference(c.b); !result.Equals(c.expectRecursiveDifference) {
 				t.Fatalf("RecursiveDifference expected: \n%v\n, got: \n%v\n", c.expectRecursiveDifference, result)
+			}
+		})
+	}
+}
+
+var nestedSchema = func() (*schema.Schema, schema.TypeRef) {
+	sc := &schema.Schema{}
+	name := "type"
+	err := yaml.Unmarshal([]byte(`types:
+- name: type
+  map:
+    elementType:
+      namedType: type
+    fields:
+      - name: named
+        type:
+          namedType: type
+      - name: list
+        type:
+          list:
+            elementRelationShip: associative
+            keys: ["name"]
+            elementType:
+              namedType: type
+      - name: value
+        type:
+          scalar: numeric
+`), &sc)
+	if err != nil {
+		panic(err)
+	}
+	return sc, schema.TypeRef{NamedType: &name}
+}
+
+var _P = MakePathOrDie
+
+func TestEnsureNamedFieldsAreMembers(t *testing.T) {
+	table := []struct {
+		set, expected *Set
+	}{
+		{
+			set: NewSet(_P("named", "named", "value")),
+			expected: NewSet(
+				_P("named", "named", "value"),
+				_P("named", "named"),
+				_P("named"),
+			),
+		},
+		{
+			set: NewSet(_P("named", "a", "named", "value"), _P("a", "named", "value"), _P("a", "b", "value")),
+			expected: NewSet(
+				_P("named", "a", "named", "value"),
+				_P("named", "a", "named"),
+				_P("named"),
+				_P("a", "named", "value"),
+				_P("a", "named"),
+				_P("a", "b", "value"),
+			),
+		},
+		{
+			set: NewSet(_P("named", "list", KeyByFields("name", "a"), "named", "a", "value")),
+			expected: NewSet(
+				_P("named", "list", KeyByFields("name", "a"), "named", "a", "value"),
+				_P("named", "list", KeyByFields("name", "a"), "named"),
+				_P("named", "list"),
+				_P("named"),
+			),
+		},
+	}
+
+	for _, test := range table {
+		t.Run(fmt.Sprintf("%v", test.set), func(t *testing.T) {
+			got := test.set.EnsureNamedFieldsAreMembers(nestedSchema())
+			if !got.Equals(test.expected) {
+				t.Errorf("expected %v, got %v (missing: %v/superfluous: %v)",
+					test.expected,
+					got,
+					test.expected.Difference(got),
+					got.Difference(test.expected),
+				)
 			}
 		})
 	}

--- a/merge/ignore_test.go
+++ b/merge/ignore_test.go
@@ -190,6 +190,13 @@ func TestIgnoredFieldsUsesVersions(t *testing.T) {
 			`,
 			APIVersion: "v4",
 			Managed: fieldpath.ManagedFields{
+				"apply-one": fieldpath.NewVersionedSet(
+					_NS(
+						_P("mapOfMapsRecursive"),
+					),
+					"v4",
+					false,
+				),
 				"apply-two": fieldpath.NewVersionedSet(
 					_NS(
 						_P("mapOfMapsRecursive", "aa"),

--- a/merge/multiple_appliers_test.go
+++ b/merge/multiple_appliers_test.go
@@ -554,11 +554,10 @@ func testMultipleAppliersFieldUnsetting(t *testing.T, v1, v2, v3 fieldpath.APIVe
 					`,
 				},
 			},
-			Object: typed.YAMLObject(fmt.Sprintf(`
+			Object: typed.YAMLObject(`
 				struct:
 				  name: a
-				  complexField_%s: null
-			`, v3)),
+			`),
 			APIVersion: v3,
 			Managed: fieldpath.ManagedFields{
 				"apply-one": fieldpath.NewVersionedSet(
@@ -1072,6 +1071,13 @@ func TestMultipleAppliersNestedType(t *testing.T) {
 			`,
 			APIVersion: "v1",
 			Managed: fieldpath.ManagedFields{
+				"apply-one": fieldpath.NewVersionedSet(
+					_NS(
+						_P("mapOfMapsRecursive"),
+					),
+					"v4",
+					false,
+				),
 				"apply-two": fieldpath.NewVersionedSet(
 					_NS(
 						_P("mapOfMapsRecursive", "a"),
@@ -1285,6 +1291,13 @@ func TestMultipleAppliersRealConversion(t *testing.T) {
 			`,
 			APIVersion: "v4",
 			Managed: fieldpath.ManagedFields{
+				"apply-one": fieldpath.NewVersionedSet(
+					_NS(
+						_P("mapOfMapsRecursive"),
+					),
+					"v4",
+					false,
+				),
 				"apply-two": fieldpath.NewVersionedSet(
 					_NS(
 						_P("mapOfMapsRecursive", "aa"),

--- a/merge/nested_test.go
+++ b/merge/nested_test.go
@@ -44,6 +44,18 @@ var nestedTypeParser = func() Parser {
       - name: mapOfMapsRecursive
         type:
           namedType: mapOfMapsRecursive
+      - name: struct
+        type:
+          namedType: struct
+- name: struct
+  map:
+    fields:
+    - name: name
+      type:
+        scalar: string
+    - name: value
+      type:
+        scalar: number
 - name: listOfLists
   list:
     elementType:
@@ -499,6 +511,193 @@ func TestUpdateNestedType(t *testing.T) {
 					false,
 				),
 			},
+		},
+		"struct_apply_remove_all": {
+			Ops: []Operation{
+				Apply{
+					Manager: "default",
+					Object: `
+						struct:
+						  name: a
+						  value: 1
+					`,
+					APIVersion: "v1",
+				},
+				Apply{
+					Manager: "default",
+					Object: `
+					`,
+					APIVersion: "v1",
+				},
+			},
+			Object: `
+			`,
+			APIVersion: "v1",
+			Managed:    fieldpath.ManagedFields{},
+		},
+		"struct_apply_remove_dangling": {
+			Ops: []Operation{
+				Apply{
+					Manager: "default",
+					Object: `
+						struct:
+						  name: a
+					`,
+					APIVersion: "v1",
+				},
+				Apply{
+					Manager: "default",
+					Object: `
+						struct:
+					`,
+					APIVersion: "v1",
+				},
+			},
+			Object: `
+				struct:
+			`,
+			APIVersion: "v1",
+			Managed: fieldpath.ManagedFields{
+				"default": fieldpath.NewVersionedSet(
+					_NS(
+						_P("struct"),
+					),
+					"v1",
+					true,
+				),
+			},
+		},
+		"struct_apply_update_remove_all": {
+			Ops: []Operation{
+				Apply{
+					Manager: "default",
+					Object: `
+						struct:
+						  name: a
+					`,
+					APIVersion: "v1",
+				},
+				Update{
+					Manager: "controller",
+					Object: `
+						struct:
+						  name: a
+						  value: 1
+					`,
+					APIVersion: "v1",
+				},
+				Apply{
+					Manager: "default",
+					Object: `
+					`,
+					APIVersion: "v1",
+				},
+			},
+			Object: `
+				struct:
+				  value: 1
+			`,
+			APIVersion: "v1",
+		},
+		"struct_apply_update_dict_dangling": {
+			Ops: []Operation{
+				Apply{
+					Manager: "default",
+					Object: `
+						struct:
+						  name: a
+					`,
+					APIVersion: "v1",
+				},
+				Update{
+					Manager: "controller",
+					Object: `
+						struct:
+						  name: a
+						  value: 1
+					`,
+					APIVersion: "v1",
+				},
+				Apply{
+					Manager: "default",
+					Object: `
+						struct: {}
+					`,
+					APIVersion: "v1",
+				},
+			},
+			Object: `
+				struct:
+				  value: 1
+			`,
+			APIVersion: "v1",
+		},
+		"struct_apply_update_dict_null": {
+			Ops: []Operation{
+				Apply{
+					Manager: "default",
+					Object: `
+						struct:
+						  name: a
+					`,
+					APIVersion: "v1",
+				},
+				Update{
+					Manager: "controller",
+					Object: `
+						struct:
+						  name: a
+						  value: 1
+					`,
+					APIVersion: "v1",
+				},
+				Apply{
+					Manager: "default",
+					Object: `
+						struct:
+					`,
+					APIVersion: "v1",
+				},
+			},
+			Object: `
+				struct:
+				  value: 1
+			`,
+			APIVersion: "v1",
+		},
+		"struct_apply_update_took_over": {
+			Ops: []Operation{
+				Apply{
+					Manager: "default",
+					Object: `
+						struct:
+						  name: a
+					`,
+					APIVersion: "v1",
+				},
+				Update{
+					Manager: "controller",
+					Object: `
+						struct:
+						  name: b
+						  value: 1
+					`,
+					APIVersion: "v1",
+				},
+				Apply{
+					Manager: "default",
+					Object: `
+						struct:
+					`,
+					APIVersion: "v1",
+				},
+			},
+			Object: `
+				struct:
+				  name: b
+				  value: 1
+			`,
+			APIVersion: "v1",
 		},
 	}
 

--- a/typed/tofieldset.go
+++ b/typed/tofieldset.go
@@ -137,7 +137,9 @@ func (v *toFieldSetWalker) visitMapItems(t *schema.Map, m value.Map) (errs Valid
 		v2 := v.prepareDescent(pe, tr)
 		v2.value = val
 		errs = append(errs, v2.toFieldSet()...)
-		if _, ok := t.FindField(key); !ok {
+		if val.IsNull() || (val.IsMap() && val.AsMap().Length() == 0) {
+			v2.set.Insert(v2.path)
+		} else if _, ok := t.FindField(key); !ok {
 			v2.set.Insert(v2.path)
 		}
 		v.finishDescent(v2)


### PR DESCRIPTION
Fixes #171 

This fixes a bug and slightly changes an existing behavior.

Struct that have a null value will now be owned, i.e.
```
struct:
```
will now be owned by whoever applies that (currently, these can't be owned, which means we may accidentally drop the empty struct).

Also, removing a struct will now remove all the items that are not owned by someone else in it (including things that are owned by an updater).