### PR TITLE
Don't process schemaless fields with ReconcileFieldSetWithSchema

### DIFF
--- a/typed/reconcile_schema_test.go
+++ b/typed/reconcile_schema_test.go
@@ -98,6 +98,66 @@ func granularSchema(version string) typed.YAMLObject {
     - name: numeric
       type:
         scalar: numeric
+- name: empty
+  map:
+    elementType:
+      scalar: untyped
+      list:
+        elementType:
+          namedType: __untyped_atomic_
+        elementRelationship: atomic
+      map:
+        elementType:
+          namedType: __untyped_deduced_
+        elementRelationship: separable
+- name: emptyWithPreserveUnknown
+  map:
+    fields:
+    - name: preserveField
+      type:
+        map:
+          elementType:
+            scalar: untyped
+            list:
+              elementType:
+                namedType: __untyped_atomic_
+              elementRelationship: atomic
+            map:
+              elementType:
+                namedType: __untyped_deduced_
+              elementRelationship: separable
+- name: populatedWithPreserveUnknown
+  map:
+    fields:
+    - name: preserveField
+      type:
+        map:
+          fields:
+          - name: list
+            type:
+              namedType: list
+          elementType:
+            namedType: __untyped_deduced_
+- name: __untyped_atomic_
+  scalar: untyped
+  list:
+    elementType:
+      namedType: __untyped_atomic_
+    elementRelationship: atomic
+  map:
+    elementType:
+      namedType: __untyped_atomic_
+    elementRelationship: atomic
+- name: __untyped_deduced_
+  scalar: untyped
+  list:
+    elementType:
+      namedType: __untyped_atomic_
+    elementRelationship: atomic
+  map:
+    elementType:
+      namedType: __untyped_deduced_
+    elementRelationship: separable
 `, version))
 }
 
@@ -164,6 +224,66 @@ func atomicSchema(version string) typed.YAMLObject {
     - name: numeric
       type:
         scalar: numeric
+- name: empty
+  map:
+    elementType:
+      scalar: untyped
+      list:
+        elementType:
+          namedType: __untyped_atomic_
+        elementRelationship: atomic
+      map:
+        elementType:
+          namedType: __untyped_deduced_
+        elementRelationship: separable
+- name: emptyWithPreserveUnknown
+  map:
+    fields:
+    - name: preserveField
+      type:
+        map:
+          elementType:
+            scalar: untyped
+            list:
+              elementType:
+                namedType: __untyped_atomic_
+              elementRelationship: atomic
+            map:
+              elementType:
+                namedType: __untyped_deduced_
+              elementRelationship: separable
+- name: populatedWithPreserveUnknown
+  map:
+    fields:
+    - name: preserveField
+      type:
+        map:
+          fields:
+          - name: list
+            type:
+              namedType: list
+          elementType:
+            namedType: __untyped_deduced_
+- name: __untyped_atomic_
+  scalar: untyped
+  list:
+    elementType:
+      namedType: __untyped_atomic_
+    elementRelationship: atomic
+  map:
+    elementType:
+      namedType: __untyped_atomic_
+    elementRelationship: atomic
+- name: __untyped_deduced_
+  scalar: untyped
+  list:
+    elementType:
+      namedType: __untyped_atomic_
+    elementRelationship: atomic
+  map:
+    elementType:
+      namedType: __untyped_deduced_
+    elementRelationship: separable
 `, version))
 }
 
@@ -257,6 +377,55 @@ unchanged: {}
 		_P("unchanged"),
 	),
 	fixedFields: nil, // indicates no change
+}, {
+	name:         "deduced",
+	rootTypeName: "empty",
+	oldSchema:    atomicSchema("v1"),
+	newSchema:    granularSchema("v1"),
+	liveObject:   basicLiveObject,
+	oldFields: _NS(
+		_P("struct"),
+		_P("list"),
+		_P("objectList"),
+		_P("unchanged", "numeric"),
+	),
+	fixedFields: nil, // indicates no change
+}, {
+	name:         "empty-preserve-unknown",
+	rootTypeName: "emptyWithPreserveUnknown",
+	oldSchema:    atomicSchema("v1"),
+	newSchema:    granularSchema("v1"),
+	liveObject: typed.YAMLObject(`
+preserveField:
+  arbitrary: abc
+`),
+	oldFields: _NS(
+		_P("preserveField"),
+		_P("preserveField", "arbitrary"),
+	),
+	fixedFields: nil, // indicates no change
+}, {
+	name:         "populated-preserve-unknown",
+	rootTypeName: "populatedWithPreserveUnknown",
+	oldSchema:    granularSchema("v1"),
+	newSchema:    atomicSchema("v1"),
+	liveObject: typed.YAMLObject(`
+preserveField:
+  arbitrary: abc
+  list:
+  - one
+`),
+	oldFields: _NS(
+		_P("preserveField"),
+		_P("preserveField", "arbitrary"),
+		_P("preserveField", "list"),
+		_P("preserveField", "list", _V("one")),
+	),
+	fixedFields: _NS(
+		_P("preserveField"),
+		_P("preserveField", "arbitrary"),
+		_P("preserveField", "list"),
+	),
 }}
 
 func TestReconcileFieldSetWithSchema(t *testing.T) {


### PR DESCRIPTION
Mitigates https://github.com/kubernetes/kubernetes/issues/102749 by avoiding traversal of:
- CRD schemas that are deduced
- Branches of schemas where x-kubernetes-preserve-unknown-fields=true and there are no fields defined

For example, this will skip traversal for:

```yaml
apiVersion: apiextensions.k8s.io/v1
kind: CustomResourceDefinition
metadata:
  name: example.k8s.io
spec:
  group: k8s.io
  # see https://kubernetes.io/docs/tasks/extend-kubernetes/custom-resources/custom-resource-definitions/#field-pruning
  preserveUnknownFields: true
  versions:
  - name: v1
    served: true
    storage: true
```

and

```yaml
apiVersion: apiextensions.k8s.io/v1
kind: CustomResourceDefinition
...
schema:
  openAPIV3Schema:
    properties:
      spec:
        type: object
        x-kubernetes-preserve-unknown-fields: true
      status:
        type: object
        x-kubernetes-preserve-unknown-fields: true
```

But still do traversal for:

```yaml
apiVersion: apiextensions.k8s.io/v1
kind: CustomResourceDefinition
...
schema:
  openAPIV3Schema:
    properties:
      spec:
        type: object
        x-kubernetes-preserve-unknown-fields: true
        properties:
          deadline:
             format: int64
             type: integer
...
```

Additional details for reviewers
-----------------------------------------

Discovery OpenAPI schema for CRD with no schema:
- https://gist.github.com/jpbetz/9172e4620e39f9ca40b19f928af8576f

How the spec.preserveUnknownFields flags is used when converting from CRDs to discoverable openapi schemas:
- https://github.com/kubernetes/kube-openapi/blob/3c818078ee3de6569a8f02b6345ea3c4cc8b0998/pkg/schemaconv/smd.go#L289-L292

How openAPI schema's map to SMD schemas, for the case of x-kubernetes-preserve-unknown-fields:
- https://github.com/kubernetes/kube-openapi/pull/239

Manual test: https://gist.github.com/jpbetz/c06ee61492d70e47d9455af5f85dd9de