### PR TITLE
add CopyInto method to schema.Schema

### DIFF
--- a/schema/elements.go
+++ b/schema/elements.go
@@ -259,3 +259,25 @@ func (s *Schema) Resolve(tr TypeRef) (Atom, bool) {
 	}
 	return tr.Inlined, true
 }
+
+// Clones this instance of Schema into the other
+// If other is nil this method does nothing.
+// If other is already initialized, overwrites it with this instance
+// Warning: Not thread safe
+func (s Schema) CopyInto(dst *Schema) {
+	if dst == nil {
+		return
+	}
+
+	// Schema type is considered immutable so sharing references
+	dst.Types = s.Types
+
+	if s.m != nil {
+		// If cache is non-nil then the once token had been consumed.
+		// Must reset token and use it again to ensure same semantics.
+		dst.once = sync.Once{}
+		dst.once.Do(func() {
+			dst.m = s.m
+		})
+	}
+}

--- a/schema/elements_test.go
+++ b/schema/elements_test.go
@@ -120,3 +120,44 @@ func TestResolve(t *testing.T) {
 		})
 	}
 }
+
+func TestCopyInto(t *testing.T) {
+	existing := "existing"
+	notExisting := "not-existing"
+	a := Atom{List: &List{}}
+
+	tests := []struct {
+		testName       string
+		schemaTypeDefs []TypeDef
+		typeRef        TypeRef
+	}{
+		{"noNamedType", nil, TypeRef{Inlined: a}},
+		{"notExistingNamedType", nil, TypeRef{NamedType: &notExisting}},
+		{"existingNamedType", []TypeDef{{Name: existing, Atom: a}}, TypeRef{NamedType: &existing}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.testName, func(t *testing.T) {
+			t.Parallel()
+			s := Schema{
+				Types: tt.schemaTypeDefs,
+			}
+
+			theCopy := Schema{}
+			s.CopyInto(&theCopy)
+
+			if !reflect.DeepEqual(s, theCopy) {
+				t.Fatal("")
+			}
+
+			// test after resolve
+			_, _ = s.Resolve(tt.typeRef)
+			theCopy = Schema{}
+			s.CopyInto(&theCopy)
+
+			if !reflect.DeepEqual(s, theCopy) {
+				t.Fatal("")
+			}
+		})
+	}
+}


### PR DESCRIPTION
Now that schema.Schema has sync.Once attached, it makes no sense to encourage others to treat it as a value. This PR adds a `NewSchema` function as well as changes some usages of Schemas to use pointers rather than values.