### PR TITLE
Fix benchmark broken by owning empty structs

### DIFF
--- a/merge/multiple_appliers_test.go
+++ b/merge/multiple_appliers_test.go
@@ -1772,6 +1772,13 @@ func BenchmarkMultipleApplierRecursiveRealConversion(b *testing.B) {
 		`,
 		APIVersion: "v4",
 		Managed: fieldpath.ManagedFields{
+			"apply-one": fieldpath.NewVersionedSet(
+				_NS(
+					_P("mapOfMapsRecursive"),
+				),
+				"v4",
+				false,
+			),
 			"apply-two": fieldpath.NewVersionedSet(
 				_NS(
 					_P("mapOfMapsRecursive", "aa"),


### PR DESCRIPTION
This should have been part of f09efb3313b4f4544756a0c89900c4a25787e054