### PR TITLE
Update gopkg.in/yaml.v2 library from v2.2.1 to v2.2.8

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module sigs.k8s.io/structured-merge-diff/v4
 
-require gopkg.in/yaml.v2 v2.2.1
+require gopkg.in/yaml.v2 v2.2.8
 
 require (
 	github.com/google/gofuzz v1.0.0

--- a/go.sum
+++ b/go.sum
@@ -15,5 +15,5 @@ github.com/stretchr/testify v1.3.0 h1:TivCn/peBQ7UY8ooIcPgZFpTNSz0Q2U6UrFlUfqbe0
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
-gopkg.in/yaml.v2 v2.2.1 h1:mUhvW9EsL+naU5Q3cakzfE91YhliOondGd6ZrsDBHQE=
-gopkg.in/yaml.v2 v2.2.1/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
+gopkg.in/yaml.v2 v2.2.8 h1:obN1ZagJSUGI0Ek/LBmuj4SNLPfIny3KsKFopxRdj10=
+gopkg.in/yaml.v2 v2.2.8/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=


### PR DESCRIPTION
The latest / `v4.1.1` release of `structured-merge-diff` still uses `v2.2.1` of `gopkg.in/yaml.v2` ([go.mod](https://github.com/kubernetes-sigs/structured-merge-diff/blob/v4.1.1/go.sum#L18-L19)), which still contains the medium vulnerability [CVE-2019-11254](https://nvd.nist.gov/vuln/detail/CVE-2019-11254) which can cause excessive CPU while parsing certain YAML. This is fixed in [v2.2.8](https://github.com/go-yaml/yaml/releases/tag/v2.2.8) of `gopkg.in/yaml.v2` , specifically [this commit](https://github.com/go-yaml/yaml/commit/53403b58ad1b561927d19068c655246f2db79d48).