### PR TITLE
Skip comparison when value or object itself is null

### DIFF
--- a/typed/typed.go
+++ b/typed/typed.go
@@ -126,8 +126,14 @@ func (tv TypedValue) Compare(rhs *TypedValue) (c *Comparison, err error) {
 	}
 	_, err = merge(&tv, rhs, func(w *mergingWalker) {
 		if w.lhs == nil {
+			if w.rhs == nil || w.rhs.IsNull() {
+				return
+			}
 			c.Added.Insert(w.path)
 		} else if w.rhs == nil {
+			if w.lhs == nil || w.lhs.IsNull() {
+				return
+			}
 			c.Removed.Insert(w.path)
 		} else if !value.Equals(w.rhs, w.lhs) {
 			// TODO: Equality is not sufficient for this.


### PR DESCRIPTION
When there is null field in left hand side(lhs) or right hand side(rhs),
comparison of TypedValue always thinks that these fields are added or removed.
That causes that time field is always updated as if some fields are changed.
However, no field is changed.

This PR adds extra check for both `lhs` and `rhs`. If both sides are
null, compare function will think that there is no change.

Fixes: https://github.com/kubernetes/kubernetes/issues/108234

cc: @apelisse 