### PR TITLE
Fix potential conversion failure in addBackOwnedItems

### DIFF
--- a/merge/update.go
+++ b/merge/update.go
@@ -250,33 +250,54 @@ func (s *Updater) addBackOwnedItems(merged, pruned *typed.TypedValue, managedFie
 		}
 		managedAtVersion[managerSet.APIVersion()] = managedAtVersion[managerSet.APIVersion()].Union(managerSet.Set())
 	}
+	// Add back owned items at pruned version first to avoid conversion failure
+	// caused by pruned fields which are required for conversion.
+	prunedVersion := fieldpath.APIVersion(*pruned.TypeRef().NamedType)
+	if managed, ok := managedAtVersion[prunedVersion]; ok {
+		merged, pruned, err = s.addBackOwnedItemsForVersion(merged, pruned, prunedVersion, managed)
+		if err != nil {
+			return nil, err
+		}
+		delete(managedAtVersion, prunedVersion)
+	}
 	for version, managed := range managedAtVersion {
-		merged, err = s.Converter.Convert(merged, version)
+		merged, pruned, err = s.addBackOwnedItemsForVersion(merged, pruned, version, managed)
 		if err != nil {
-			if s.Converter.IsMissingVersionError(err) {
-				continue
-			}
-			return nil, fmt.Errorf("failed to convert merged object at version %v: %v", version, err)
+			return nil, err
 		}
-		pruned, err = s.Converter.Convert(pruned, version)
-		if err != nil {
-			if s.Converter.IsMissingVersionError(err) {
-				continue
-			}
-			return nil, fmt.Errorf("failed to convert pruned object at version %v: %v", version, err)
-		}
-		mergedSet, err := merged.ToFieldSet()
-		if err != nil {
-			return nil, fmt.Errorf("failed to create field set from merged object at version %v: %v", version, err)
-		}
-		prunedSet, err := pruned.ToFieldSet()
-		if err != nil {
-			return nil, fmt.Errorf("failed to create field set from pruned object at version %v: %v", version, err)
-		}
-		sc, tr := merged.Schema(), merged.TypeRef()
-		pruned = merged.RemoveItems(mergedSet.EnsureNamedFieldsAreMembers(sc, tr).Difference(prunedSet.EnsureNamedFieldsAreMembers(sc, tr).Union(managed.EnsureNamedFieldsAreMembers(sc, tr))))
 	}
 	return pruned, nil
+}
+
+// addBackOwnedItemsForVersion adds back any fields, list and map items that were removed by prune with specific managed field path at a version.
+// It is an extracted sub-function from addBackOwnedItems for code reuse.
+func (s *Updater) addBackOwnedItemsForVersion(merged, pruned *typed.TypedValue, version fieldpath.APIVersion, managed *fieldpath.Set) (*typed.TypedValue, *typed.TypedValue, error) {
+	var err error
+	merged, err = s.Converter.Convert(merged, version)
+	if err != nil {
+		if s.Converter.IsMissingVersionError(err) {
+			return merged, pruned, nil
+		}
+		return nil, nil, fmt.Errorf("failed to convert merged object at version %v: %v", version, err)
+	}
+	pruned, err = s.Converter.Convert(pruned, version)
+	if err != nil {
+		if s.Converter.IsMissingVersionError(err) {
+			return merged, pruned, nil
+		}
+		return nil, nil, fmt.Errorf("failed to convert pruned object at version %v: %v", version, err)
+	}
+	mergedSet, err := merged.ToFieldSet()
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to create field set from merged object at version %v: %v", version, err)
+	}
+	prunedSet, err := pruned.ToFieldSet()
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to create field set from pruned object at version %v: %v", version, err)
+	}
+	sc, tr := merged.Schema(), merged.TypeRef()
+	pruned = merged.RemoveItems(mergedSet.EnsureNamedFieldsAreMembers(sc, tr).Difference(prunedSet.EnsureNamedFieldsAreMembers(sc, tr).Union(managed.EnsureNamedFieldsAreMembers(sc, tr))))
+	return merged, pruned, nil
 }
 
 // addBackDanglingItems makes sure that the fields list and map items removed by prune were


### PR DESCRIPTION
Currently `addBackOwnedItems` adds back managed fields by API version in a random order (for range a map), consider the following scenario:

We have an object with two API versions: v1 and v2, and use a conversion webhook to convert between the two versions. When converting v2 to v1, the conversion webhook rely on a required field **foo** of v2.

Now there're several users use server-side apply to manage this object in different versions, when some user initiate a server-side apply to the object in v2, `addBackOwnedItems` would have to convert and add back fields to the pruned object in both v1 and v2. At this time, the order matters:

If `addBackOwnedItems` converts and adds back fields to v2 first then v1, everything will go smoothly, however, if the order is reversed, a `failed to convert pruned object at version v1` error will arise and the server-side apply will fail. This is because when `addBackOwnedItems` convert the pruned v1 object, the required field **foo** of v2 hasn't been added back and will cause the conversion from v2 to v1 to fail.

This PR indroduce a retry loop to `addBackOwnedItems` to ensure that when it convert the pruned object to a specific version, the object already has all the required fields back.