### PR TITLE
Add test to verify that apply after update should work with no conflict

### DIFF
--- a/merge/leaf_test.go
+++ b/merge/leaf_test.go
@@ -47,6 +47,37 @@ var leafFieldsParser = func() Parser {
 
 func TestUpdateLeaf(t *testing.T) {
 	tests := map[string]TestCase{
+		"update_apply": {
+			Ops: []Operation{
+				Update{
+					Manager: "default",
+					Object: `
+						numeric: 1
+					`,
+					APIVersion: "v1",
+				},
+				Apply{
+					Manager: "default",
+					Object: `
+						numeric: 2
+					`,
+					APIVersion: "v1",
+				},
+			},
+			Object: `
+				numeric: 2
+			`,
+			APIVersion: "v1",
+			Managed: fieldpath.ManagedFields{
+				"default": fieldpath.NewVersionedSet(
+					_NS(
+						_P("numeric"),
+					),
+					"v1",
+					true,
+				),
+			},
+		},
 		"apply_twice": {
 			Ops: []Operation{
 				Apply{


### PR DESCRIPTION
While investigating https://github.com/kubernetes/kubernetes/issues/107417 , I found that at least at the level of structured merge diff, `Apply` doesn't cause conflict with `Update` if manager name is the same.  This PR adds test for it.