### PR TITLE
add field-level element relationship which overrides referred type

### DIFF
--- a/internal/fixture/state.go
+++ b/internal/fixture/state.go
@@ -477,7 +477,7 @@ func (cs ChangeParser) run(state *State) error {
 	// Swap the schema in for use with the live object so it merges.
 	// If the schema is incompatible, this will fail validation.
 
-	liveWithNewSchema, err := typed.AsTyped(state.Live.AsValue(), &cs.Parser.Schema, state.Live.TypeRef())
+	liveWithNewSchema, err := typed.AsTyped(state.Live.AsValue(), cs.Parser.Schema, state.Live.TypeRef())
 	if err != nil {
 		return err
 	}

--- a/internal/testdata/k8s-schema-100pct-fieldoverride.yaml
+++ b/internal/testdata/k8s-schema-100pct-fieldoverride.yaml
@@ -1,0 +1,10903 @@
+types:
+- name: io.k8s.api.admissionregistration.v1alpha1.Initializer
+  map:
+    fields:
+    - name: name
+      type:
+        scalar: string
+    - name: rules
+      type:
+        list:
+          elementType:
+            namedType: io.k8s.api.admissionregistration.v1alpha1.Rule
+          elementRelationship: atomic
+- name: io.k8s.api.admissionregistration.v1alpha1.InitializerConfiguration
+  map:
+    fields:
+    - name: apiVersion
+      type:
+        scalar: string
+    - name: initializers
+      type:
+        list:
+          elementType:
+            namedType: io.k8s.api.admissionregistration.v1alpha1.Initializer
+          elementRelationship: associative
+          keys:
+          - name
+    - name: kind
+      type:
+        scalar: string
+    - name: metadata
+      type:
+        namedType: io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta
+        elementRelationship: granular
+- name: io.k8s.api.admissionregistration.v1alpha1.InitializerConfigurationList
+  map:
+    fields:
+    - name: apiVersion
+      type:
+        scalar: string
+    - name: items
+      type:
+        list:
+          elementType:
+            namedType: io.k8s.api.admissionregistration.v1alpha1.InitializerConfiguration
+          elementRelationship: atomic
+    - name: kind
+      type:
+        scalar: string
+    - name: metadata
+      type:
+        namedType: io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta
+        elementRelationship: granular
+        elementRelationship: granular
+- name: io.k8s.api.admissionregistration.v1alpha1.Rule
+  map:
+    fields:
+    - name: apiGroups
+      type:
+        list:
+          elementType:
+            scalar: string
+          elementRelationship: atomic
+    - name: apiVersions
+      type:
+        list:
+          elementType:
+            scalar: string
+          elementRelationship: atomic
+    - name: resources
+      type:
+        list:
+          elementType:
+            scalar: string
+          elementRelationship: atomic
+- name: io.k8s.api.admissionregistration.v1beta1.MutatingWebhookConfiguration
+  map:
+    fields:
+    - name: apiVersion
+      type:
+        scalar: string
+    - name: kind
+      type:
+        scalar: string
+    - name: metadata
+      type:
+        namedType: io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta
+        elementRelationship: granular
+    - name: webhooks
+      type:
+        list:
+          elementType:
+            namedType: io.k8s.api.admissionregistration.v1beta1.Webhook
+          elementRelationship: associative
+          keys:
+          - name
+- name: io.k8s.api.admissionregistration.v1beta1.MutatingWebhookConfigurationList
+  map:
+    fields:
+    - name: apiVersion
+      type:
+        scalar: string
+    - name: items
+      type:
+        list:
+          elementType:
+            namedType: io.k8s.api.admissionregistration.v1beta1.MutatingWebhookConfiguration
+          elementRelationship: atomic
+    - name: kind
+      type:
+        scalar: string
+    - name: metadata
+      type:
+        namedType: io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta
+        elementRelationship: granular
+- name: io.k8s.api.admissionregistration.v1beta1.RuleWithOperations
+  map:
+    fields:
+    - name: apiGroups
+      type:
+        list:
+          elementType:
+            scalar: string
+          elementRelationship: atomic
+    - name: apiVersions
+      type:
+        list:
+          elementType:
+            scalar: string
+          elementRelationship: atomic
+    - name: operations
+      type:
+        list:
+          elementType:
+            scalar: string
+          elementRelationship: atomic
+    - name: resources
+      type:
+        list:
+          elementType:
+            scalar: string
+          elementRelationship: atomic
+- name: io.k8s.api.admissionregistration.v1beta1.ServiceReference
+  map:
+    fields:
+    - name: name
+      type:
+        scalar: string
+    - name: namespace
+      type:
+        scalar: string
+    - name: path
+      type:
+        scalar: string
+- name: io.k8s.api.admissionregistration.v1beta1.ValidatingWebhookConfiguration
+  map:
+    fields:
+    - name: apiVersion
+      type:
+        scalar: string
+    - name: kind
+      type:
+        scalar: string
+    - name: metadata
+      type:
+        namedType: io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta
+        elementRelationship: granular
+    - name: webhooks
+      type:
+        list:
+          elementType:
+            namedType: io.k8s.api.admissionregistration.v1beta1.Webhook
+          elementRelationship: associative
+          keys:
+          - name
+- name: io.k8s.api.admissionregistration.v1beta1.ValidatingWebhookConfigurationList
+  map:
+    fields:
+    - name: apiVersion
+      type:
+        scalar: string
+    - name: items
+      type:
+        list:
+          elementType:
+            namedType: io.k8s.api.admissionregistration.v1beta1.ValidatingWebhookConfiguration
+          elementRelationship: atomic
+    - name: kind
+      type:
+        scalar: string
+    - name: metadata
+      type:
+        namedType: io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta
+        elementRelationship: granular
+- name: io.k8s.api.admissionregistration.v1beta1.Webhook
+  map:
+    fields:
+    - name: clientConfig
+      type:
+        namedType: io.k8s.api.admissionregistration.v1beta1.WebhookClientConfig
+        elementRelationship: granular
+    - name: failurePolicy
+      type:
+        scalar: string
+    - name: name
+      type:
+        scalar: string
+    - name: namespaceSelector
+      type:
+        namedType: io.k8s.apimachinery.pkg.apis.meta.v1.LabelSelector
+        elementRelationship: granular
+    - name: rules
+      type:
+        list:
+          elementType:
+            namedType: io.k8s.api.admissionregistration.v1beta1.RuleWithOperations
+          elementRelationship: atomic
+    - name: sideEffects
+      type:
+        scalar: string
+- name: io.k8s.api.admissionregistration.v1beta1.WebhookClientConfig
+  map:
+    fields:
+    - name: caBundle
+      type:
+        scalar: string
+    - name: service
+      type:
+        namedType: io.k8s.api.admissionregistration.v1beta1.ServiceReference
+        elementRelationship: granular
+    - name: url
+      type:
+        scalar: string
+- name: io.k8s.api.apps.v1.ControllerRevision
+  map:
+    fields:
+    - name: apiVersion
+      type:
+        scalar: string
+    - name: data
+      type:
+        namedType: __untyped_atomic_
+        elementRelationship: granular
+    - name: kind
+      type:
+        scalar: string
+    - name: metadata
+      type:
+        namedType: io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta
+        elementRelationship: granular
+    - name: revision
+      type:
+        scalar: numeric
+- name: io.k8s.api.apps.v1.ControllerRevisionList
+  map:
+    fields:
+    - name: apiVersion
+      type:
+        scalar: string
+    - name: items
+      type:
+        list:
+          elementType:
+            namedType: io.k8s.api.apps.v1.ControllerRevision
+          elementRelationship: atomic
+    - name: kind
+      type:
+        scalar: string
+    - name: metadata
+      type:
+        namedType: io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta
+        elementRelationship: granular
+- name: io.k8s.api.apps.v1.DaemonSet
+  map:
+    fields:
+    - name: apiVersion
+      type:
+        scalar: string
+    - name: kind
+      type:
+        scalar: string
+    - name: metadata
+      type:
+        namedType: io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta
+        elementRelationship: granular
+    - name: spec
+      type:
+        namedType: io.k8s.api.apps.v1.DaemonSetSpec
+        elementRelationship: granular
+    - name: status
+      type:
+        namedType: io.k8s.api.apps.v1.DaemonSetStatus
+        elementRelationship: granular
+- name: io.k8s.api.apps.v1.DaemonSetCondition
+  map:
+    fields:
+    - name: lastTransitionTime
+      type:
+        namedType: io.k8s.apimachinery.pkg.apis.meta.v1.Time
+    - name: message
+      type:
+        scalar: string
+    - name: reason
+      type:
+        scalar: string
+    - name: status
+      type:
+        scalar: string
+    - name: type
+      type:
+        scalar: string
+- name: io.k8s.api.apps.v1.DaemonSetList
+  map:
+    fields:
+    - name: apiVersion
+      type:
+        scalar: string
+    - name: items
+      type:
+        list:
+          elementType:
+            namedType: io.k8s.api.apps.v1.DaemonSet
+          elementRelationship: atomic
+    - name: kind
+      type:
+        scalar: string
+    - name: metadata
+      type:
+        namedType: io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta
+        elementRelationship: granular
+- name: io.k8s.api.apps.v1.DaemonSetSpec
+  map:
+    fields:
+    - name: minReadySeconds
+      type:
+        scalar: numeric
+    - name: revisionHistoryLimit
+      type:
+        scalar: numeric
+    - name: selector
+      type:
+        namedType: io.k8s.apimachinery.pkg.apis.meta.v1.LabelSelector
+        elementRelationship: granular
+    - name: template
+      type:
+        namedType: io.k8s.api.core.v1.PodTemplateSpec
+        elementRelationship: granular
+    - name: updateStrategy
+      type:
+        namedType: io.k8s.api.apps.v1.DaemonSetUpdateStrategy
+        elementRelationship: granular
+- name: io.k8s.api.apps.v1.DaemonSetStatus
+  map:
+    fields:
+    - name: collisionCount
+      type:
+        scalar: numeric
+    - name: conditions
+      type:
+        list:
+          elementType:
+            namedType: io.k8s.api.apps.v1.DaemonSetCondition
+          elementRelationship: associative
+          keys:
+          - type
+    - name: currentNumberScheduled
+      type:
+        scalar: numeric
+    - name: desiredNumberScheduled
+      type:
+        scalar: numeric
+    - name: numberAvailable
+      type:
+        scalar: numeric
+    - name: numberMisscheduled
+      type:
+        scalar: numeric
+    - name: numberReady
+      type:
+        scalar: numeric
+    - name: numberUnavailable
+      type:
+        scalar: numeric
+    - name: observedGeneration
+      type:
+        scalar: numeric
+    - name: updatedNumberScheduled
+      type:
+        scalar: numeric
+- name: io.k8s.api.apps.v1.DaemonSetUpdateStrategy
+  map:
+    fields:
+    - name: rollingUpdate
+      type:
+        namedType: io.k8s.api.apps.v1.RollingUpdateDaemonSet
+        elementRelationship: granular
+    - name: type
+      type:
+        scalar: string
+- name: io.k8s.api.apps.v1.Deployment
+  map:
+    fields:
+    - name: apiVersion
+      type:
+        scalar: string
+    - name: kind
+      type:
+        scalar: string
+    - name: metadata
+      type:
+        namedType: io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta
+        elementRelationship: granular
+    - name: spec
+      type:
+        namedType: io.k8s.api.apps.v1.DeploymentSpec
+        elementRelationship: granular
+    - name: status
+      type:
+        namedType: io.k8s.api.apps.v1.DeploymentStatus
+        elementRelationship: granular
+- name: io.k8s.api.apps.v1.DeploymentCondition
+  map:
+    fields:
+    - name: lastTransitionTime
+      type:
+        namedType: io.k8s.apimachinery.pkg.apis.meta.v1.Time
+    - name: lastUpdateTime
+      type:
+        namedType: io.k8s.apimachinery.pkg.apis.meta.v1.Time
+    - name: message
+      type:
+        scalar: string
+    - name: reason
+      type:
+        scalar: string
+    - name: status
+      type:
+        scalar: string
+    - name: type
+      type:
+        scalar: string
+- name: io.k8s.api.apps.v1.DeploymentList
+  map:
+    fields:
+    - name: apiVersion
+      type:
+        scalar: string
+    - name: items
+      type:
+        list:
+          elementType:
+            namedType: io.k8s.api.apps.v1.Deployment
+          elementRelationship: atomic
+    - name: kind
+      type:
+        scalar: string
+    - name: metadata
+      type:
+        namedType: io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta
+        elementRelationship: granular
+- name: io.k8s.api.apps.v1.DeploymentSpec
+  map:
+    fields:
+    - name: minReadySeconds
+      type:
+        scalar: numeric
+    - name: paused
+      type:
+        scalar: boolean
+    - name: progressDeadlineSeconds
+      type:
+        scalar: numeric
+    - name: replicas
+      type:
+        scalar: numeric
+    - name: revisionHistoryLimit
+      type:
+        scalar: numeric
+    - name: selector
+      type:
+        namedType: io.k8s.apimachinery.pkg.apis.meta.v1.LabelSelector
+        elementRelationship: granular
+    - name: strategy
+      type:
+        namedType: io.k8s.api.apps.v1.DeploymentStrategy
+        elementRelationship: granular
+    - name: template
+      type:
+        namedType: io.k8s.api.core.v1.PodTemplateSpec
+        elementRelationship: granular
+- name: io.k8s.api.apps.v1.DeploymentStatus
+  map:
+    fields:
+    - name: availableReplicas
+      type:
+        scalar: numeric
+    - name: collisionCount
+      type:
+        scalar: numeric
+    - name: conditions
+      type:
+        list:
+          elementType:
+            namedType: io.k8s.api.apps.v1.DeploymentCondition
+          elementRelationship: associative
+          keys:
+          - type
+    - name: observedGeneration
+      type:
+        scalar: numeric
+    - name: readyReplicas
+      type:
+        scalar: numeric
+    - name: replicas
+      type:
+        scalar: numeric
+    - name: unavailableReplicas
+      type:
+        scalar: numeric
+    - name: updatedReplicas
+      type:
+        scalar: numeric
+- name: io.k8s.api.apps.v1.DeploymentStrategy
+  map:
+    fields:
+    - name: rollingUpdate
+      type:
+        namedType: io.k8s.api.apps.v1.RollingUpdateDeployment
+        elementRelationship: granular
+    - name: type
+      type:
+        scalar: string
+- name: io.k8s.api.apps.v1.ReplicaSet
+  map:
+    fields:
+    - name: apiVersion
+      type:
+        scalar: string
+    - name: kind
+      type:
+        scalar: string
+    - name: metadata
+      type:
+        namedType: io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta
+        elementRelationship: granular
+    - name: spec
+      type:
+        namedType: io.k8s.api.apps.v1.ReplicaSetSpec
+        elementRelationship: granular
+    - name: status
+      type:
+        namedType: io.k8s.api.apps.v1.ReplicaSetStatus
+        elementRelationship: granular
+- name: io.k8s.api.apps.v1.ReplicaSetCondition
+  map:
+    fields:
+    - name: lastTransitionTime
+      type:
+        namedType: io.k8s.apimachinery.pkg.apis.meta.v1.Time
+    - name: message
+      type:
+        scalar: string
+    - name: reason
+      type:
+        scalar: string
+    - name: status
+      type:
+        scalar: string
+    - name: type
+      type:
+        scalar: string
+- name: io.k8s.api.apps.v1.ReplicaSetList
+  map:
+    fields:
+    - name: apiVersion
+      type:
+        scalar: string
+    - name: items
+      type:
+        list:
+          elementType:
+            namedType: io.k8s.api.apps.v1.ReplicaSet
+          elementRelationship: atomic
+    - name: kind
+      type:
+        scalar: string
+    - name: metadata
+      type:
+        namedType: io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta
+        elementRelationship: granular
+- name: io.k8s.api.apps.v1.ReplicaSetSpec
+  map:
+    fields:
+    - name: minReadySeconds
+      type:
+        scalar: numeric
+    - name: replicas
+      type:
+        scalar: numeric
+    - name: selector
+      type:
+        namedType: io.k8s.apimachinery.pkg.apis.meta.v1.LabelSelector
+        elementRelationship: granular
+    - name: template
+      type:
+        namedType: io.k8s.api.core.v1.PodTemplateSpec
+        elementRelationship: granular
+- name: io.k8s.api.apps.v1.ReplicaSetStatus
+  map:
+    fields:
+    - name: availableReplicas
+      type:
+        scalar: numeric
+    - name: conditions
+      type:
+        list:
+          elementType:
+            namedType: io.k8s.api.apps.v1.ReplicaSetCondition
+          elementRelationship: associative
+          keys:
+          - type
+    - name: fullyLabeledReplicas
+      type:
+        scalar: numeric
+    - name: observedGeneration
+      type:
+        scalar: numeric
+    - name: readyReplicas
+      type:
+        scalar: numeric
+    - name: replicas
+      type:
+        scalar: numeric
+- name: io.k8s.api.apps.v1.RollingUpdateDaemonSet
+  map:
+    fields:
+    - name: maxUnavailable
+      type:
+        namedType: io.k8s.apimachinery.pkg.util.intstr.IntOrString
+        elementRelationship: granular
+- name: io.k8s.api.apps.v1.RollingUpdateDeployment
+  map:
+    fields:
+    - name: maxSurge
+      type:
+        namedType: io.k8s.apimachinery.pkg.util.intstr.IntOrString
+        elementRelationship: granular
+    - name: maxUnavailable
+      type:
+        namedType: io.k8s.apimachinery.pkg.util.intstr.IntOrString
+        elementRelationship: granular
+- name: io.k8s.api.apps.v1.RollingUpdateStatefulSetStrategy
+  map:
+    fields:
+    - name: partition
+      type:
+        scalar: numeric
+- name: io.k8s.api.apps.v1.StatefulSet
+  map:
+    fields:
+    - name: apiVersion
+      type:
+        scalar: string
+    - name: kind
+      type:
+        scalar: string
+    - name: metadata
+      type:
+        namedType: io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta
+        elementRelationship: granular
+    - name: spec
+      type:
+        namedType: io.k8s.api.apps.v1.StatefulSetSpec
+        elementRelationship: granular
+    - name: status
+      type:
+        namedType: io.k8s.api.apps.v1.StatefulSetStatus
+        elementRelationship: granular
+- name: io.k8s.api.apps.v1.StatefulSetCondition
+  map:
+    fields:
+    - name: lastTransitionTime
+      type:
+        namedType: io.k8s.apimachinery.pkg.apis.meta.v1.Time
+    - name: message
+      type:
+        scalar: string
+    - name: reason
+      type:
+        scalar: string
+    - name: status
+      type:
+        scalar: string
+    - name: type
+      type:
+        scalar: string
+- name: io.k8s.api.apps.v1.StatefulSetList
+  map:
+    fields:
+    - name: apiVersion
+      type:
+        scalar: string
+    - name: items
+      type:
+        list:
+          elementType:
+            namedType: io.k8s.api.apps.v1.StatefulSet
+          elementRelationship: atomic
+    - name: kind
+      type:
+        scalar: string
+    - name: metadata
+      type:
+        namedType: io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta
+        elementRelationship: granular
+- name: io.k8s.api.apps.v1.StatefulSetSpec
+  map:
+    fields:
+    - name: podManagementPolicy
+      type:
+        scalar: string
+    - name: replicas
+      type:
+        scalar: numeric
+    - name: revisionHistoryLimit
+      type:
+        scalar: numeric
+    - name: selector
+      type:
+        namedType: io.k8s.apimachinery.pkg.apis.meta.v1.LabelSelector
+        elementRelationship: granular
+    - name: serviceName
+      type:
+        scalar: string
+    - name: template
+      type:
+        namedType: io.k8s.api.core.v1.PodTemplateSpec
+        elementRelationship: granular
+    - name: updateStrategy
+      type:
+        namedType: io.k8s.api.apps.v1.StatefulSetUpdateStrategy
+        elementRelationship: granular
+    - name: volumeClaimTemplates
+      type:
+        list:
+          elementType:
+            namedType: io.k8s.api.core.v1.PersistentVolumeClaim
+          elementRelationship: atomic
+- name: io.k8s.api.apps.v1.StatefulSetStatus
+  map:
+    fields:
+    - name: collisionCount
+      type:
+        scalar: numeric
+    - name: conditions
+      type:
+        list:
+          elementType:
+            namedType: io.k8s.api.apps.v1.StatefulSetCondition
+          elementRelationship: associative
+          keys:
+          - type
+    - name: currentReplicas
+      type:
+        scalar: numeric
+    - name: currentRevision
+      type:
+        scalar: string
+    - name: observedGeneration
+      type:
+        scalar: numeric
+    - name: readyReplicas
+      type:
+        scalar: numeric
+    - name: replicas
+      type:
+        scalar: numeric
+    - name: updateRevision
+      type:
+        scalar: string
+    - name: updatedReplicas
+      type:
+        scalar: numeric
+- name: io.k8s.api.apps.v1.StatefulSetUpdateStrategy
+  map:
+    fields:
+    - name: rollingUpdate
+      type:
+        namedType: io.k8s.api.apps.v1.RollingUpdateStatefulSetStrategy
+        elementRelationship: granular
+    - name: type
+      type:
+        scalar: string
+- name: io.k8s.api.apps.v1beta1.ControllerRevision
+  map:
+    fields:
+    - name: apiVersion
+      type:
+        scalar: string
+    - name: data
+      type:
+        namedType: __untyped_atomic_
+        elementRelationship: granular
+    - name: kind
+      type:
+        scalar: string
+    - name: metadata
+      type:
+        namedType: io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta
+        elementRelationship: granular
+    - name: revision
+      type:
+        scalar: numeric
+- name: io.k8s.api.apps.v1beta1.ControllerRevisionList
+  map:
+    fields:
+    - name: apiVersion
+      type:
+        scalar: string
+    - name: items
+      type:
+        list:
+          elementType:
+            namedType: io.k8s.api.apps.v1beta1.ControllerRevision
+          elementRelationship: atomic
+    - name: kind
+      type:
+        scalar: string
+    - name: metadata
+      type:
+        namedType: io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta
+        elementRelationship: granular
+- name: io.k8s.api.apps.v1beta1.Deployment
+  map:
+    fields:
+    - name: apiVersion
+      type:
+        scalar: string
+    - name: kind
+      type:
+        scalar: string
+    - name: metadata
+      type:
+        namedType: io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta
+        elementRelationship: granular
+    - name: spec
+      type:
+        namedType: io.k8s.api.apps.v1beta1.DeploymentSpec
+        elementRelationship: granular
+    - name: status
+      type:
+        namedType: io.k8s.api.apps.v1beta1.DeploymentStatus
+        elementRelationship: granular
+- name: io.k8s.api.apps.v1beta1.DeploymentCondition
+  map:
+    fields:
+    - name: lastTransitionTime
+      type:
+        namedType: io.k8s.apimachinery.pkg.apis.meta.v1.Time
+    - name: lastUpdateTime
+      type:
+        namedType: io.k8s.apimachinery.pkg.apis.meta.v1.Time
+    - name: message
+      type:
+        scalar: string
+    - name: reason
+      type:
+        scalar: string
+    - name: status
+      type:
+        scalar: string
+    - name: type
+      type:
+        scalar: string
+- name: io.k8s.api.apps.v1beta1.DeploymentList
+  map:
+    fields:
+    - name: apiVersion
+      type:
+        scalar: string
+    - name: items
+      type:
+        list:
+          elementType:
+            namedType: io.k8s.api.apps.v1beta1.Deployment
+          elementRelationship: atomic
+    - name: kind
+      type:
+        scalar: string
+    - name: metadata
+      type:
+        namedType: io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta
+        elementRelationship: granular
+- name: io.k8s.api.apps.v1beta1.DeploymentRollback
+  map:
+    fields:
+    - name: apiVersion
+      type:
+        scalar: string
+    - name: kind
+      type:
+        scalar: string
+    - name: name
+      type:
+        scalar: string
+    - name: rollbackTo
+      type:
+        namedType: io.k8s.api.apps.v1beta1.RollbackConfig
+        elementRelationship: granular
+    - name: updatedAnnotations
+      type:
+        map:
+          elementType:
+            scalar: string
+- name: io.k8s.api.apps.v1beta1.DeploymentSpec
+  map:
+    fields:
+    - name: minReadySeconds
+      type:
+        scalar: numeric
+    - name: paused
+      type:
+        scalar: boolean
+    - name: progressDeadlineSeconds
+      type:
+        scalar: numeric
+    - name: replicas
+      type:
+        scalar: numeric
+    - name: revisionHistoryLimit
+      type:
+        scalar: numeric
+    - name: rollbackTo
+      type:
+        namedType: io.k8s.api.apps.v1beta1.RollbackConfig
+        elementRelationship: granular
+    - name: selector
+      type:
+        namedType: io.k8s.apimachinery.pkg.apis.meta.v1.LabelSelector
+        elementRelationship: granular
+    - name: strategy
+      type:
+        namedType: io.k8s.api.apps.v1beta1.DeploymentStrategy
+        elementRelationship: granular
+    - name: template
+      type:
+        namedType: io.k8s.api.core.v1.PodTemplateSpec
+        elementRelationship: granular
+- name: io.k8s.api.apps.v1beta1.DeploymentStatus
+  map:
+    fields:
+    - name: availableReplicas
+      type:
+        scalar: numeric
+    - name: collisionCount
+      type:
+        scalar: numeric
+    - name: conditions
+      type:
+        list:
+          elementType:
+            namedType: io.k8s.api.apps.v1beta1.DeploymentCondition
+          elementRelationship: associative
+          keys:
+          - type
+    - name: observedGeneration
+      type:
+        scalar: numeric
+    - name: readyReplicas
+      type:
+        scalar: numeric
+    - name: replicas
+      type:
+        scalar: numeric
+    - name: unavailableReplicas
+      type:
+        scalar: numeric
+    - name: updatedReplicas
+      type:
+        scalar: numeric
+- name: io.k8s.api.apps.v1beta1.DeploymentStrategy
+  map:
+    fields:
+    - name: rollingUpdate
+      type:
+        namedType: io.k8s.api.apps.v1beta1.RollingUpdateDeployment
+        elementRelationship: granular
+    - name: type
+      type:
+        scalar: string
+    unions:
+    - discriminator: type
+      fields:
+      - fieldName: rollingUpdate
+        discriminatorValue: RollingUpdate
+- name: io.k8s.api.apps.v1beta1.RollbackConfig
+  map:
+    fields:
+    - name: revision
+      type:
+        scalar: numeric
+- name: io.k8s.api.apps.v1beta1.RollingUpdateDeployment
+  map:
+    fields:
+    - name: maxSurge
+      type:
+        namedType: io.k8s.apimachinery.pkg.util.intstr.IntOrString
+        elementRelationship: granular
+    - name: maxUnavailable
+      type:
+        namedType: io.k8s.apimachinery.pkg.util.intstr.IntOrString
+        elementRelationship: granular
+- name: io.k8s.api.apps.v1beta1.RollingUpdateStatefulSetStrategy
+  map:
+    fields:
+    - name: partition
+      type:
+        scalar: numeric
+- name: io.k8s.api.apps.v1beta1.Scale
+  map:
+    fields:
+    - name: apiVersion
+      type:
+        scalar: string
+    - name: kind
+      type:
+        scalar: string
+    - name: metadata
+      type:
+        namedType: io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta
+        elementRelationship: granular
+    - name: spec
+      type:
+        namedType: io.k8s.api.apps.v1beta1.ScaleSpec
+        elementRelationship: granular
+    - name: status
+      type:
+        namedType: io.k8s.api.apps.v1beta1.ScaleStatus
+        elementRelationship: granular
+- name: io.k8s.api.apps.v1beta1.ScaleSpec
+  map:
+    fields:
+    - name: replicas
+      type:
+        scalar: numeric
+- name: io.k8s.api.apps.v1beta1.ScaleStatus
+  map:
+    fields:
+    - name: replicas
+      type:
+        scalar: numeric
+    - name: selector
+      type:
+        map:
+          elementType:
+            scalar: string
+    - name: targetSelector
+      type:
+        scalar: string
+- name: io.k8s.api.apps.v1beta1.StatefulSet
+  map:
+    fields:
+    - name: apiVersion
+      type:
+        scalar: string
+    - name: kind
+      type:
+        scalar: string
+    - name: metadata
+      type:
+        namedType: io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta
+        elementRelationship: granular
+    - name: spec
+      type:
+        namedType: io.k8s.api.apps.v1beta1.StatefulSetSpec
+        elementRelationship: granular
+    - name: status
+      type:
+        namedType: io.k8s.api.apps.v1beta1.StatefulSetStatus
+        elementRelationship: granular
+- name: io.k8s.api.apps.v1beta1.StatefulSetCondition
+  map:
+    fields:
+    - name: lastTransitionTime
+      type:
+        namedType: io.k8s.apimachinery.pkg.apis.meta.v1.Time
+    - name: message
+      type:
+        scalar: string
+    - name: reason
+      type:
+        scalar: string
+    - name: status
+      type:
+        scalar: string
+    - name: type
+      type:
+        scalar: string
+- name: io.k8s.api.apps.v1beta1.StatefulSetList
+  map:
+    fields:
+    - name: apiVersion
+      type:
+        scalar: string
+    - name: items
+      type:
+        list:
+          elementType:
+            namedType: io.k8s.api.apps.v1beta1.StatefulSet
+          elementRelationship: atomic
+    - name: kind
+      type:
+        scalar: string
+    - name: metadata
+      type:
+        namedType: io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta
+        elementRelationship: granular
+- name: io.k8s.api.apps.v1beta1.StatefulSetSpec
+  map:
+    fields:
+    - name: podManagementPolicy
+      type:
+        scalar: string
+    - name: replicas
+      type:
+        scalar: numeric
+    - name: revisionHistoryLimit
+      type:
+        scalar: numeric
+    - name: selector
+      type:
+        namedType: io.k8s.apimachinery.pkg.apis.meta.v1.LabelSelector
+        elementRelationship: granular
+    - name: serviceName
+      type:
+        scalar: string
+    - name: template
+      type:
+        namedType: io.k8s.api.core.v1.PodTemplateSpec
+        elementRelationship: granular
+    - name: updateStrategy
+      type:
+        namedType: io.k8s.api.apps.v1beta1.StatefulSetUpdateStrategy
+        elementRelationship: granular
+    - name: volumeClaimTemplates
+      type:
+        list:
+          elementType:
+            namedType: io.k8s.api.core.v1.PersistentVolumeClaim
+          elementRelationship: atomic
+- name: io.k8s.api.apps.v1beta1.StatefulSetStatus
+  map:
+    fields:
+    - name: collisionCount
+      type:
+        scalar: numeric
+    - name: conditions
+      type:
+        list:
+          elementType:
+            namedType: io.k8s.api.apps.v1beta1.StatefulSetCondition
+          elementRelationship: associative
+          keys:
+          - type
+    - name: currentReplicas
+      type:
+        scalar: numeric
+    - name: currentRevision
+      type:
+        scalar: string
+    - name: observedGeneration
+      type:
+        scalar: numeric
+    - name: readyReplicas
+      type:
+        scalar: numeric
+    - name: replicas
+      type:
+        scalar: numeric
+    - name: updateRevision
+      type:
+        scalar: string
+    - name: updatedReplicas
+      type:
+        scalar: numeric
+- name: io.k8s.api.apps.v1beta1.StatefulSetUpdateStrategy
+  map:
+    fields:
+    - name: rollingUpdate
+      type:
+        namedType: io.k8s.api.apps.v1beta1.RollingUpdateStatefulSetStrategy
+        elementRelationship: granular
+    - name: type
+      type:
+        scalar: string
+- name: io.k8s.api.apps.v1beta2.ControllerRevision
+  map:
+    fields:
+    - name: apiVersion
+      type:
+        scalar: string
+    - name: data
+      type:
+        namedType: __untyped_atomic_
+        elementRelationship: granular
+    - name: kind
+      type:
+        scalar: string
+    - name: metadata
+      type:
+        namedType: io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta
+        elementRelationship: granular
+    - name: revision
+      type:
+        scalar: numeric
+- name: io.k8s.api.apps.v1beta2.ControllerRevisionList
+  map:
+    fields:
+    - name: apiVersion
+      type:
+        scalar: string
+    - name: items
+      type:
+        list:
+          elementType:
+            namedType: io.k8s.api.apps.v1beta2.ControllerRevision
+          elementRelationship: atomic
+    - name: kind
+      type:
+        scalar: string
+    - name: metadata
+      type:
+        namedType: io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta
+        elementRelationship: granular
+- name: io.k8s.api.apps.v1beta2.DaemonSet
+  map:
+    fields:
+    - name: apiVersion
+      type:
+        scalar: string
+    - name: kind
+      type:
+        scalar: string
+    - name: metadata
+      type:
+        namedType: io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta
+        elementRelationship: granular
+    - name: spec
+      type:
+        namedType: io.k8s.api.apps.v1beta2.DaemonSetSpec
+        elementRelationship: granular
+    - name: status
+      type:
+        namedType: io.k8s.api.apps.v1beta2.DaemonSetStatus
+        elementRelationship: granular
+- name: io.k8s.api.apps.v1beta2.DaemonSetCondition
+  map:
+    fields:
+    - name: lastTransitionTime
+      type:
+        namedType: io.k8s.apimachinery.pkg.apis.meta.v1.Time
+    - name: message
+      type:
+        scalar: string
+    - name: reason
+      type:
+        scalar: string
+    - name: status
+      type:
+        scalar: string
+    - name: type
+      type:
+        scalar: string
+- name: io.k8s.api.apps.v1beta2.DaemonSetList
+  map:
+    fields:
+    - name: apiVersion
+      type:
+        scalar: string
+    - name: items
+      type:
+        list:
+          elementType:
+            namedType: io.k8s.api.apps.v1beta2.DaemonSet
+          elementRelationship: atomic
+    - name: kind
+      type:
+        scalar: string
+    - name: metadata
+      type:
+        namedType: io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta
+        elementRelationship: granular
+- name: io.k8s.api.apps.v1beta2.DaemonSetSpec
+  map:
+    fields:
+    - name: minReadySeconds
+      type:
+        scalar: numeric
+    - name: revisionHistoryLimit
+      type:
+        scalar: numeric
+    - name: selector
+      type:
+        namedType: io.k8s.apimachinery.pkg.apis.meta.v1.LabelSelector
+        elementRelationship: granular
+    - name: template
+      type:
+        namedType: io.k8s.api.core.v1.PodTemplateSpec
+        elementRelationship: granular
+    - name: updateStrategy
+      type:
+        namedType: io.k8s.api.apps.v1beta2.DaemonSetUpdateStrategy
+        elementRelationship: granular
+- name: io.k8s.api.apps.v1beta2.DaemonSetStatus
+  map:
+    fields:
+    - name: collisionCount
+      type:
+        scalar: numeric
+    - name: conditions
+      type:
+        list:
+          elementType:
+            namedType: io.k8s.api.apps.v1beta2.DaemonSetCondition
+          elementRelationship: associative
+          keys:
+          - type
+    - name: currentNumberScheduled
+      type:
+        scalar: numeric
+    - name: desiredNumberScheduled
+      type:
+        scalar: numeric
+    - name: numberAvailable
+      type:
+        scalar: numeric
+    - name: numberMisscheduled
+      type:
+        scalar: numeric
+    - name: numberReady
+      type:
+        scalar: numeric
+    - name: numberUnavailable
+      type:
+        scalar: numeric
+    - name: observedGeneration
+      type:
+        scalar: numeric
+    - name: updatedNumberScheduled
+      type:
+        scalar: numeric
+- name: io.k8s.api.apps.v1beta2.DaemonSetUpdateStrategy
+  map:
+    fields:
+    - name: rollingUpdate
+      type:
+        namedType: io.k8s.api.apps.v1beta2.RollingUpdateDaemonSet
+        elementRelationship: granular
+    - name: type
+      type:
+        scalar: string
+- name: io.k8s.api.apps.v1beta2.Deployment
+  map:
+    fields:
+    - name: apiVersion
+      type:
+        scalar: string
+    - name: kind
+      type:
+        scalar: string
+    - name: metadata
+      type:
+        namedType: io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta
+        elementRelationship: granular
+    - name: spec
+      type:
+        namedType: io.k8s.api.apps.v1beta2.DeploymentSpec
+        elementRelationship: granular
+    - name: status
+      type:
+        namedType: io.k8s.api.apps.v1beta2.DeploymentStatus
+        elementRelationship: granular
+- name: io.k8s.api.apps.v1beta2.DeploymentCondition
+  map:
+    fields:
+    - name: lastTransitionTime
+      type:
+        namedType: io.k8s.apimachinery.pkg.apis.meta.v1.Time
+    - name: lastUpdateTime
+      type:
+        namedType: io.k8s.apimachinery.pkg.apis.meta.v1.Time
+    - name: message
+      type:
+        scalar: string
+    - name: reason
+      type:
+        scalar: string
+    - name: status
+      type:
+        scalar: string
+    - name: type
+      type:
+        scalar: string
+- name: io.k8s.api.apps.v1beta2.DeploymentList
+  map:
+    fields:
+    - name: apiVersion
+      type:
+        scalar: string
+    - name: items
+      type:
+        list:
+          elementType:
+            namedType: io.k8s.api.apps.v1beta2.Deployment
+          elementRelationship: atomic
+    - name: kind
+      type:
+        scalar: string
+    - name: metadata
+      type:
+        namedType: io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta
+        elementRelationship: granular
+- name: io.k8s.api.apps.v1beta2.DeploymentSpec
+  map:
+    fields:
+    - name: minReadySeconds
+      type:
+        scalar: numeric
+    - name: paused
+      type:
+        scalar: boolean
+    - name: progressDeadlineSeconds
+      type:
+        scalar: numeric
+    - name: replicas
+      type:
+        scalar: numeric
+    - name: revisionHistoryLimit
+      type:
+        scalar: numeric
+    - name: selector
+      type:
+        namedType: io.k8s.apimachinery.pkg.apis.meta.v1.LabelSelector
+        elementRelationship: granular
+    - name: strategy
+      type:
+        namedType: io.k8s.api.apps.v1beta2.DeploymentStrategy
+        elementRelationship: granular
+    - name: template
+      type:
+        namedType: io.k8s.api.core.v1.PodTemplateSpec
+        elementRelationship: granular
+- name: io.k8s.api.apps.v1beta2.DeploymentStatus
+  map:
+    fields:
+    - name: availableReplicas
+      type:
+        scalar: numeric
+    - name: collisionCount
+      type:
+        scalar: numeric
+    - name: conditions
+      type:
+        list:
+          elementType:
+            namedType: io.k8s.api.apps.v1beta2.DeploymentCondition
+          elementRelationship: associative
+          keys:
+          - type
+    - name: observedGeneration
+      type:
+        scalar: numeric
+    - name: readyReplicas
+      type:
+        scalar: numeric
+    - name: replicas
+      type:
+        scalar: numeric
+    - name: unavailableReplicas
+      type:
+        scalar: numeric
+    - name: updatedReplicas
+      type:
+        scalar: numeric
+- name: io.k8s.api.apps.v1beta2.DeploymentStrategy
+  map:
+    fields:
+    - name: rollingUpdate
+      type:
+        namedType: io.k8s.api.apps.v1beta2.RollingUpdateDeployment
+        elementRelationship: granular
+    - name: type
+      type:
+        scalar: string
+- name: io.k8s.api.apps.v1beta2.ReplicaSet
+  map:
+    fields:
+    - name: apiVersion
+      type:
+        scalar: string
+    - name: kind
+      type:
+        scalar: string
+    - name: metadata
+      type:
+        namedType: io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta
+        elementRelationship: granular
+    - name: spec
+      type:
+        namedType: io.k8s.api.apps.v1beta2.ReplicaSetSpec
+        elementRelationship: granular
+    - name: status
+      type:
+        namedType: io.k8s.api.apps.v1beta2.ReplicaSetStatus
+        elementRelationship: granular
+- name: io.k8s.api.apps.v1beta2.ReplicaSetCondition
+  map:
+    fields:
+    - name: lastTransitionTime
+      type:
+        namedType: io.k8s.apimachinery.pkg.apis.meta.v1.Time
+    - name: message
+      type:
+        scalar: string
+    - name: reason
+      type:
+        scalar: string
+    - name: status
+      type:
+        scalar: string
+    - name: type
+      type:
+        scalar: string
+- name: io.k8s.api.apps.v1beta2.ReplicaSetList
+  map:
+    fields:
+    - name: apiVersion
+      type:
+        scalar: string
+    - name: items
+      type:
+        list:
+          elementType:
+            namedType: io.k8s.api.apps.v1beta2.ReplicaSet
+          elementRelationship: atomic
+    - name: kind
+      type:
+        scalar: string
+    - name: metadata
+      type:
+        namedType: io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta
+        elementRelationship: granular
+- name: io.k8s.api.apps.v1beta2.ReplicaSetSpec
+  map:
+    fields:
+    - name: minReadySeconds
+      type:
+        scalar: numeric
+    - name: replicas
+      type:
+        scalar: numeric
+    - name: selector
+      type:
+        namedType: io.k8s.apimachinery.pkg.apis.meta.v1.LabelSelector
+        elementRelationship: granular
+    - name: template
+      type:
+        namedType: io.k8s.api.core.v1.PodTemplateSpec
+        elementRelationship: granular
+- name: io.k8s.api.apps.v1beta2.ReplicaSetStatus
+  map:
+    fields:
+    - name: availableReplicas
+      type:
+        scalar: numeric
+    - name: conditions
+      type:
+        list:
+          elementType:
+            namedType: io.k8s.api.apps.v1beta2.ReplicaSetCondition
+          elementRelationship: associative
+          keys:
+          - type
+    - name: fullyLabeledReplicas
+      type:
+        scalar: numeric
+    - name: observedGeneration
+      type:
+        scalar: numeric
+    - name: readyReplicas
+      type:
+        scalar: numeric
+    - name: replicas
+      type:
+        scalar: numeric
+- name: io.k8s.api.apps.v1beta2.RollingUpdateDaemonSet
+  map:
+    fields:
+    - name: maxUnavailable
+      type:
+        namedType: io.k8s.apimachinery.pkg.util.intstr.IntOrString
+        elementRelationship: granular
+- name: io.k8s.api.apps.v1beta2.RollingUpdateDeployment
+  map:
+    fields:
+    - name: maxSurge
+      type:
+        namedType: io.k8s.apimachinery.pkg.util.intstr.IntOrString
+        elementRelationship: granular
+    - name: maxUnavailable
+      type:
+        namedType: io.k8s.apimachinery.pkg.util.intstr.IntOrString
+        elementRelationship: granular
+- name: io.k8s.api.apps.v1beta2.RollingUpdateStatefulSetStrategy
+  map:
+    fields:
+    - name: partition
+      type:
+        scalar: numeric
+- name: io.k8s.api.apps.v1beta2.Scale
+  map:
+    fields:
+    - name: apiVersion
+      type:
+        scalar: string
+    - name: kind
+      type:
+        scalar: string
+    - name: metadata
+      type:
+        namedType: io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta
+        elementRelationship: granular
+    - name: spec
+      type:
+        namedType: io.k8s.api.apps.v1beta2.ScaleSpec
+        elementRelationship: granular
+    - name: status
+      type:
+        namedType: io.k8s.api.apps.v1beta2.ScaleStatus
+        elementRelationship: granular
+- name: io.k8s.api.apps.v1beta2.ScaleSpec
+  map:
+    fields:
+    - name: replicas
+      type:
+        scalar: numeric
+- name: io.k8s.api.apps.v1beta2.ScaleStatus
+  map:
+    fields:
+    - name: replicas
+      type:
+        scalar: numeric
+    - name: selector
+      type:
+        map:
+          elementType:
+            scalar: string
+    - name: targetSelector
+      type:
+        scalar: string
+- name: io.k8s.api.apps.v1beta2.StatefulSet
+  map:
+    fields:
+    - name: apiVersion
+      type:
+        scalar: string
+    - name: kind
+      type:
+        scalar: string
+    - name: metadata
+      type:
+        namedType: io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta
+        elementRelationship: granular
+    - name: spec
+      type:
+        namedType: io.k8s.api.apps.v1beta2.StatefulSetSpec
+        elementRelationship: granular
+    - name: status
+      type:
+        namedType: io.k8s.api.apps.v1beta2.StatefulSetStatus
+        elementRelationship: granular
+- name: io.k8s.api.apps.v1beta2.StatefulSetCondition
+  map:
+    fields:
+    - name: lastTransitionTime
+      type:
+        namedType: io.k8s.apimachinery.pkg.apis.meta.v1.Time
+    - name: message
+      type:
+        scalar: string
+    - name: reason
+      type:
+        scalar: string
+    - name: status
+      type:
+        scalar: string
+    - name: type
+      type:
+        scalar: string
+- name: io.k8s.api.apps.v1beta2.StatefulSetList
+  map:
+    fields:
+    - name: apiVersion
+      type:
+        scalar: string
+    - name: items
+      type:
+        list:
+          elementType:
+            namedType: io.k8s.api.apps.v1beta2.StatefulSet
+          elementRelationship: atomic
+    - name: kind
+      type:
+        scalar: string
+    - name: metadata
+      type:
+        namedType: io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta
+        elementRelationship: granular
+- name: io.k8s.api.apps.v1beta2.StatefulSetSpec
+  map:
+    fields:
+    - name: podManagementPolicy
+      type:
+        scalar: string
+    - name: replicas
+      type:
+        scalar: numeric
+    - name: revisionHistoryLimit
+      type:
+        scalar: numeric
+    - name: selector
+      type:
+        namedType: io.k8s.apimachinery.pkg.apis.meta.v1.LabelSelector
+        elementRelationship: granular
+    - name: serviceName
+      type:
+        scalar: string
+    - name: template
+      type:
+        namedType: io.k8s.api.core.v1.PodTemplateSpec
+        elementRelationship: granular
+    - name: updateStrategy
+      type:
+        namedType: io.k8s.api.apps.v1beta2.StatefulSetUpdateStrategy
+        elementRelationship: granular
+    - name: volumeClaimTemplates
+      type:
+        list:
+          elementType:
+            namedType: io.k8s.api.core.v1.PersistentVolumeClaim
+          elementRelationship: atomic
+- name: io.k8s.api.apps.v1beta2.StatefulSetStatus
+  map:
+    fields:
+    - name: collisionCount
+      type:
+        scalar: numeric
+    - name: conditions
+      type:
+        list:
+          elementType:
+            namedType: io.k8s.api.apps.v1beta2.StatefulSetCondition
+          elementRelationship: associative
+          keys:
+          - type
+    - name: currentReplicas
+      type:
+        scalar: numeric
+    - name: currentRevision
+      type:
+        scalar: string
+    - name: observedGeneration
+      type:
+        scalar: numeric
+    - name: readyReplicas
+      type:
+        scalar: numeric
+    - name: replicas
+      type:
+        scalar: numeric
+    - name: updateRevision
+      type:
+        scalar: string
+    - name: updatedReplicas
+      type:
+        scalar: numeric
+- name: io.k8s.api.apps.v1beta2.StatefulSetUpdateStrategy
+  map:
+    fields:
+    - name: rollingUpdate
+      type:
+        namedType: io.k8s.api.apps.v1beta2.RollingUpdateStatefulSetStrategy
+        elementRelationship: granular
+    - name: type
+      type:
+        scalar: string
+- name: io.k8s.api.auditregistration.v1alpha1.AuditSink
+  map:
+    fields:
+    - name: apiVersion
+      type:
+        scalar: string
+    - name: kind
+      type:
+        scalar: string
+    - name: metadata
+      type:
+        namedType: io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta
+        elementRelationship: granular
+    - name: spec
+      type:
+        namedType: io.k8s.api.auditregistration.v1alpha1.AuditSinkSpec
+        elementRelationship: granular
+- name: io.k8s.api.auditregistration.v1alpha1.AuditSinkList
+  map:
+    fields:
+    - name: apiVersion
+      type:
+        scalar: string
+    - name: items
+      type:
+        list:
+          elementType:
+            namedType: io.k8s.api.auditregistration.v1alpha1.AuditSink
+          elementRelationship: atomic
+    - name: kind
+      type:
+        scalar: string
+    - name: metadata
+      type:
+        namedType: io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta
+        elementRelationship: granular
+- name: io.k8s.api.auditregistration.v1alpha1.AuditSinkSpec
+  map:
+    fields:
+    - name: policy
+      type:
+        namedType: io.k8s.api.auditregistration.v1alpha1.Policy
+        elementRelationship: granular
+    - name: webhook
+      type:
+        namedType: io.k8s.api.auditregistration.v1alpha1.Webhook
+        elementRelationship: granular
+- name: io.k8s.api.auditregistration.v1alpha1.Policy
+  map:
+    fields:
+    - name: level
+      type:
+        scalar: string
+    - name: stages
+      type:
+        list:
+          elementType:
+            scalar: string
+          elementRelationship: atomic
+- name: io.k8s.api.auditregistration.v1alpha1.ServiceReference
+  map:
+    fields:
+    - name: name
+      type:
+        scalar: string
+    - name: namespace
+      type:
+        scalar: string
+    - name: path
+      type:
+        scalar: string
+- name: io.k8s.api.auditregistration.v1alpha1.Webhook
+  map:
+    fields:
+    - name: clientConfig
+      type:
+        namedType: io.k8s.api.auditregistration.v1alpha1.WebhookClientConfig
+        elementRelationship: granular
+    - name: throttle
+      type:
+        namedType: io.k8s.api.auditregistration.v1alpha1.WebhookThrottleConfig
+        elementRelationship: granular
+- name: io.k8s.api.auditregistration.v1alpha1.WebhookClientConfig
+  map:
+    fields:
+    - name: caBundle
+      type:
+        scalar: string
+    - name: service
+      type:
+        namedType: io.k8s.api.auditregistration.v1alpha1.ServiceReference
+        elementRelationship: granular
+    - name: url
+      type:
+        scalar: string
+- name: io.k8s.api.auditregistration.v1alpha1.WebhookThrottleConfig
+  map:
+    fields:
+    - name: burst
+      type:
+        scalar: numeric
+    - name: qps
+      type:
+        scalar: numeric
+- name: io.k8s.api.authentication.v1.TokenReview
+  map:
+    fields:
+    - name: apiVersion
+      type:
+        scalar: string
+    - name: kind
+      type:
+        scalar: string
+    - name: metadata
+      type:
+        namedType: io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta
+        elementRelationship: granular
+    - name: spec
+      type:
+        namedType: io.k8s.api.authentication.v1.TokenReviewSpec
+        elementRelationship: granular
+    - name: status
+      type:
+        namedType: io.k8s.api.authentication.v1.TokenReviewStatus
+        elementRelationship: granular
+- name: io.k8s.api.authentication.v1.TokenReviewSpec
+  map:
+    fields:
+    - name: token
+      type:
+        scalar: string
+- name: io.k8s.api.authentication.v1.TokenReviewStatus
+  map:
+    fields:
+    - name: authenticated
+      type:
+        scalar: boolean
+    - name: error
+      type:
+        scalar: string
+    - name: user
+      type:
+        namedType: io.k8s.api.authentication.v1.UserInfo
+        elementRelationship: granular
+- name: io.k8s.api.authentication.v1.UserInfo
+  map:
+    fields:
+    - name: extra
+      type:
+        map:
+          elementType:
+            list:
+              elementType:
+                scalar: string
+              elementRelationship: atomic
+    - name: groups
+      type:
+        list:
+          elementType:
+            scalar: string
+          elementRelationship: atomic
+    - name: uid
+      type:
+        scalar: string
+    - name: username
+      type:
+        scalar: string
+- name: io.k8s.api.authentication.v1beta1.TokenReview
+  map:
+    fields:
+    - name: apiVersion
+      type:
+        scalar: string
+    - name: kind
+      type:
+        scalar: string
+    - name: metadata
+      type:
+        namedType: io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta
+        elementRelationship: granular
+    - name: spec
+      type:
+        namedType: io.k8s.api.authentication.v1beta1.TokenReviewSpec
+        elementRelationship: granular
+    - name: status
+      type:
+        namedType: io.k8s.api.authentication.v1beta1.TokenReviewStatus
+        elementRelationship: granular
+- name: io.k8s.api.authentication.v1beta1.TokenReviewSpec
+  map:
+    fields:
+    - name: token
+      type:
+        scalar: string
+- name: io.k8s.api.authentication.v1beta1.TokenReviewStatus
+  map:
+    fields:
+    - name: authenticated
+      type:
+        scalar: boolean
+    - name: error
+      type:
+        scalar: string
+    - name: user
+      type:
+        namedType: io.k8s.api.authentication.v1beta1.UserInfo
+        elementRelationship: granular
+- name: io.k8s.api.authentication.v1beta1.UserInfo
+  map:
+    fields:
+    - name: extra
+      type:
+        map:
+          elementType:
+            list:
+              elementType:
+                scalar: string
+              elementRelationship: atomic
+    - name: groups
+      type:
+        list:
+          elementType:
+            scalar: string
+          elementRelationship: atomic
+    - name: uid
+      type:
+        scalar: string
+    - name: username
+      type:
+        scalar: string
+- name: io.k8s.api.authorization.v1.LocalSubjectAccessReview
+  map:
+    fields:
+    - name: apiVersion
+      type:
+        scalar: string
+    - name: kind
+      type:
+        scalar: string
+    - name: metadata
+      type:
+        namedType: io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta
+        elementRelationship: granular
+    - name: spec
+      type:
+        namedType: io.k8s.api.authorization.v1.SubjectAccessReviewSpec
+        elementRelationship: granular
+    - name: status
+      type:
+        namedType: io.k8s.api.authorization.v1.SubjectAccessReviewStatus
+        elementRelationship: granular
+- name: io.k8s.api.authorization.v1.NonResourceAttributes
+  map:
+    fields:
+    - name: path
+      type:
+        scalar: string
+    - name: verb
+      type:
+        scalar: string
+- name: io.k8s.api.authorization.v1.NonResourceRule
+  map:
+    fields:
+    - name: nonResourceURLs
+      type:
+        list:
+          elementType:
+            scalar: string
+          elementRelationship: atomic
+    - name: verbs
+      type:
+        list:
+          elementType:
+            scalar: string
+          elementRelationship: atomic
+- name: io.k8s.api.authorization.v1.ResourceAttributes
+  map:
+    fields:
+    - name: group
+      type:
+        scalar: string
+    - name: name
+      type:
+        scalar: string
+    - name: namespace
+      type:
+        scalar: string
+    - name: resource
+      type:
+        scalar: string
+    - name: subresource
+      type:
+        scalar: string
+    - name: verb
+      type:
+        scalar: string
+    - name: version
+      type:
+        scalar: string
+- name: io.k8s.api.authorization.v1.ResourceRule
+  map:
+    fields:
+    - name: apiGroups
+      type:
+        list:
+          elementType:
+            scalar: string
+          elementRelationship: atomic
+    - name: resourceNames
+      type:
+        list:
+          elementType:
+            scalar: string
+          elementRelationship: atomic
+    - name: resources
+      type:
+        list:
+          elementType:
+            scalar: string
+          elementRelationship: atomic
+    - name: verbs
+      type:
+        list:
+          elementType:
+            scalar: string
+          elementRelationship: atomic
+- name: io.k8s.api.authorization.v1.SelfSubjectAccessReview
+  map:
+    fields:
+    - name: apiVersion
+      type:
+        scalar: string
+    - name: kind
+      type:
+        scalar: string
+    - name: metadata
+      type:
+        namedType: io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta
+        elementRelationship: granular
+    - name: spec
+      type:
+        namedType: io.k8s.api.authorization.v1.SelfSubjectAccessReviewSpec
+        elementRelationship: granular
+    - name: status
+      type:
+        namedType: io.k8s.api.authorization.v1.SubjectAccessReviewStatus
+        elementRelationship: granular
+- name: io.k8s.api.authorization.v1.SelfSubjectAccessReviewSpec
+  map:
+    fields:
+    - name: nonResourceAttributes
+      type:
+        namedType: io.k8s.api.authorization.v1.NonResourceAttributes
+        elementRelationship: granular
+    - name: resourceAttributes
+      type:
+        namedType: io.k8s.api.authorization.v1.ResourceAttributes
+        elementRelationship: granular
+- name: io.k8s.api.authorization.v1.SelfSubjectRulesReview
+  map:
+    fields:
+    - name: apiVersion
+      type:
+        scalar: string
+    - name: kind
+      type:
+        scalar: string
+    - name: metadata
+      type:
+        namedType: io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta
+        elementRelationship: granular
+    - name: spec
+      type:
+        namedType: io.k8s.api.authorization.v1.SelfSubjectRulesReviewSpec
+        elementRelationship: granular
+    - name: status
+      type:
+        namedType: io.k8s.api.authorization.v1.SubjectRulesReviewStatus
+        elementRelationship: granular
+- name: io.k8s.api.authorization.v1.SelfSubjectRulesReviewSpec
+  map:
+    fields:
+    - name: namespace
+      type:
+        scalar: string
+- name: io.k8s.api.authorization.v1.SubjectAccessReview
+  map:
+    fields:
+    - name: apiVersion
+      type:
+        scalar: string
+    - name: kind
+      type:
+        scalar: string
+    - name: metadata
+      type:
+        namedType: io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta
+        elementRelationship: granular
+    - name: spec
+      type:
+        namedType: io.k8s.api.authorization.v1.SubjectAccessReviewSpec
+        elementRelationship: granular
+    - name: status
+      type:
+        namedType: io.k8s.api.authorization.v1.SubjectAccessReviewStatus
+        elementRelationship: granular
+- name: io.k8s.api.authorization.v1.SubjectAccessReviewSpec
+  map:
+    fields:
+    - name: extra
+      type:
+        map:
+          elementType:
+            list:
+              elementType:
+                scalar: string
+              elementRelationship: atomic
+    - name: groups
+      type:
+        list:
+          elementType:
+            scalar: string
+          elementRelationship: atomic
+    - name: nonResourceAttributes
+      type:
+        namedType: io.k8s.api.authorization.v1.NonResourceAttributes
+        elementRelationship: granular
+    - name: resourceAttributes
+      type:
+        namedType: io.k8s.api.authorization.v1.ResourceAttributes
+        elementRelationship: granular
+    - name: uid
+      type:
+        scalar: string
+    - name: user
+      type:
+        scalar: string
+- name: io.k8s.api.authorization.v1.SubjectAccessReviewStatus
+  map:
+    fields:
+    - name: allowed
+      type:
+        scalar: boolean
+    - name: denied
+      type:
+        scalar: boolean
+    - name: evaluationError
+      type:
+        scalar: string
+    - name: reason
+      type:
+        scalar: string
+- name: io.k8s.api.authorization.v1.SubjectRulesReviewStatus
+  map:
+    fields:
+    - name: evaluationError
+      type:
+        scalar: string
+    - name: incomplete
+      type:
+        scalar: boolean
+    - name: nonResourceRules
+      type:
+        list:
+          elementType:
+            namedType: io.k8s.api.authorization.v1.NonResourceRule
+          elementRelationship: atomic
+    - name: resourceRules
+      type:
+        list:
+          elementType:
+            namedType: io.k8s.api.authorization.v1.ResourceRule
+          elementRelationship: atomic
+- name: io.k8s.api.authorization.v1beta1.LocalSubjectAccessReview
+  map:
+    fields:
+    - name: apiVersion
+      type:
+        scalar: string
+    - name: kind
+      type:
+        scalar: string
+    - name: metadata
+      type:
+        namedType: io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta
+        elementRelationship: granular
+    - name: spec
+      type:
+        namedType: io.k8s.api.authorization.v1beta1.SubjectAccessReviewSpec
+        elementRelationship: granular
+    - name: status
+      type:
+        namedType: io.k8s.api.authorization.v1beta1.SubjectAccessReviewStatus
+        elementRelationship: granular
+- name: io.k8s.api.authorization.v1beta1.NonResourceAttributes
+  map:
+    fields:
+    - name: path
+      type:
+        scalar: string
+    - name: verb
+      type:
+        scalar: string
+- name: io.k8s.api.authorization.v1beta1.NonResourceRule
+  map:
+    fields:
+    - name: nonResourceURLs
+      type:
+        list:
+          elementType:
+            scalar: string
+          elementRelationship: atomic
+    - name: verbs
+      type:
+        list:
+          elementType:
+            scalar: string
+          elementRelationship: atomic
+- name: io.k8s.api.authorization.v1beta1.ResourceAttributes
+  map:
+    fields:
+    - name: group
+      type:
+        scalar: string
+    - name: name
+      type:
+        scalar: string
+    - name: namespace
+      type:
+        scalar: string
+    - name: resource
+      type:
+        scalar: string
+    - name: subresource
+      type:
+        scalar: string
+    - name: verb
+      type:
+        scalar: string
+    - name: version
+      type:
+        scalar: string
+- name: io.k8s.api.authorization.v1beta1.ResourceRule
+  map:
+    fields:
+    - name: apiGroups
+      type:
+        list:
+          elementType:
+            scalar: string
+          elementRelationship: atomic
+    - name: resourceNames
+      type:
+        list:
+          elementType:
+            scalar: string
+          elementRelationship: atomic
+    - name: resources
+      type:
+        list:
+          elementType:
+            scalar: string
+          elementRelationship: atomic
+    - name: verbs
+      type:
+        list:
+          elementType:
+            scalar: string
+          elementRelationship: atomic
+- name: io.k8s.api.authorization.v1beta1.SelfSubjectAccessReview
+  map:
+    fields:
+    - name: apiVersion
+      type:
+        scalar: string
+    - name: kind
+      type:
+        scalar: string
+    - name: metadata
+      type:
+        namedType: io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta
+        elementRelationship: granular
+    - name: spec
+      type:
+        namedType: io.k8s.api.authorization.v1beta1.SelfSubjectAccessReviewSpec
+        elementRelationship: granular
+    - name: status
+      type:
+        namedType: io.k8s.api.authorization.v1beta1.SubjectAccessReviewStatus
+        elementRelationship: granular
+- name: io.k8s.api.authorization.v1beta1.SelfSubjectAccessReviewSpec
+  map:
+    fields:
+    - name: nonResourceAttributes
+      type:
+        namedType: io.k8s.api.authorization.v1beta1.NonResourceAttributes
+        elementRelationship: granular
+    - name: resourceAttributes
+      type:
+        namedType: io.k8s.api.authorization.v1beta1.ResourceAttributes
+        elementRelationship: granular
+- name: io.k8s.api.authorization.v1beta1.SelfSubjectRulesReview
+  map:
+    fields:
+    - name: apiVersion
+      type:
+        scalar: string
+    - name: kind
+      type:
+        scalar: string
+    - name: metadata
+      type:
+        namedType: io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta
+        elementRelationship: granular
+    - name: spec
+      type:
+        namedType: io.k8s.api.authorization.v1beta1.SelfSubjectRulesReviewSpec
+        elementRelationship: granular
+    - name: status
+      type:
+        namedType: io.k8s.api.authorization.v1beta1.SubjectRulesReviewStatus
+        elementRelationship: granular
+- name: io.k8s.api.authorization.v1beta1.SelfSubjectRulesReviewSpec
+  map:
+    fields:
+    - name: namespace
+      type:
+        scalar: string
+- name: io.k8s.api.authorization.v1beta1.SubjectAccessReview
+  map:
+    fields:
+    - name: apiVersion
+      type:
+        scalar: string
+    - name: kind
+      type:
+        scalar: string
+    - name: metadata
+      type:
+        namedType: io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta
+        elementRelationship: granular
+    - name: spec
+      type:
+        namedType: io.k8s.api.authorization.v1beta1.SubjectAccessReviewSpec
+        elementRelationship: granular
+    - name: status
+      type:
+        namedType: io.k8s.api.authorization.v1beta1.SubjectAccessReviewStatus
+        elementRelationship: granular
+- name: io.k8s.api.authorization.v1beta1.SubjectAccessReviewSpec
+  map:
+    fields:
+    - name: extra
+      type:
+        map:
+          elementType:
+            list:
+              elementType:
+                scalar: string
+              elementRelationship: atomic
+    - name: group
+      type:
+        list:
+          elementType:
+            scalar: string
+          elementRelationship: atomic
+    - name: nonResourceAttributes
+      type:
+        namedType: io.k8s.api.authorization.v1beta1.NonResourceAttributes
+        elementRelationship: granular
+    - name: resourceAttributes
+      type:
+        namedType: io.k8s.api.authorization.v1beta1.ResourceAttributes
+        elementRelationship: granular
+    - name: uid
+      type:
+        scalar: string
+    - name: user
+      type:
+        scalar: string
+- name: io.k8s.api.authorization.v1beta1.SubjectAccessReviewStatus
+  map:
+    fields:
+    - name: allowed
+      type:
+        scalar: boolean
+    - name: denied
+      type:
+        scalar: boolean
+    - name: evaluationError
+      type:
+        scalar: string
+    - name: reason
+      type:
+        scalar: string
+- name: io.k8s.api.authorization.v1beta1.SubjectRulesReviewStatus
+  map:
+    fields:
+    - name: evaluationError
+      type:
+        scalar: string
+    - name: incomplete
+      type:
+        scalar: boolean
+    - name: nonResourceRules
+      type:
+        list:
+          elementType:
+            namedType: io.k8s.api.authorization.v1beta1.NonResourceRule
+          elementRelationship: atomic
+    - name: resourceRules
+      type:
+        list:
+          elementType:
+            namedType: io.k8s.api.authorization.v1beta1.ResourceRule
+          elementRelationship: atomic
+- name: io.k8s.api.autoscaling.v1.CrossVersionObjectReference
+  map:
+    fields:
+    - name: apiVersion
+      type:
+        scalar: string
+    - name: kind
+      type:
+        scalar: string
+    - name: name
+      type:
+        scalar: string
+- name: io.k8s.api.autoscaling.v1.HorizontalPodAutoscaler
+  map:
+    fields:
+    - name: apiVersion
+      type:
+        scalar: string
+    - name: kind
+      type:
+        scalar: string
+    - name: metadata
+      type:
+        namedType: io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta
+        elementRelationship: granular
+    - name: spec
+      type:
+        namedType: io.k8s.api.autoscaling.v1.HorizontalPodAutoscalerSpec
+        elementRelationship: granular
+    - name: status
+      type:
+        namedType: io.k8s.api.autoscaling.v1.HorizontalPodAutoscalerStatus
+        elementRelationship: granular
+- name: io.k8s.api.autoscaling.v1.HorizontalPodAutoscalerList
+  map:
+    fields:
+    - name: apiVersion
+      type:
+        scalar: string
+    - name: items
+      type:
+        list:
+          elementType:
+            namedType: io.k8s.api.autoscaling.v1.HorizontalPodAutoscaler
+          elementRelationship: atomic
+    - name: kind
+      type:
+        scalar: string
+    - name: metadata
+      type:
+        namedType: io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta
+        elementRelationship: granular
+- name: io.k8s.api.autoscaling.v1.HorizontalPodAutoscalerSpec
+  map:
+    fields:
+    - name: maxReplicas
+      type:
+        scalar: numeric
+    - name: minReplicas
+      type:
+        scalar: numeric
+    - name: scaleTargetRef
+      type:
+        namedType: io.k8s.api.autoscaling.v1.CrossVersionObjectReference
+        elementRelationship: granular
+    - name: targetCPUUtilizationPercentage
+      type:
+        scalar: numeric
+- name: io.k8s.api.autoscaling.v1.HorizontalPodAutoscalerStatus
+  map:
+    fields:
+    - name: currentCPUUtilizationPercentage
+      type:
+        scalar: numeric
+    - name: currentReplicas
+      type:
+        scalar: numeric
+    - name: desiredReplicas
+      type:
+        scalar: numeric
+    - name: lastScaleTime
+      type:
+        namedType: io.k8s.apimachinery.pkg.apis.meta.v1.Time
+    - name: observedGeneration
+      type:
+        scalar: numeric
+- name: io.k8s.api.autoscaling.v1.Scale
+  map:
+    fields:
+    - name: apiVersion
+      type:
+        scalar: string
+    - name: kind
+      type:
+        scalar: string
+    - name: metadata
+      type:
+        namedType: io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta
+        elementRelationship: granular
+    - name: spec
+      type:
+        namedType: io.k8s.api.autoscaling.v1.ScaleSpec
+        elementRelationship: granular
+    - name: status
+      type:
+        namedType: io.k8s.api.autoscaling.v1.ScaleStatus
+        elementRelationship: granular
+- name: io.k8s.api.autoscaling.v1.ScaleSpec
+  map:
+    fields:
+    - name: replicas
+      type:
+        scalar: numeric
+- name: io.k8s.api.autoscaling.v1.ScaleStatus
+  map:
+    fields:
+    - name: replicas
+      type:
+        scalar: numeric
+    - name: selector
+      type:
+        scalar: string
+- name: io.k8s.api.autoscaling.v2beta1.CrossVersionObjectReference
+  map:
+    fields:
+    - name: apiVersion
+      type:
+        scalar: string
+    - name: kind
+      type:
+        scalar: string
+    - name: name
+      type:
+        scalar: string
+- name: io.k8s.api.autoscaling.v2beta1.ExternalMetricSource
+  map:
+    fields:
+    - name: metricName
+      type:
+        scalar: string
+    - name: metricSelector
+      type:
+        namedType: io.k8s.apimachinery.pkg.apis.meta.v1.LabelSelector
+        elementRelationship: granular
+    - name: targetAverageValue
+      type:
+        namedType: io.k8s.apimachinery.pkg.api.resource.Quantity
+        elementRelationship: granular
+    - name: targetValue
+      type:
+        namedType: io.k8s.apimachinery.pkg.api.resource.Quantity
+        elementRelationship: granular
+- name: io.k8s.api.autoscaling.v2beta1.ExternalMetricStatus
+  map:
+    fields:
+    - name: currentAverageValue
+      type:
+        namedType: io.k8s.apimachinery.pkg.api.resource.Quantity
+        elementRelationship: granular
+    - name: currentValue
+      type:
+        namedType: io.k8s.apimachinery.pkg.api.resource.Quantity
+        elementRelationship: granular
+    - name: metricName
+      type:
+        scalar: string
+    - name: metricSelector
+      type:
+        namedType: io.k8s.apimachinery.pkg.apis.meta.v1.LabelSelector
+        elementRelationship: granular
+- name: io.k8s.api.autoscaling.v2beta1.HorizontalPodAutoscaler
+  map:
+    fields:
+    - name: apiVersion
+      type:
+        scalar: string
+    - name: kind
+      type:
+        scalar: string
+    - name: metadata
+      type:
+        namedType: io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta
+        elementRelationship: granular
+    - name: spec
+      type:
+        namedType: io.k8s.api.autoscaling.v2beta1.HorizontalPodAutoscalerSpec
+        elementRelationship: granular
+    - name: status
+      type:
+        namedType: io.k8s.api.autoscaling.v2beta1.HorizontalPodAutoscalerStatus
+        elementRelationship: granular
+- name: io.k8s.api.autoscaling.v2beta1.HorizontalPodAutoscalerCondition
+  map:
+    fields:
+    - name: lastTransitionTime
+      type:
+        namedType: io.k8s.apimachinery.pkg.apis.meta.v1.Time
+    - name: message
+      type:
+        scalar: string
+    - name: reason
+      type:
+        scalar: string
+    - name: status
+      type:
+        scalar: string
+    - name: type
+      type:
+        scalar: string
+- name: io.k8s.api.autoscaling.v2beta1.HorizontalPodAutoscalerList
+  map:
+    fields:
+    - name: apiVersion
+      type:
+        scalar: string
+    - name: items
+      type:
+        list:
+          elementType:
+            namedType: io.k8s.api.autoscaling.v2beta1.HorizontalPodAutoscaler
+          elementRelationship: atomic
+    - name: kind
+      type:
+        scalar: string
+    - name: metadata
+      type:
+        namedType: io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta
+        elementRelationship: granular
+- name: io.k8s.api.autoscaling.v2beta1.HorizontalPodAutoscalerSpec
+  map:
+    fields:
+    - name: maxReplicas
+      type:
+        scalar: numeric
+    - name: metrics
+      type:
+        list:
+          elementType:
+            namedType: io.k8s.api.autoscaling.v2beta1.MetricSpec
+          elementRelationship: atomic
+    - name: minReplicas
+      type:
+        scalar: numeric
+    - name: scaleTargetRef
+      type:
+        namedType: io.k8s.api.autoscaling.v2beta1.CrossVersionObjectReference
+        elementRelationship: granular
+- name: io.k8s.api.autoscaling.v2beta1.HorizontalPodAutoscalerStatus
+  map:
+    fields:
+    - name: conditions
+      type:
+        list:
+          elementType:
+            namedType: io.k8s.api.autoscaling.v2beta1.HorizontalPodAutoscalerCondition
+          elementRelationship: atomic
+    - name: currentMetrics
+      type:
+        list:
+          elementType:
+            namedType: io.k8s.api.autoscaling.v2beta1.MetricStatus
+          elementRelationship: atomic
+    - name: currentReplicas
+      type:
+        scalar: numeric
+    - name: desiredReplicas
+      type:
+        scalar: numeric
+    - name: lastScaleTime
+      type:
+        namedType: io.k8s.apimachinery.pkg.apis.meta.v1.Time
+    - name: observedGeneration
+      type:
+        scalar: numeric
+- name: io.k8s.api.autoscaling.v2beta1.MetricSpec
+  map:
+    fields:
+    - name: external
+      type:
+        namedType: io.k8s.api.autoscaling.v2beta1.ExternalMetricSource
+        elementRelationship: granular
+    - name: object
+      type:
+        namedType: io.k8s.api.autoscaling.v2beta1.ObjectMetricSource
+        elementRelationship: granular
+    - name: pods
+      type:
+        namedType: io.k8s.api.autoscaling.v2beta1.PodsMetricSource
+        elementRelationship: granular
+    - name: resource
+      type:
+        namedType: io.k8s.api.autoscaling.v2beta1.ResourceMetricSource
+        elementRelationship: granular
+    - name: type
+      type:
+        scalar: string
+- name: io.k8s.api.autoscaling.v2beta1.MetricStatus
+  map:
+    fields:
+    - name: external
+      type:
+        namedType: io.k8s.api.autoscaling.v2beta1.ExternalMetricStatus
+        elementRelationship: granular
+    - name: object
+      type:
+        namedType: io.k8s.api.autoscaling.v2beta1.ObjectMetricStatus
+        elementRelationship: granular
+    - name: pods
+      type:
+        namedType: io.k8s.api.autoscaling.v2beta1.PodsMetricStatus
+        elementRelationship: granular
+    - name: resource
+      type:
+        namedType: io.k8s.api.autoscaling.v2beta1.ResourceMetricStatus
+        elementRelationship: granular
+    - name: type
+      type:
+        scalar: string
+- name: io.k8s.api.autoscaling.v2beta1.ObjectMetricSource
+  map:
+    fields:
+    - name: averageValue
+      type:
+        namedType: io.k8s.apimachinery.pkg.api.resource.Quantity
+        elementRelationship: granular
+    - name: metricName
+      type:
+        scalar: string
+    - name: selector
+      type:
+        namedType: io.k8s.apimachinery.pkg.apis.meta.v1.LabelSelector
+        elementRelationship: granular
+    - name: target
+      type:
+        namedType: io.k8s.api.autoscaling.v2beta1.CrossVersionObjectReference
+        elementRelationship: granular
+    - name: targetValue
+      type:
+        namedType: io.k8s.apimachinery.pkg.api.resource.Quantity
+        elementRelationship: granular
+- name: io.k8s.api.autoscaling.v2beta1.ObjectMetricStatus
+  map:
+    fields:
+    - name: averageValue
+      type:
+        namedType: io.k8s.apimachinery.pkg.api.resource.Quantity
+        elementRelationship: granular
+    - name: currentValue
+      type:
+        namedType: io.k8s.apimachinery.pkg.api.resource.Quantity
+        elementRelationship: granular
+    - name: metricName
+      type:
+        scalar: string
+    - name: selector
+      type:
+        namedType: io.k8s.apimachinery.pkg.apis.meta.v1.LabelSelector
+        elementRelationship: granular
+    - name: target
+      type:
+        namedType: io.k8s.api.autoscaling.v2beta1.CrossVersionObjectReference
+        elementRelationship: granular
+- name: io.k8s.api.autoscaling.v2beta1.PodsMetricSource
+  map:
+    fields:
+    - name: metricName
+      type:
+        scalar: string
+    - name: selector
+      type:
+        namedType: io.k8s.apimachinery.pkg.apis.meta.v1.LabelSelector
+        elementRelationship: granular
+    - name: targetAverageValue
+      type:
+        namedType: io.k8s.apimachinery.pkg.api.resource.Quantity
+        elementRelationship: granular
+- name: io.k8s.api.autoscaling.v2beta1.PodsMetricStatus
+  map:
+    fields:
+    - name: currentAverageValue
+      type:
+        namedType: io.k8s.apimachinery.pkg.api.resource.Quantity
+        elementRelationship: granular
+    - name: metricName
+      type:
+        scalar: string
+    - name: selector
+      type:
+        namedType: io.k8s.apimachinery.pkg.apis.meta.v1.LabelSelector
+        elementRelationship: granular
+- name: io.k8s.api.autoscaling.v2beta1.ResourceMetricSource
+  map:
+    fields:
+    - name: name
+      type:
+        scalar: string
+    - name: targetAverageUtilization
+      type:
+        scalar: numeric
+    - name: targetAverageValue
+      type:
+        namedType: io.k8s.apimachinery.pkg.api.resource.Quantity
+        elementRelationship: granular
+- name: io.k8s.api.autoscaling.v2beta1.ResourceMetricStatus
+  map:
+    fields:
+    - name: currentAverageUtilization
+      type:
+        scalar: numeric
+    - name: currentAverageValue
+      type:
+        namedType: io.k8s.apimachinery.pkg.api.resource.Quantity
+        elementRelationship: granular
+    - name: name
+      type:
+        scalar: string
+- name: io.k8s.api.autoscaling.v2beta2.CrossVersionObjectReference
+  map:
+    fields:
+    - name: apiVersion
+      type:
+        scalar: string
+    - name: kind
+      type:
+        scalar: string
+    - name: name
+      type:
+        scalar: string
+- name: io.k8s.api.autoscaling.v2beta2.ExternalMetricSource
+  map:
+    fields:
+    - name: metric
+      type:
+        namedType: io.k8s.api.autoscaling.v2beta2.MetricIdentifier
+        elementRelationship: granular
+    - name: target
+      type:
+        namedType: io.k8s.api.autoscaling.v2beta2.MetricTarget
+        elementRelationship: granular
+- name: io.k8s.api.autoscaling.v2beta2.ExternalMetricStatus
+  map:
+    fields:
+    - name: current
+      type:
+        namedType: io.k8s.api.autoscaling.v2beta2.MetricValueStatus
+        elementRelationship: granular
+    - name: metric
+      type:
+        namedType: io.k8s.api.autoscaling.v2beta2.MetricIdentifier
+        elementRelationship: granular
+- name: io.k8s.api.autoscaling.v2beta2.HorizontalPodAutoscaler
+  map:
+    fields:
+    - name: apiVersion
+      type:
+        scalar: string
+    - name: kind
+      type:
+        scalar: string
+    - name: metadata
+      type:
+        namedType: io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta
+        elementRelationship: granular
+    - name: spec
+      type:
+        namedType: io.k8s.api.autoscaling.v2beta2.HorizontalPodAutoscalerSpec
+        elementRelationship: granular
+    - name: status
+      type:
+        namedType: io.k8s.api.autoscaling.v2beta2.HorizontalPodAutoscalerStatus
+        elementRelationship: granular
+- name: io.k8s.api.autoscaling.v2beta2.HorizontalPodAutoscalerCondition
+  map:
+    fields:
+    - name: lastTransitionTime
+      type:
+        namedType: io.k8s.apimachinery.pkg.apis.meta.v1.Time
+    - name: message
+      type:
+        scalar: string
+    - name: reason
+      type:
+        scalar: string
+    - name: status
+      type:
+        scalar: string
+    - name: type
+      type:
+        scalar: string
+- name: io.k8s.api.autoscaling.v2beta2.HorizontalPodAutoscalerList
+  map:
+    fields:
+    - name: apiVersion
+      type:
+        scalar: string
+    - name: items
+      type:
+        list:
+          elementType:
+            namedType: io.k8s.api.autoscaling.v2beta2.HorizontalPodAutoscaler
+          elementRelationship: atomic
+    - name: kind
+      type:
+        scalar: string
+    - name: metadata
+      type:
+        namedType: io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta
+        elementRelationship: granular
+- name: io.k8s.api.autoscaling.v2beta2.HorizontalPodAutoscalerSpec
+  map:
+    fields:
+    - name: maxReplicas
+      type:
+        scalar: numeric
+    - name: metrics
+      type:
+        list:
+          elementType:
+            namedType: io.k8s.api.autoscaling.v2beta2.MetricSpec
+          elementRelationship: atomic
+    - name: minReplicas
+      type:
+        scalar: numeric
+    - name: scaleTargetRef
+      type:
+        namedType: io.k8s.api.autoscaling.v2beta2.CrossVersionObjectReference
+        elementRelationship: granular
+- name: io.k8s.api.autoscaling.v2beta2.HorizontalPodAutoscalerStatus
+  map:
+    fields:
+    - name: conditions
+      type:
+        list:
+          elementType:
+            namedType: io.k8s.api.autoscaling.v2beta2.HorizontalPodAutoscalerCondition
+          elementRelationship: atomic
+    - name: currentMetrics
+      type:
+        list:
+          elementType:
+            namedType: io.k8s.api.autoscaling.v2beta2.MetricStatus
+          elementRelationship: atomic
+    - name: currentReplicas
+      type:
+        scalar: numeric
+    - name: desiredReplicas
+      type:
+        scalar: numeric
+    - name: lastScaleTime
+      type:
+        namedType: io.k8s.apimachinery.pkg.apis.meta.v1.Time
+    - name: observedGeneration
+      type:
+        scalar: numeric
+- name: io.k8s.api.autoscaling.v2beta2.MetricIdentifier
+  map:
+    fields:
+    - name: name
+      type:
+        scalar: string
+    - name: selector
+      type:
+        namedType: io.k8s.apimachinery.pkg.apis.meta.v1.LabelSelector
+        elementRelationship: granular
+- name: io.k8s.api.autoscaling.v2beta2.MetricSpec
+  map:
+    fields:
+    - name: external
+      type:
+        namedType: io.k8s.api.autoscaling.v2beta2.ExternalMetricSource
+        elementRelationship: granular
+    - name: object
+      type:
+        namedType: io.k8s.api.autoscaling.v2beta2.ObjectMetricSource
+        elementRelationship: granular
+    - name: pods
+      type:
+        namedType: io.k8s.api.autoscaling.v2beta2.PodsMetricSource
+        elementRelationship: granular
+    - name: resource
+      type:
+        namedType: io.k8s.api.autoscaling.v2beta2.ResourceMetricSource
+        elementRelationship: granular
+    - name: type
+      type:
+        scalar: string
+- name: io.k8s.api.autoscaling.v2beta2.MetricStatus
+  map:
+    fields:
+    - name: external
+      type:
+        namedType: io.k8s.api.autoscaling.v2beta2.ExternalMetricStatus
+        elementRelationship: granular
+    - name: object
+      type:
+        namedType: io.k8s.api.autoscaling.v2beta2.ObjectMetricStatus
+        elementRelationship: granular
+    - name: pods
+      type:
+        namedType: io.k8s.api.autoscaling.v2beta2.PodsMetricStatus
+        elementRelationship: granular
+    - name: resource
+      type:
+        namedType: io.k8s.api.autoscaling.v2beta2.ResourceMetricStatus
+        elementRelationship: granular
+    - name: type
+      type:
+        scalar: string
+- name: io.k8s.api.autoscaling.v2beta2.MetricTarget
+  map:
+    fields:
+    - name: averageUtilization
+      type:
+        scalar: numeric
+    - name: averageValue
+      type:
+        namedType: io.k8s.apimachinery.pkg.api.resource.Quantity
+        elementRelationship: granular
+    - name: type
+      type:
+        scalar: string
+    - name: value
+      type:
+        namedType: io.k8s.apimachinery.pkg.api.resource.Quantity
+        elementRelationship: granular
+- name: io.k8s.api.autoscaling.v2beta2.MetricValueStatus
+  map:
+    fields:
+    - name: averageUtilization
+      type:
+        scalar: numeric
+    - name: averageValue
+      type:
+        namedType: io.k8s.apimachinery.pkg.api.resource.Quantity
+        elementRelationship: granular
+    - name: value
+      type:
+        namedType: io.k8s.apimachinery.pkg.api.resource.Quantity
+        elementRelationship: granular
+- name: io.k8s.api.autoscaling.v2beta2.ObjectMetricSource
+  map:
+    fields:
+    - name: describedObject
+      type:
+        namedType: io.k8s.api.autoscaling.v2beta2.CrossVersionObjectReference
+        elementRelationship: granular
+    - name: metric
+      type:
+        namedType: io.k8s.api.autoscaling.v2beta2.MetricIdentifier
+        elementRelationship: granular
+    - name: target
+      type:
+        namedType: io.k8s.api.autoscaling.v2beta2.MetricTarget
+        elementRelationship: granular
+- name: io.k8s.api.autoscaling.v2beta2.ObjectMetricStatus
+  map:
+    fields:
+    - name: current
+      type:
+        namedType: io.k8s.api.autoscaling.v2beta2.MetricValueStatus
+        elementRelationship: granular
+    - name: describedObject
+      type:
+        namedType: io.k8s.api.autoscaling.v2beta2.CrossVersionObjectReference
+        elementRelationship: granular
+    - name: metric
+      type:
+        namedType: io.k8s.api.autoscaling.v2beta2.MetricIdentifier
+        elementRelationship: granular
+- name: io.k8s.api.autoscaling.v2beta2.PodsMetricSource
+  map:
+    fields:
+    - name: metric
+      type:
+        namedType: io.k8s.api.autoscaling.v2beta2.MetricIdentifier
+        elementRelationship: granular
+    - name: target
+      type:
+        namedType: io.k8s.api.autoscaling.v2beta2.MetricTarget
+        elementRelationship: granular
+- name: io.k8s.api.autoscaling.v2beta2.PodsMetricStatus
+  map:
+    fields:
+    - name: current
+      type:
+        namedType: io.k8s.api.autoscaling.v2beta2.MetricValueStatus
+        elementRelationship: granular
+    - name: metric
+      type:
+        namedType: io.k8s.api.autoscaling.v2beta2.MetricIdentifier
+        elementRelationship: granular
+- name: io.k8s.api.autoscaling.v2beta2.ResourceMetricSource
+  map:
+    fields:
+    - name: name
+      type:
+        scalar: string
+    - name: target
+      type:
+        namedType: io.k8s.api.autoscaling.v2beta2.MetricTarget
+        elementRelationship: granular
+- name: io.k8s.api.autoscaling.v2beta2.ResourceMetricStatus
+  map:
+    fields:
+    - name: current
+      type:
+        namedType: io.k8s.api.autoscaling.v2beta2.MetricValueStatus
+        elementRelationship: granular
+    - name: name
+      type:
+        scalar: string
+- name: io.k8s.api.batch.v1.Job
+  map:
+    fields:
+    - name: apiVersion
+      type:
+        scalar: string
+    - name: kind
+      type:
+        scalar: string
+    - name: metadata
+      type:
+        namedType: io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta
+        elementRelationship: granular
+    - name: spec
+      type:
+        namedType: io.k8s.api.batch.v1.JobSpec
+        elementRelationship: granular
+    - name: status
+      type:
+        namedType: io.k8s.api.batch.v1.JobStatus
+        elementRelationship: granular
+- name: io.k8s.api.batch.v1.JobCondition
+  map:
+    fields:
+    - name: lastProbeTime
+      type:
+        namedType: io.k8s.apimachinery.pkg.apis.meta.v1.Time
+    - name: lastTransitionTime
+      type:
+        namedType: io.k8s.apimachinery.pkg.apis.meta.v1.Time
+    - name: message
+      type:
+        scalar: string
+    - name: reason
+      type:
+        scalar: string
+    - name: status
+      type:
+        scalar: string
+    - name: type
+      type:
+        scalar: string
+- name: io.k8s.api.batch.v1.JobList
+  map:
+    fields:
+    - name: apiVersion
+      type:
+        scalar: string
+    - name: items
+      type:
+        list:
+          elementType:
+            namedType: io.k8s.api.batch.v1.Job
+          elementRelationship: atomic
+    - name: kind
+      type:
+        scalar: string
+    - name: metadata
+      type:
+        namedType: io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta
+        elementRelationship: granular
+- name: io.k8s.api.batch.v1.JobSpec
+  map:
+    fields:
+    - name: activeDeadlineSeconds
+      type:
+        scalar: numeric
+    - name: backoffLimit
+      type:
+        scalar: numeric
+    - name: completions
+      type:
+        scalar: numeric
+    - name: manualSelector
+      type:
+        scalar: boolean
+    - name: parallelism
+      type:
+        scalar: numeric
+    - name: selector
+      type:
+        namedType: io.k8s.apimachinery.pkg.apis.meta.v1.LabelSelector
+        elementRelationship: granular
+    - name: template
+      type:
+        namedType: io.k8s.api.core.v1.PodTemplateSpec
+        elementRelationship: granular
+    - name: ttlSecondsAfterFinished
+      type:
+        scalar: numeric
+- name: io.k8s.api.batch.v1.JobStatus
+  map:
+    fields:
+    - name: active
+      type:
+        scalar: numeric
+    - name: completionTime
+      type:
+        namedType: io.k8s.apimachinery.pkg.apis.meta.v1.Time
+    - name: conditions
+      type:
+        list:
+          elementType:
+            namedType: io.k8s.api.batch.v1.JobCondition
+          elementRelationship: associative
+          keys:
+          - type
+    - name: failed
+      type:
+        scalar: numeric
+    - name: startTime
+      type:
+        namedType: io.k8s.apimachinery.pkg.apis.meta.v1.Time
+    - name: succeeded
+      type:
+        scalar: numeric
+- name: io.k8s.api.batch.v1beta1.CronJob
+  map:
+    fields:
+    - name: apiVersion
+      type:
+        scalar: string
+    - name: kind
+      type:
+        scalar: string
+    - name: metadata
+      type:
+        namedType: io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta
+        elementRelationship: granular
+    - name: spec
+      type:
+        namedType: io.k8s.api.batch.v1beta1.CronJobSpec
+        elementRelationship: granular
+    - name: status
+      type:
+        namedType: io.k8s.api.batch.v1beta1.CronJobStatus
+        elementRelationship: granular
+- name: io.k8s.api.batch.v1beta1.CronJobList
+  map:
+    fields:
+    - name: apiVersion
+      type:
+        scalar: string
+    - name: items
+      type:
+        list:
+          elementType:
+            namedType: io.k8s.api.batch.v1beta1.CronJob
+          elementRelationship: atomic
+    - name: kind
+      type:
+        scalar: string
+    - name: metadata
+      type:
+        namedType: io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta
+        elementRelationship: granular
+- name: io.k8s.api.batch.v1beta1.CronJobSpec
+  map:
+    fields:
+    - name: concurrencyPolicy
+      type:
+        scalar: string
+    - name: failedJobsHistoryLimit
+      type:
+        scalar: numeric
+    - name: jobTemplate
+      type:
+        namedType: io.k8s.api.batch.v1beta1.JobTemplateSpec
+        elementRelationship: granular
+    - name: schedule
+      type:
+        scalar: string
+    - name: startingDeadlineSeconds
+      type:
+        scalar: numeric
+    - name: successfulJobsHistoryLimit
+      type:
+        scalar: numeric
+    - name: suspend
+      type:
+        scalar: boolean
+- name: io.k8s.api.batch.v1beta1.CronJobStatus
+  map:
+    fields:
+    - name: active
+      type:
+        list:
+          elementType:
+            namedType: io.k8s.api.core.v1.ObjectReference
+          elementRelationship: atomic
+    - name: lastScheduleTime
+      type:
+        namedType: io.k8s.apimachinery.pkg.apis.meta.v1.Time
+- name: io.k8s.api.batch.v1beta1.JobTemplateSpec
+  map:
+    fields:
+    - name: metadata
+      type:
+        namedType: io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta
+        elementRelationship: granular
+    - name: spec
+      type:
+        namedType: io.k8s.api.batch.v1.JobSpec
+        elementRelationship: granular
+- name: io.k8s.api.batch.v2alpha1.CronJob
+  map:
+    fields:
+    - name: apiVersion
+      type:
+        scalar: string
+    - name: kind
+      type:
+        scalar: string
+    - name: metadata
+      type:
+        namedType: io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta
+        elementRelationship: granular
+    - name: spec
+      type:
+        namedType: io.k8s.api.batch.v2alpha1.CronJobSpec
+        elementRelationship: granular
+    - name: status
+      type:
+        namedType: io.k8s.api.batch.v2alpha1.CronJobStatus
+        elementRelationship: granular
+- name: io.k8s.api.batch.v2alpha1.CronJobList
+  map:
+    fields:
+    - name: apiVersion
+      type:
+        scalar: string
+    - name: items
+      type:
+        list:
+          elementType:
+            namedType: io.k8s.api.batch.v2alpha1.CronJob
+          elementRelationship: atomic
+    - name: kind
+      type:
+        scalar: string
+    - name: metadata
+      type:
+        namedType: io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta
+        elementRelationship: granular
+- name: io.k8s.api.batch.v2alpha1.CronJobSpec
+  map:
+    fields:
+    - name: concurrencyPolicy
+      type:
+        scalar: string
+    - name: failedJobsHistoryLimit
+      type:
+        scalar: numeric
+    - name: jobTemplate
+      type:
+        namedType: io.k8s.api.batch.v2alpha1.JobTemplateSpec
+        elementRelationship: granular
+    - name: schedule
+      type:
+        scalar: string
+    - name: startingDeadlineSeconds
+      type:
+        scalar: numeric
+    - name: successfulJobsHistoryLimit
+      type:
+        scalar: numeric
+    - name: suspend
+      type:
+        scalar: boolean
+- name: io.k8s.api.batch.v2alpha1.CronJobStatus
+  map:
+    fields:
+    - name: active
+      type:
+        list:
+          elementType:
+            namedType: io.k8s.api.core.v1.ObjectReference
+          elementRelationship: atomic
+    - name: lastScheduleTime
+      type:
+        namedType: io.k8s.apimachinery.pkg.apis.meta.v1.Time
+- name: io.k8s.api.batch.v2alpha1.JobTemplateSpec
+  map:
+    fields:
+    - name: metadata
+      type:
+        namedType: io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta
+        elementRelationship: granular
+    - name: spec
+      type:
+        namedType: io.k8s.api.batch.v1.JobSpec
+        elementRelationship: granular
+- name: io.k8s.api.certificates.v1beta1.CertificateSigningRequest
+  map:
+    fields:
+    - name: apiVersion
+      type:
+        scalar: string
+    - name: kind
+      type:
+        scalar: string
+    - name: metadata
+      type:
+        namedType: io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta
+        elementRelationship: granular
+    - name: spec
+      type:
+        namedType: io.k8s.api.certificates.v1beta1.CertificateSigningRequestSpec
+        elementRelationship: granular
+    - name: status
+      type:
+        namedType: io.k8s.api.certificates.v1beta1.CertificateSigningRequestStatus
+        elementRelationship: granular
+- name: io.k8s.api.certificates.v1beta1.CertificateSigningRequestCondition
+  map:
+    fields:
+    - name: lastUpdateTime
+      type:
+        namedType: io.k8s.apimachinery.pkg.apis.meta.v1.Time
+    - name: message
+      type:
+        scalar: string
+    - name: reason
+      type:
+        scalar: string
+    - name: type
+      type:
+        scalar: string
+- name: io.k8s.api.certificates.v1beta1.CertificateSigningRequestList
+  map:
+    fields:
+    - name: apiVersion
+      type:
+        scalar: string
+    - name: items
+      type:
+        list:
+          elementType:
+            namedType: io.k8s.api.certificates.v1beta1.CertificateSigningRequest
+          elementRelationship: atomic
+    - name: kind
+      type:
+        scalar: string
+    - name: metadata
+      type:
+        namedType: io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta
+        elementRelationship: granular
+- name: io.k8s.api.certificates.v1beta1.CertificateSigningRequestSpec
+  map:
+    fields:
+    - name: extra
+      type:
+        map:
+          elementType:
+            list:
+              elementType:
+                scalar: string
+              elementRelationship: atomic
+    - name: groups
+      type:
+        list:
+          elementType:
+            scalar: string
+          elementRelationship: atomic
+    - name: request
+      type:
+        scalar: string
+    - name: uid
+      type:
+        scalar: string
+    - name: usages
+      type:
+        list:
+          elementType:
+            scalar: string
+          elementRelationship: atomic
+    - name: username
+      type:
+        scalar: string
+- name: io.k8s.api.certificates.v1beta1.CertificateSigningRequestStatus
+  map:
+    fields:
+    - name: certificate
+      type:
+        scalar: string
+    - name: conditions
+      type:
+        list:
+          elementType:
+            namedType: io.k8s.api.certificates.v1beta1.CertificateSigningRequestCondition
+          elementRelationship: atomic
+- name: io.k8s.api.coordination.v1beta1.Lease
+  map:
+    fields:
+    - name: apiVersion
+      type:
+        scalar: string
+    - name: kind
+      type:
+        scalar: string
+    - name: metadata
+      type:
+        namedType: io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta
+        elementRelationship: granular
+    - name: spec
+      type:
+        namedType: io.k8s.api.coordination.v1beta1.LeaseSpec
+        elementRelationship: granular
+- name: io.k8s.api.coordination.v1beta1.LeaseList
+  map:
+    fields:
+    - name: apiVersion
+      type:
+        scalar: string
+    - name: items
+      type:
+        list:
+          elementType:
+            namedType: io.k8s.api.coordination.v1beta1.Lease
+          elementRelationship: atomic
+    - name: kind
+      type:
+        scalar: string
+    - name: metadata
+      type:
+        namedType: io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta
+        elementRelationship: granular
+- name: io.k8s.api.coordination.v1beta1.LeaseSpec
+  map:
+    fields:
+    - name: acquireTime
+      type:
+        namedType: io.k8s.apimachinery.pkg.apis.meta.v1.MicroTime
+        elementRelationship: granular
+    - name: holderIdentity
+      type:
+        scalar: string
+    - name: leaseDurationSeconds
+      type:
+        scalar: numeric
+    - name: leaseTransitions
+      type:
+        scalar: numeric
+    - name: renewTime
+      type:
+        namedType: io.k8s.apimachinery.pkg.apis.meta.v1.MicroTime
+        elementRelationship: granular
+- name: io.k8s.api.core.v1.AWSElasticBlockStoreVolumeSource
+  map:
+    fields:
+    - name: fsType
+      type:
+        scalar: string
+    - name: partition
+      type:
+        scalar: numeric
+    - name: readOnly
+      type:
+        scalar: boolean
+    - name: volumeID
+      type:
+        scalar: string
+- name: io.k8s.api.core.v1.Affinity
+  map:
+    fields:
+    - name: nodeAffinity
+      type:
+        namedType: io.k8s.api.core.v1.NodeAffinity
+        elementRelationship: granular
+    - name: podAffinity
+      type:
+        namedType: io.k8s.api.core.v1.PodAffinity
+        elementRelationship: granular
+    - name: podAntiAffinity
+      type:
+        namedType: io.k8s.api.core.v1.PodAntiAffinity
+        elementRelationship: granular
+- name: io.k8s.api.core.v1.AttachedVolume
+  map:
+    fields:
+    - name: devicePath
+      type:
+        scalar: string
+    - name: name
+      type:
+        scalar: string
+- name: io.k8s.api.core.v1.AzureDiskVolumeSource
+  map:
+    fields:
+    - name: cachingMode
+      type:
+        scalar: string
+    - name: diskName
+      type:
+        scalar: string
+    - name: diskURI
+      type:
+        scalar: string
+    - name: fsType
+      type:
+        scalar: string
+    - name: kind
+      type:
+        scalar: string
+    - name: readOnly
+      type:
+        scalar: boolean
+- name: io.k8s.api.core.v1.AzureFilePersistentVolumeSource
+  map:
+    fields:
+    - name: readOnly
+      type:
+        scalar: boolean
+    - name: secretName
+      type:
+        scalar: string
+    - name: secretNamespace
+      type:
+        scalar: string
+    - name: shareName
+      type:
+        scalar: string
+- name: io.k8s.api.core.v1.AzureFileVolumeSource
+  map:
+    fields:
+    - name: readOnly
+      type:
+        scalar: boolean
+    - name: secretName
+      type:
+        scalar: string
+    - name: shareName
+      type:
+        scalar: string
+- name: io.k8s.api.core.v1.Binding
+  map:
+    fields:
+    - name: apiVersion
+      type:
+        scalar: string
+    - name: kind
+      type:
+        scalar: string
+    - name: metadata
+      type:
+        namedType: io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta
+        elementRelationship: granular
+    - name: target
+      type:
+        namedType: io.k8s.api.core.v1.ObjectReference
+        elementRelationship: granular
+- name: io.k8s.api.core.v1.CSIPersistentVolumeSource
+  map:
+    fields:
+    - name: controllerPublishSecretRef
+      type:
+        namedType: io.k8s.api.core.v1.SecretReference
+        elementRelationship: granular
+    - name: driver
+      type:
+        scalar: string
+    - name: fsType
+      type:
+        scalar: string
+    - name: nodePublishSecretRef
+      type:
+        namedType: io.k8s.api.core.v1.SecretReference
+        elementRelationship: granular
+    - name: nodeStageSecretRef
+      type:
+        namedType: io.k8s.api.core.v1.SecretReference
+        elementRelationship: granular
+    - name: readOnly
+      type:
+        scalar: boolean
+    - name: volumeAttributes
+      type:
+        map:
+          elementType:
+            scalar: string
+    - name: volumeHandle
+      type:
+        scalar: string
+- name: io.k8s.api.core.v1.Capabilities
+  map:
+    fields:
+    - name: add
+      type:
+        list:
+          elementType:
+            scalar: string
+          elementRelationship: atomic
+    - name: drop
+      type:
+        list:
+          elementType:
+            scalar: string
+          elementRelationship: atomic
+- name: io.k8s.api.core.v1.CephFSPersistentVolumeSource
+  map:
+    fields:
+    - name: monitors
+      type:
+        list:
+          elementType:
+            scalar: string
+          elementRelationship: atomic
+    - name: path
+      type:
+        scalar: string
+    - name: readOnly
+      type:
+        scalar: boolean
+    - name: secretFile
+      type:
+        scalar: string
+    - name: secretRef
+      type:
+        namedType: io.k8s.api.core.v1.SecretReference
+        elementRelationship: granular
+    - name: user
+      type:
+        scalar: string
+- name: io.k8s.api.core.v1.CephFSVolumeSource
+  map:
+    fields:
+    - name: monitors
+      type:
+        list:
+          elementType:
+            scalar: string
+          elementRelationship: atomic
+    - name: path
+      type:
+        scalar: string
+    - name: readOnly
+      type:
+        scalar: boolean
+    - name: secretFile
+      type:
+        scalar: string
+    - name: secretRef
+      type:
+        namedType: io.k8s.api.core.v1.LocalObjectReference
+        elementRelationship: granular
+    - name: user
+      type:
+        scalar: string
+- name: io.k8s.api.core.v1.CinderPersistentVolumeSource
+  map:
+    fields:
+    - name: fsType
+      type:
+        scalar: string
+    - name: readOnly
+      type:
+        scalar: boolean
+    - name: secretRef
+      type:
+        namedType: io.k8s.api.core.v1.SecretReference
+        elementRelationship: granular
+    - name: volumeID
+      type:
+        scalar: string
+- name: io.k8s.api.core.v1.CinderVolumeSource
+  map:
+    fields:
+    - name: fsType
+      type:
+        scalar: string
+    - name: readOnly
+      type:
+        scalar: boolean
+    - name: secretRef
+      type:
+        namedType: io.k8s.api.core.v1.LocalObjectReference
+        elementRelationship: granular
+    - name: volumeID
+      type:
+        scalar: string
+- name: io.k8s.api.core.v1.ClientIPConfig
+  map:
+    fields:
+    - name: timeoutSeconds
+      type:
+        scalar: numeric
+- name: io.k8s.api.core.v1.ComponentCondition
+  map:
+    fields:
+    - name: error
+      type:
+        scalar: string
+    - name: message
+      type:
+        scalar: string
+    - name: status
+      type:
+        scalar: string
+    - name: type
+      type:
+        scalar: string
+- name: io.k8s.api.core.v1.ComponentStatus
+  map:
+    fields:
+    - name: apiVersion
+      type:
+        scalar: string
+    - name: conditions
+      type:
+        list:
+          elementType:
+            namedType: io.k8s.api.core.v1.ComponentCondition
+          elementRelationship: associative
+          keys:
+          - type
+    - name: kind
+      type:
+        scalar: string
+    - name: metadata
+      type:
+        namedType: io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta
+        elementRelationship: granular
+- name: io.k8s.api.core.v1.ComponentStatusList
+  map:
+    fields:
+    - name: apiVersion
+      type:
+        scalar: string
+    - name: items
+      type:
+        list:
+          elementType:
+            namedType: io.k8s.api.core.v1.ComponentStatus
+          elementRelationship: atomic
+    - name: kind
+      type:
+        scalar: string
+    - name: metadata
+      type:
+        namedType: io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta
+        elementRelationship: granular
+- name: io.k8s.api.core.v1.ConfigMap
+  map:
+    fields:
+    - name: apiVersion
+      type:
+        scalar: string
+    - name: binaryData
+      type:
+        map:
+          elementType:
+            scalar: string
+    - name: data
+      type:
+        map:
+          elementType:
+            scalar: string
+    - name: kind
+      type:
+        scalar: string
+    - name: metadata
+      type:
+        namedType: io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta
+        elementRelationship: granular
+- name: io.k8s.api.core.v1.ConfigMapEnvSource
+  map:
+    fields:
+    - name: name
+      type:
+        scalar: string
+    - name: optional
+      type:
+        scalar: boolean
+- name: io.k8s.api.core.v1.ConfigMapKeySelector
+  map:
+    fields:
+    - name: key
+      type:
+        scalar: string
+    - name: name
+      type:
+        scalar: string
+    - name: optional
+      type:
+        scalar: boolean
+- name: io.k8s.api.core.v1.ConfigMapList
+  map:
+    fields:
+    - name: apiVersion
+      type:
+        scalar: string
+    - name: items
+      type:
+        list:
+          elementType:
+            namedType: io.k8s.api.core.v1.ConfigMap
+          elementRelationship: atomic
+    - name: kind
+      type:
+        scalar: string
+    - name: metadata
+      type:
+        namedType: io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta
+        elementRelationship: granular
+- name: io.k8s.api.core.v1.ConfigMapNodeConfigSource
+  map:
+    fields:
+    - name: kubeletConfigKey
+      type:
+        scalar: string
+    - name: name
+      type:
+        scalar: string
+    - name: namespace
+      type:
+        scalar: string
+    - name: resourceVersion
+      type:
+        scalar: string
+    - name: uid
+      type:
+        scalar: string
+- name: io.k8s.api.core.v1.ConfigMapProjection
+  map:
+    fields:
+    - name: items
+      type:
+        list:
+          elementType:
+            namedType: io.k8s.api.core.v1.KeyToPath
+          elementRelationship: atomic
+    - name: name
+      type:
+        scalar: string
+    - name: optional
+      type:
+        scalar: boolean
+- name: io.k8s.api.core.v1.ConfigMapVolumeSource
+  map:
+    fields:
+    - name: defaultMode
+      type:
+        scalar: numeric
+    - name: items
+      type:
+        list:
+          elementType:
+            namedType: io.k8s.api.core.v1.KeyToPath
+          elementRelationship: atomic
+    - name: name
+      type:
+        scalar: string
+    - name: optional
+      type:
+        scalar: boolean
+- name: io.k8s.api.core.v1.Container
+  map:
+    fields:
+    - name: args
+      type:
+        list:
+          elementType:
+            scalar: string
+          elementRelationship: atomic
+    - name: command
+      type:
+        list:
+          elementType:
+            scalar: string
+          elementRelationship: atomic
+    - name: env
+      type:
+        list:
+          elementType:
+            namedType: io.k8s.api.core.v1.EnvVar
+          elementRelationship: associative
+          keys:
+          - name
+    - name: envFrom
+      type:
+        list:
+          elementType:
+            namedType: io.k8s.api.core.v1.EnvFromSource
+          elementRelationship: atomic
+    - name: image
+      type:
+        scalar: string
+    - name: imagePullPolicy
+      type:
+        scalar: string
+    - name: lifecycle
+      type:
+        namedType: io.k8s.api.core.v1.Lifecycle
+        elementRelationship: granular
+    - name: livenessProbe
+      type:
+        namedType: io.k8s.api.core.v1.Probe
+        elementRelationship: granular
+    - name: name
+      type:
+        scalar: string
+    - name: ports
+      type:
+        list:
+          elementType:
+            namedType: io.k8s.api.core.v1.ContainerPort
+          elementRelationship: associative
+          keys:
+          - containerPort
+          - protocol
+    - name: readinessProbe
+      type:
+        namedType: io.k8s.api.core.v1.Probe
+        elementRelationship: granular
+    - name: resources
+      type:
+        namedType: io.k8s.api.core.v1.ResourceRequirements
+        elementRelationship: granular
+    - name: securityContext
+      type:
+        namedType: io.k8s.api.core.v1.SecurityContext
+        elementRelationship: granular
+    - name: stdin
+      type:
+        scalar: boolean
+    - name: stdinOnce
+      type:
+        scalar: boolean
+    - name: terminationMessagePath
+      type:
+        scalar: string
+    - name: terminationMessagePolicy
+      type:
+        scalar: string
+    - name: tty
+      type:
+        scalar: boolean
+    - name: volumeDevices
+      type:
+        list:
+          elementType:
+            namedType: io.k8s.api.core.v1.VolumeDevice
+          elementRelationship: associative
+          keys:
+          - devicePath
+    - name: volumeMounts
+      type:
+        list:
+          elementType:
+            namedType: io.k8s.api.core.v1.VolumeMount
+          elementRelationship: associative
+          keys:
+          - mountPath
+    - name: workingDir
+      type:
+        scalar: string
+- name: io.k8s.api.core.v1.ContainerImage
+  map:
+    fields:
+    - name: names
+      type:
+        list:
+          elementType:
+            scalar: string
+          elementRelationship: atomic
+    - name: sizeBytes
+      type:
+        scalar: numeric
+- name: io.k8s.api.core.v1.ContainerPort
+  map:
+    fields:
+    - name: containerPort
+      type:
+        scalar: numeric
+    - name: hostIP
+      type:
+        scalar: string
+    - name: hostPort
+      type:
+        scalar: numeric
+    - name: name
+      type:
+        scalar: string
+    - name: protocol
+      type:
+        scalar: string
+- name: io.k8s.api.core.v1.ContainerState
+  map:
+    fields:
+    - name: running
+      type:
+        namedType: io.k8s.api.core.v1.ContainerStateRunning
+        elementRelationship: granular
+    - name: terminated
+      type:
+        namedType: io.k8s.api.core.v1.ContainerStateTerminated
+        elementRelationship: granular
+    - name: waiting
+      type:
+        namedType: io.k8s.api.core.v1.ContainerStateWaiting
+        elementRelationship: granular
+- name: io.k8s.api.core.v1.ContainerStateRunning
+  map:
+    fields:
+    - name: startedAt
+      type:
+        namedType: io.k8s.apimachinery.pkg.apis.meta.v1.Time
+- name: io.k8s.api.core.v1.ContainerStateTerminated
+  map:
+    fields:
+    - name: containerID
+      type:
+        scalar: string
+    - name: exitCode
+      type:
+        scalar: numeric
+    - name: finishedAt
+      type:
+        namedType: io.k8s.apimachinery.pkg.apis.meta.v1.Time
+    - name: message
+      type:
+        scalar: string
+    - name: reason
+      type:
+        scalar: string
+    - name: signal
+      type:
+        scalar: numeric
+    - name: startedAt
+      type:
+        namedType: io.k8s.apimachinery.pkg.apis.meta.v1.Time
+- name: io.k8s.api.core.v1.ContainerStateWaiting
+  map:
+    fields:
+    - name: message
+      type:
+        scalar: string
+    - name: reason
+      type:
+        scalar: string
+- name: io.k8s.api.core.v1.ContainerStatus
+  map:
+    fields:
+    - name: containerID
+      type:
+        scalar: string
+    - name: image
+      type:
+        scalar: string
+    - name: imageID
+      type:
+        scalar: string
+    - name: lastState
+      type:
+        namedType: io.k8s.api.core.v1.ContainerState
+        elementRelationship: granular
+    - name: name
+      type:
+        scalar: string
+    - name: ready
+      type:
+        scalar: boolean
+    - name: restartCount
+      type:
+        scalar: numeric
+    - name: state
+      type:
+        namedType: io.k8s.api.core.v1.ContainerState
+        elementRelationship: granular
+- name: io.k8s.api.core.v1.DaemonEndpoint
+  map:
+    fields:
+    - name: Port
+      type:
+        scalar: numeric
+- name: io.k8s.api.core.v1.DownwardAPIProjection
+  map:
+    fields:
+    - name: items
+      type:
+        list:
+          elementType:
+            namedType: io.k8s.api.core.v1.DownwardAPIVolumeFile
+          elementRelationship: atomic
+- name: io.k8s.api.core.v1.DownwardAPIVolumeFile
+  map:
+    fields:
+    - name: fieldRef
+      type:
+        namedType: io.k8s.api.core.v1.ObjectFieldSelector
+        elementRelationship: granular
+    - name: mode
+      type:
+        scalar: numeric
+    - name: path
+      type:
+        scalar: string
+    - name: resourceFieldRef
+      type:
+        namedType: io.k8s.api.core.v1.ResourceFieldSelector
+        elementRelationship: granular
+- name: io.k8s.api.core.v1.DownwardAPIVolumeSource
+  map:
+    fields:
+    - name: defaultMode
+      type:
+        scalar: numeric
+    - name: items
+      type:
+        list:
+          elementType:
+            namedType: io.k8s.api.core.v1.DownwardAPIVolumeFile
+          elementRelationship: atomic
+- name: io.k8s.api.core.v1.EmptyDirVolumeSource
+  map:
+    fields:
+    - name: medium
+      type:
+        scalar: string
+    - name: sizeLimit
+      type:
+        namedType: io.k8s.apimachinery.pkg.api.resource.Quantity
+        elementRelationship: granular
+- name: io.k8s.api.core.v1.EndpointAddress
+  map:
+    fields:
+    - name: hostname
+      type:
+        scalar: string
+    - name: ip
+      type:
+        scalar: string
+    - name: nodeName
+      type:
+        scalar: string
+    - name: targetRef
+      type:
+        namedType: io.k8s.api.core.v1.ObjectReference
+        elementRelationship: granular
+- name: io.k8s.api.core.v1.EndpointPort
+  map:
+    fields:
+    - name: name
+      type:
+        scalar: string
+    - name: port
+      type:
+        scalar: numeric
+    - name: protocol
+      type:
+        scalar: string
+- name: io.k8s.api.core.v1.EndpointSubset
+  map:
+    fields:
+    - name: addresses
+      type:
+        list:
+          elementType:
+            namedType: io.k8s.api.core.v1.EndpointAddress
+          elementRelationship: atomic
+    - name: notReadyAddresses
+      type:
+        list:
+          elementType:
+            namedType: io.k8s.api.core.v1.EndpointAddress
+          elementRelationship: atomic
+    - name: ports
+      type:
+        list:
+          elementType:
+            namedType: io.k8s.api.core.v1.EndpointPort
+          elementRelationship: atomic
+- name: io.k8s.api.core.v1.Endpoints
+  map:
+    fields:
+    - name: apiVersion
+      type:
+        scalar: string
+    - name: kind
+      type:
+        scalar: string
+    - name: metadata
+      type:
+        namedType: io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta
+        elementRelationship: granular
+    - name: subsets
+      type:
+        list:
+          elementType:
+            namedType: io.k8s.api.core.v1.EndpointSubset
+          elementRelationship: atomic
+- name: io.k8s.api.core.v1.EndpointsList
+  map:
+    fields:
+    - name: apiVersion
+      type:
+        scalar: string
+    - name: items
+      type:
+        list:
+          elementType:
+            namedType: io.k8s.api.core.v1.Endpoints
+          elementRelationship: atomic
+    - name: kind
+      type:
+        scalar: string
+    - name: metadata
+      type:
+        namedType: io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta
+        elementRelationship: granular
+- name: io.k8s.api.core.v1.EnvFromSource
+  map:
+    fields:
+    - name: configMapRef
+      type:
+        namedType: io.k8s.api.core.v1.ConfigMapEnvSource
+        elementRelationship: granular
+    - name: prefix
+      type:
+        scalar: string
+    - name: secretRef
+      type:
+        namedType: io.k8s.api.core.v1.SecretEnvSource
+        elementRelationship: granular
+- name: io.k8s.api.core.v1.EnvVar
+  map:
+    fields:
+    - name: name
+      type:
+        scalar: string
+    - name: value
+      type:
+        scalar: string
+    - name: valueFrom
+      type:
+        namedType: io.k8s.api.core.v1.EnvVarSource
+        elementRelationship: granular
+- name: io.k8s.api.core.v1.EnvVarSource
+  map:
+    fields:
+    - name: configMapKeyRef
+      type:
+        namedType: io.k8s.api.core.v1.ConfigMapKeySelector
+        elementRelationship: granular
+    - name: fieldRef
+      type:
+        namedType: io.k8s.api.core.v1.ObjectFieldSelector
+        elementRelationship: granular
+    - name: resourceFieldRef
+      type:
+        namedType: io.k8s.api.core.v1.ResourceFieldSelector
+        elementRelationship: granular
+    - name: secretKeyRef
+      type:
+        namedType: io.k8s.api.core.v1.SecretKeySelector
+        elementRelationship: granular
+- name: io.k8s.api.core.v1.Event
+  map:
+    fields:
+    - name: action
+      type:
+        scalar: string
+    - name: apiVersion
+      type:
+        scalar: string
+    - name: count
+      type:
+        scalar: numeric
+    - name: eventTime
+      type:
+        namedType: io.k8s.apimachinery.pkg.apis.meta.v1.MicroTime
+        elementRelationship: granular
+    - name: firstTimestamp
+      type:
+        namedType: io.k8s.apimachinery.pkg.apis.meta.v1.Time
+    - name: involvedObject
+      type:
+        namedType: io.k8s.api.core.v1.ObjectReference
+        elementRelationship: granular
+    - name: kind
+      type:
+        scalar: string
+    - name: lastTimestamp
+      type:
+        namedType: io.k8s.apimachinery.pkg.apis.meta.v1.Time
+    - name: message
+      type:
+        scalar: string
+    - name: metadata
+      type:
+        namedType: io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta
+        elementRelationship: granular
+    - name: reason
+      type:
+        scalar: string
+    - name: related
+      type:
+        namedType: io.k8s.api.core.v1.ObjectReference
+        elementRelationship: granular
+    - name: reportingComponent
+      type:
+        scalar: string
+    - name: reportingInstance
+      type:
+        scalar: string
+    - name: series
+      type:
+        namedType: io.k8s.api.core.v1.EventSeries
+        elementRelationship: granular
+    - name: source
+      type:
+        namedType: io.k8s.api.core.v1.EventSource
+        elementRelationship: granular
+    - name: type
+      type:
+        scalar: string
+- name: io.k8s.api.core.v1.EventList
+  map:
+    fields:
+    - name: apiVersion
+      type:
+        scalar: string
+    - name: items
+      type:
+        list:
+          elementType:
+            namedType: io.k8s.api.core.v1.Event
+          elementRelationship: atomic
+    - name: kind
+      type:
+        scalar: string
+    - name: metadata
+      type:
+        namedType: io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta
+        elementRelationship: granular
+- name: io.k8s.api.core.v1.EventSeries
+  map:
+    fields:
+    - name: count
+      type:
+        scalar: numeric
+    - name: lastObservedTime
+      type:
+        namedType: io.k8s.apimachinery.pkg.apis.meta.v1.MicroTime
+        elementRelationship: granular
+    - name: state
+      type:
+        scalar: string
+- name: io.k8s.api.core.v1.EventSource
+  map:
+    fields:
+    - name: component
+      type:
+        scalar: string
+    - name: host
+      type:
+        scalar: string
+- name: io.k8s.api.core.v1.ExecAction
+  map:
+    fields:
+    - name: command
+      type:
+        list:
+          elementType:
+            scalar: string
+          elementRelationship: atomic
+- name: io.k8s.api.core.v1.FCVolumeSource
+  map:
+    fields:
+    - name: fsType
+      type:
+        scalar: string
+    - name: lun
+      type:
+        scalar: numeric
+    - name: readOnly
+      type:
+        scalar: boolean
+    - name: targetWWNs
+      type:
+        list:
+          elementType:
+            scalar: string
+          elementRelationship: atomic
+    - name: wwids
+      type:
+        list:
+          elementType:
+            scalar: string
+          elementRelationship: atomic
+- name: io.k8s.api.core.v1.FlexPersistentVolumeSource
+  map:
+    fields:
+    - name: driver
+      type:
+        scalar: string
+    - name: fsType
+      type:
+        scalar: string
+    - name: options
+      type:
+        map:
+          elementType:
+            scalar: string
+    - name: readOnly
+      type:
+        scalar: boolean
+    - name: secretRef
+      type:
+        namedType: io.k8s.api.core.v1.SecretReference
+        elementRelationship: granular
+- name: io.k8s.api.core.v1.FlexVolumeSource
+  map:
+    fields:
+    - name: driver
+      type:
+        scalar: string
+    - name: fsType
+      type:
+        scalar: string
+    - name: options
+      type:
+        map:
+          elementType:
+            scalar: string
+    - name: readOnly
+      type:
+        scalar: boolean
+    - name: secretRef
+      type:
+        namedType: io.k8s.api.core.v1.LocalObjectReference
+        elementRelationship: granular
+- name: io.k8s.api.core.v1.FlockerVolumeSource
+  map:
+    fields:
+    - name: datasetName
+      type:
+        scalar: string
+    - name: datasetUUID
+      type:
+        scalar: string
+- name: io.k8s.api.core.v1.GCEPersistentDiskVolumeSource
+  map:
+    fields:
+    - name: fsType
+      type:
+        scalar: string
+    - name: partition
+      type:
+        scalar: numeric
+    - name: pdName
+      type:
+        scalar: string
+    - name: readOnly
+      type:
+        scalar: boolean
+- name: io.k8s.api.core.v1.GitRepoVolumeSource
+  map:
+    fields:
+    - name: directory
+      type:
+        scalar: string
+    - name: repository
+      type:
+        scalar: string
+    - name: revision
+      type:
+        scalar: string
+- name: io.k8s.api.core.v1.GlusterfsVolumeSource
+  map:
+    fields:
+    - name: endpoints
+      type:
+        scalar: string
+    - name: path
+      type:
+        scalar: string
+    - name: readOnly
+      type:
+        scalar: boolean
+- name: io.k8s.api.core.v1.HTTPGetAction
+  map:
+    fields:
+    - name: host
+      type:
+        scalar: string
+    - name: httpHeaders
+      type:
+        list:
+          elementType:
+            namedType: io.k8s.api.core.v1.HTTPHeader
+          elementRelationship: atomic
+    - name: path
+      type:
+        scalar: string
+    - name: port
+      type:
+        namedType: io.k8s.apimachinery.pkg.util.intstr.IntOrString
+        elementRelationship: granular
+    - name: scheme
+      type:
+        scalar: string
+- name: io.k8s.api.core.v1.HTTPHeader
+  map:
+    fields:
+    - name: name
+      type:
+        scalar: string
+    - name: value
+      type:
+        scalar: string
+- name: io.k8s.api.core.v1.Handler
+  map:
+    fields:
+    - name: exec
+      type:
+        namedType: io.k8s.api.core.v1.ExecAction
+        elementRelationship: granular
+    - name: httpGet
+      type:
+        namedType: io.k8s.api.core.v1.HTTPGetAction
+        elementRelationship: granular
+    - name: tcpSocket
+      type:
+        namedType: io.k8s.api.core.v1.TCPSocketAction
+        elementRelationship: granular
+- name: io.k8s.api.core.v1.HostAlias
+  map:
+    fields:
+    - name: hostnames
+      type:
+        list:
+          elementType:
+            scalar: string
+          elementRelationship: atomic
+    - name: ip
+      type:
+        scalar: string
+- name: io.k8s.api.core.v1.HostPathVolumeSource
+  map:
+    fields:
+    - name: path
+      type:
+        scalar: string
+    - name: type
+      type:
+        scalar: string
+- name: io.k8s.api.core.v1.ISCSIPersistentVolumeSource
+  map:
+    fields:
+    - name: chapAuthDiscovery
+      type:
+        scalar: boolean
+    - name: chapAuthSession
+      type:
+        scalar: boolean
+    - name: fsType
+      type:
+        scalar: string
+    - name: initiatorName
+      type:
+        scalar: string
+    - name: iqn
+      type:
+        scalar: string
+    - name: iscsiInterface
+      type:
+        scalar: string
+    - name: lun
+      type:
+        scalar: numeric
+    - name: portals
+      type:
+        list:
+          elementType:
+            scalar: string
+          elementRelationship: atomic
+    - name: readOnly
+      type:
+        scalar: boolean
+    - name: secretRef
+      type:
+        namedType: io.k8s.api.core.v1.SecretReference
+        elementRelationship: granular
+    - name: targetPortal
+      type:
+        scalar: string
+- name: io.k8s.api.core.v1.ISCSIVolumeSource
+  map:
+    fields:
+    - name: chapAuthDiscovery
+      type:
+        scalar: boolean
+    - name: chapAuthSession
+      type:
+        scalar: boolean
+    - name: fsType
+      type:
+        scalar: string
+    - name: initiatorName
+      type:
+        scalar: string
+    - name: iqn
+      type:
+        scalar: string
+    - name: iscsiInterface
+      type:
+        scalar: string
+    - name: lun
+      type:
+        scalar: numeric
+    - name: portals
+      type:
+        list:
+          elementType:
+            scalar: string
+          elementRelationship: atomic
+    - name: readOnly
+      type:
+        scalar: boolean
+    - name: secretRef
+      type:
+        namedType: io.k8s.api.core.v1.LocalObjectReference
+        elementRelationship: granular
+    - name: targetPortal
+      type:
+        scalar: string
+- name: io.k8s.api.core.v1.KeyToPath
+  map:
+    fields:
+    - name: key
+      type:
+        scalar: string
+    - name: mode
+      type:
+        scalar: numeric
+    - name: path
+      type:
+        scalar: string
+- name: io.k8s.api.core.v1.Lifecycle
+  map:
+    fields:
+    - name: postStart
+      type:
+        namedType: io.k8s.api.core.v1.Handler
+        elementRelationship: granular
+    - name: preStop
+      type:
+        namedType: io.k8s.api.core.v1.Handler
+        elementRelationship: granular
+- name: io.k8s.api.core.v1.LimitRange
+  map:
+    fields:
+    - name: apiVersion
+      type:
+        scalar: string
+    - name: kind
+      type:
+        scalar: string
+    - name: metadata
+      type:
+        namedType: io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta
+        elementRelationship: granular
+    - name: spec
+      type:
+        namedType: io.k8s.api.core.v1.LimitRangeSpec
+        elementRelationship: granular
+- name: io.k8s.api.core.v1.LimitRangeItem
+  map:
+    fields:
+    - name: default
+      type:
+        map:
+          elementType:
+            namedType: io.k8s.apimachinery.pkg.api.resource.Quantity
+    - name: defaultRequest
+      type:
+        map:
+          elementType:
+            namedType: io.k8s.apimachinery.pkg.api.resource.Quantity
+    - name: max
+      type:
+        map:
+          elementType:
+            namedType: io.k8s.apimachinery.pkg.api.resource.Quantity
+    - name: maxLimitRequestRatio
+      type:
+        map:
+          elementType:
+            namedType: io.k8s.apimachinery.pkg.api.resource.Quantity
+    - name: min
+      type:
+        map:
+          elementType:
+            namedType: io.k8s.apimachinery.pkg.api.resource.Quantity
+    - name: type
+      type:
+        scalar: string
+- name: io.k8s.api.core.v1.LimitRangeList
+  map:
+    fields:
+    - name: apiVersion
+      type:
+        scalar: string
+    - name: items
+      type:
+        list:
+          elementType:
+            namedType: io.k8s.api.core.v1.LimitRange
+          elementRelationship: atomic
+    - name: kind
+      type:
+        scalar: string
+    - name: metadata
+      type:
+        namedType: io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta
+        elementRelationship: granular
+- name: io.k8s.api.core.v1.LimitRangeSpec
+  map:
+    fields:
+    - name: limits
+      type:
+        list:
+          elementType:
+            namedType: io.k8s.api.core.v1.LimitRangeItem
+          elementRelationship: atomic
+- name: io.k8s.api.core.v1.LoadBalancerIngress
+  map:
+    fields:
+    - name: hostname
+      type:
+        scalar: string
+    - name: ip
+      type:
+        scalar: string
+- name: io.k8s.api.core.v1.LoadBalancerStatus
+  map:
+    fields:
+    - name: ingress
+      type:
+        list:
+          elementType:
+            namedType: io.k8s.api.core.v1.LoadBalancerIngress
+          elementRelationship: atomic
+- name: io.k8s.api.core.v1.LocalObjectReference
+  map:
+    fields:
+    - name: name
+      type:
+        scalar: string
+- name: io.k8s.api.core.v1.LocalVolumeSource
+  map:
+    fields:
+    - name: fsType
+      type:
+        scalar: string
+    - name: path
+      type:
+        scalar: string
+- name: io.k8s.api.core.v1.NFSVolumeSource
+  map:
+    fields:
+    - name: path
+      type:
+        scalar: string
+    - name: readOnly
+      type:
+        scalar: boolean
+    - name: server
+      type:
+        scalar: string
+- name: io.k8s.api.core.v1.Namespace
+  map:
+    fields:
+    - name: apiVersion
+      type:
+        scalar: string
+    - name: kind
+      type:
+        scalar: string
+    - name: metadata
+      type:
+        namedType: io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta
+        elementRelationship: granular
+    - name: spec
+      type:
+        namedType: io.k8s.api.core.v1.NamespaceSpec
+        elementRelationship: granular
+    - name: status
+      type:
+        namedType: io.k8s.api.core.v1.NamespaceStatus
+        elementRelationship: granular
+- name: io.k8s.api.core.v1.NamespaceList
+  map:
+    fields:
+    - name: apiVersion
+      type:
+        scalar: string
+    - name: items
+      type:
+        list:
+          elementType:
+            namedType: io.k8s.api.core.v1.Namespace
+          elementRelationship: atomic
+    - name: kind
+      type:
+        scalar: string
+    - name: metadata
+      type:
+        namedType: io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta
+        elementRelationship: granular
+- name: io.k8s.api.core.v1.NamespaceSpec
+  map:
+    fields:
+    - name: finalizers
+      type:
+        list:
+          elementType:
+            scalar: string
+          elementRelationship: atomic
+- name: io.k8s.api.core.v1.NamespaceStatus
+  map:
+    fields:
+    - name: phase
+      type:
+        scalar: string
+- name: io.k8s.api.core.v1.Node
+  map:
+    fields:
+    - name: apiVersion
+      type:
+        scalar: string
+    - name: kind
+      type:
+        scalar: string
+    - name: metadata
+      type:
+        namedType: io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta
+        elementRelationship: granular
+    - name: spec
+      type:
+        namedType: io.k8s.api.core.v1.NodeSpec
+        elementRelationship: granular
+    - name: status
+      type:
+        namedType: io.k8s.api.core.v1.NodeStatus
+        elementRelationship: granular
+- name: io.k8s.api.core.v1.NodeAddress
+  map:
+    fields:
+    - name: address
+      type:
+        scalar: string
+    - name: type
+      type:
+        scalar: string
+- name: io.k8s.api.core.v1.NodeAffinity
+  map:
+    fields:
+    - name: preferredDuringSchedulingIgnoredDuringExecution
+      type:
+        list:
+          elementType:
+            namedType: io.k8s.api.core.v1.PreferredSchedulingTerm
+          elementRelationship: atomic
+    - name: requiredDuringSchedulingIgnoredDuringExecution
+      type:
+        namedType: io.k8s.api.core.v1.NodeSelector
+        elementRelationship: granular
+- name: io.k8s.api.core.v1.NodeCondition
+  map:
+    fields:
+    - name: lastHeartbeatTime
+      type:
+        namedType: io.k8s.apimachinery.pkg.apis.meta.v1.Time
+    - name: lastTransitionTime
+      type:
+        namedType: io.k8s.apimachinery.pkg.apis.meta.v1.Time
+    - name: message
+      type:
+        scalar: string
+    - name: reason
+      type:
+        scalar: string
+    - name: status
+      type:
+        scalar: string
+    - name: type
+      type:
+        scalar: string
+- name: io.k8s.api.core.v1.NodeConfigSource
+  map:
+    fields:
+    - name: configMap
+      type:
+        namedType: io.k8s.api.core.v1.ConfigMapNodeConfigSource
+        elementRelationship: granular
+- name: io.k8s.api.core.v1.NodeConfigStatus
+  map:
+    fields:
+    - name: active
+      type:
+        namedType: io.k8s.api.core.v1.NodeConfigSource
+        elementRelationship: granular
+    - name: assigned
+      type:
+        namedType: io.k8s.api.core.v1.NodeConfigSource
+        elementRelationship: granular
+    - name: error
+      type:
+        scalar: string
+    - name: lastKnownGood
+      type:
+        namedType: io.k8s.api.core.v1.NodeConfigSource
+        elementRelationship: granular
+- name: io.k8s.api.core.v1.NodeDaemonEndpoints
+  map:
+    fields:
+    - name: kubeletEndpoint
+      type:
+        namedType: io.k8s.api.core.v1.DaemonEndpoint
+        elementRelationship: granular
+- name: io.k8s.api.core.v1.NodeList
+  map:
+    fields:
+    - name: apiVersion
+      type:
+        scalar: string
+    - name: items
+      type:
+        list:
+          elementType:
+            namedType: io.k8s.api.core.v1.Node
+          elementRelationship: atomic
+    - name: kind
+      type:
+        scalar: string
+    - name: metadata
+      type:
+        namedType: io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta
+        elementRelationship: granular
+- name: io.k8s.api.core.v1.NodeSelector
+  map:
+    fields:
+    - name: nodeSelectorTerms
+      type:
+        list:
+          elementType:
+            namedType: io.k8s.api.core.v1.NodeSelectorTerm
+          elementRelationship: atomic
+- name: io.k8s.api.core.v1.NodeSelectorRequirement
+  map:
+    fields:
+    - name: key
+      type:
+        scalar: string
+    - name: operator
+      type:
+        scalar: string
+    - name: values
+      type:
+        list:
+          elementType:
+            scalar: string
+          elementRelationship: atomic
+- name: io.k8s.api.core.v1.NodeSelectorTerm
+  map:
+    fields:
+    - name: matchExpressions
+      type:
+        list:
+          elementType:
+            namedType: io.k8s.api.core.v1.NodeSelectorRequirement
+          elementRelationship: atomic
+    - name: matchFields
+      type:
+        list:
+          elementType:
+            namedType: io.k8s.api.core.v1.NodeSelectorRequirement
+          elementRelationship: atomic
+- name: io.k8s.api.core.v1.NodeSpec
+  map:
+    fields:
+    - name: configSource
+      type:
+        namedType: io.k8s.api.core.v1.NodeConfigSource
+        elementRelationship: granular
+    - name: externalID
+      type:
+        scalar: string
+    - name: podCIDR
+      type:
+        scalar: string
+    - name: providerID
+      type:
+        scalar: string
+    - name: taints
+      type:
+        list:
+          elementType:
+            namedType: io.k8s.api.core.v1.Taint
+          elementRelationship: atomic
+    - name: unschedulable
+      type:
+        scalar: boolean
+- name: io.k8s.api.core.v1.NodeStatus
+  map:
+    fields:
+    - name: addresses
+      type:
+        list:
+          elementType:
+            namedType: io.k8s.api.core.v1.NodeAddress
+          elementRelationship: associative
+          keys:
+          - type
+    - name: allocatable
+      type:
+        map:
+          elementType:
+            namedType: io.k8s.apimachinery.pkg.api.resource.Quantity
+    - name: capacity
+      type:
+        map:
+          elementType:
+            namedType: io.k8s.apimachinery.pkg.api.resource.Quantity
+    - name: conditions
+      type:
+        list:
+          elementType:
+            namedType: io.k8s.api.core.v1.NodeCondition
+          elementRelationship: associative
+          keys:
+          - type
+    - name: config
+      type:
+        namedType: io.k8s.api.core.v1.NodeConfigStatus
+        elementRelationship: granular
+    - name: daemonEndpoints
+      type:
+        namedType: io.k8s.api.core.v1.NodeDaemonEndpoints
+        elementRelationship: granular
+    - name: images
+      type:
+        list:
+          elementType:
+            namedType: io.k8s.api.core.v1.ContainerImage
+          elementRelationship: atomic
+    - name: nodeInfo
+      type:
+        namedType: io.k8s.api.core.v1.NodeSystemInfo
+        elementRelationship: granular
+    - name: phase
+      type:
+        scalar: string
+    - name: volumesAttached
+      type:
+        list:
+          elementType:
+            namedType: io.k8s.api.core.v1.AttachedVolume
+          elementRelationship: atomic
+    - name: volumesInUse
+      type:
+        list:
+          elementType:
+            scalar: string
+          elementRelationship: atomic
+- name: io.k8s.api.core.v1.NodeSystemInfo
+  map:
+    fields:
+    - name: architecture
+      type:
+        scalar: string
+    - name: bootID
+      type:
+        scalar: string
+    - name: containerRuntimeVersion
+      type:
+        scalar: string
+    - name: kernelVersion
+      type:
+        scalar: string
+    - name: kubeProxyVersion
+      type:
+        scalar: string
+    - name: kubeletVersion
+      type:
+        scalar: string
+    - name: machineID
+      type:
+        scalar: string
+    - name: operatingSystem
+      type:
+        scalar: string
+    - name: osImage
+      type:
+        scalar: string
+    - name: systemUUID
+      type:
+        scalar: string
+- name: io.k8s.api.core.v1.ObjectFieldSelector
+  map:
+    fields:
+    - name: apiVersion
+      type:
+        scalar: string
+    - name: fieldPath
+      type:
+        scalar: string
+- name: io.k8s.api.core.v1.ObjectReference
+  map:
+    fields:
+    - name: apiVersion
+      type:
+        scalar: string
+    - name: fieldPath
+      type:
+        scalar: string
+    - name: kind
+      type:
+        scalar: string
+    - name: name
+      type:
+        scalar: string
+    - name: namespace
+      type:
+        scalar: string
+    - name: resourceVersion
+      type:
+        scalar: string
+    - name: uid
+      type:
+        scalar: string
+- name: io.k8s.api.core.v1.PersistentVolume
+  map:
+    fields:
+    - name: apiVersion
+      type:
+        scalar: string
+    - name: kind
+      type:
+        scalar: string
+    - name: metadata
+      type:
+        namedType: io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta
+        elementRelationship: granular
+    - name: spec
+      type:
+        namedType: io.k8s.api.core.v1.PersistentVolumeSpec
+        elementRelationship: granular
+    - name: status
+      type:
+        namedType: io.k8s.api.core.v1.PersistentVolumeStatus
+        elementRelationship: granular
+- name: io.k8s.api.core.v1.PersistentVolumeClaim
+  map:
+    fields:
+    - name: apiVersion
+      type:
+        scalar: string
+    - name: kind
+      type:
+        scalar: string
+    - name: metadata
+      type:
+        namedType: io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta
+        elementRelationship: granular
+    - name: spec
+      type:
+        namedType: io.k8s.api.core.v1.PersistentVolumeClaimSpec
+        elementRelationship: granular
+    - name: status
+      type:
+        namedType: io.k8s.api.core.v1.PersistentVolumeClaimStatus
+        elementRelationship: granular
+- name: io.k8s.api.core.v1.PersistentVolumeClaimCondition
+  map:
+    fields:
+    - name: lastProbeTime
+      type:
+        namedType: io.k8s.apimachinery.pkg.apis.meta.v1.Time
+    - name: lastTransitionTime
+      type:
+        namedType: io.k8s.apimachinery.pkg.apis.meta.v1.Time
+    - name: message
+      type:
+        scalar: string
+    - name: reason
+      type:
+        scalar: string
+    - name: status
+      type:
+        scalar: string
+    - name: type
+      type:
+        scalar: string
+- name: io.k8s.api.core.v1.PersistentVolumeClaimList
+  map:
+    fields:
+    - name: apiVersion
+      type:
+        scalar: string
+    - name: items
+      type:
+        list:
+          elementType:
+            namedType: io.k8s.api.core.v1.PersistentVolumeClaim
+          elementRelationship: atomic
+    - name: kind
+      type:
+        scalar: string
+    - name: metadata
+      type:
+        namedType: io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta
+        elementRelationship: granular
+- name: io.k8s.api.core.v1.PersistentVolumeClaimSpec
+  map:
+    fields:
+    - name: accessModes
+      type:
+        list:
+          elementType:
+            scalar: string
+          elementRelationship: atomic
+    - name: dataSource
+      type:
+        namedType: io.k8s.api.core.v1.TypedLocalObjectReference
+        elementRelationship: granular
+    - name: resources
+      type:
+        namedType: io.k8s.api.core.v1.ResourceRequirements
+        elementRelationship: granular
+    - name: selector
+      type:
+        namedType: io.k8s.apimachinery.pkg.apis.meta.v1.LabelSelector
+        elementRelationship: granular
+    - name: storageClassName
+      type:
+        scalar: string
+    - name: volumeMode
+      type:
+        scalar: string
+    - name: volumeName
+      type:
+        scalar: string
+- name: io.k8s.api.core.v1.PersistentVolumeClaimStatus
+  map:
+    fields:
+    - name: accessModes
+      type:
+        list:
+          elementType:
+            scalar: string
+          elementRelationship: atomic
+    - name: capacity
+      type:
+        map:
+          elementType:
+            namedType: io.k8s.apimachinery.pkg.api.resource.Quantity
+    - name: conditions
+      type:
+        list:
+          elementType:
+            namedType: io.k8s.api.core.v1.PersistentVolumeClaimCondition
+          elementRelationship: associative
+          keys:
+          - type
+    - name: phase
+      type:
+        scalar: string
+- name: io.k8s.api.core.v1.PersistentVolumeClaimVolumeSource
+  map:
+    fields:
+    - name: claimName
+      type:
+        scalar: string
+    - name: readOnly
+      type:
+        scalar: boolean
+- name: io.k8s.api.core.v1.PersistentVolumeList
+  map:
+    fields:
+    - name: apiVersion
+      type:
+        scalar: string
+    - name: items
+      type:
+        list:
+          elementType:
+            namedType: io.k8s.api.core.v1.PersistentVolume
+          elementRelationship: atomic
+    - name: kind
+      type:
+        scalar: string
+    - name: metadata
+      type:
+        namedType: io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta
+        elementRelationship: granular
+- name: io.k8s.api.core.v1.PersistentVolumeSpec
+  map:
+    fields:
+    - name: accessModes
+      type:
+        list:
+          elementType:
+            scalar: string
+          elementRelationship: atomic
+    - name: awsElasticBlockStore
+      type:
+        namedType: io.k8s.api.core.v1.AWSElasticBlockStoreVolumeSource
+        elementRelationship: granular
+    - name: azureDisk
+      type:
+        namedType: io.k8s.api.core.v1.AzureDiskVolumeSource
+        elementRelationship: granular
+    - name: azureFile
+      type:
+        namedType: io.k8s.api.core.v1.AzureFilePersistentVolumeSource
+        elementRelationship: granular
+    - name: capacity
+      type:
+        map:
+          elementType:
+            namedType: io.k8s.apimachinery.pkg.api.resource.Quantity
+    - name: cephfs
+      type:
+        namedType: io.k8s.api.core.v1.CephFSPersistentVolumeSource
+        elementRelationship: granular
+    - name: cinder
+      type:
+        namedType: io.k8s.api.core.v1.CinderPersistentVolumeSource
+        elementRelationship: granular
+    - name: claimRef
+      type:
+        namedType: io.k8s.api.core.v1.ObjectReference
+        elementRelationship: granular
+    - name: csi
+      type:
+        namedType: io.k8s.api.core.v1.CSIPersistentVolumeSource
+        elementRelationship: granular
+    - name: fc
+      type:
+        namedType: io.k8s.api.core.v1.FCVolumeSource
+        elementRelationship: granular
+    - name: flexVolume
+      type:
+        namedType: io.k8s.api.core.v1.FlexPersistentVolumeSource
+        elementRelationship: granular
+    - name: flocker
+      type:
+        namedType: io.k8s.api.core.v1.FlockerVolumeSource
+        elementRelationship: granular
+    - name: gcePersistentDisk
+      type:
+        namedType: io.k8s.api.core.v1.GCEPersistentDiskVolumeSource
+        elementRelationship: granular
+    - name: glusterfs
+      type:
+        namedType: io.k8s.api.core.v1.GlusterfsVolumeSource
+        elementRelationship: granular
+    - name: hostPath
+      type:
+        namedType: io.k8s.api.core.v1.HostPathVolumeSource
+        elementRelationship: granular
+    - name: iscsi
+      type:
+        namedType: io.k8s.api.core.v1.ISCSIPersistentVolumeSource
+        elementRelationship: granular
+    - name: local
+      type:
+        namedType: io.k8s.api.core.v1.LocalVolumeSource
+        elementRelationship: granular
+    - name: mountOptions
+      type:
+        list:
+          elementType:
+            scalar: string
+          elementRelationship: atomic
+    - name: nfs
+      type:
+        namedType: io.k8s.api.core.v1.NFSVolumeSource
+        elementRelationship: granular
+    - name: nodeAffinity
+      type:
+        namedType: io.k8s.api.core.v1.VolumeNodeAffinity
+        elementRelationship: granular
+    - name: persistentVolumeReclaimPolicy
+      type:
+        scalar: string
+    - name: photonPersistentDisk
+      type:
+        namedType: io.k8s.api.core.v1.PhotonPersistentDiskVolumeSource
+        elementRelationship: granular
+    - name: portworxVolume
+      type:
+        namedType: io.k8s.api.core.v1.PortworxVolumeSource
+        elementRelationship: granular
+    - name: quobyte
+      type:
+        namedType: io.k8s.api.core.v1.QuobyteVolumeSource
+        elementRelationship: granular
+    - name: rbd
+      type:
+        namedType: io.k8s.api.core.v1.RBDPersistentVolumeSource
+        elementRelationship: granular
+    - name: scaleIO
+      type:
+        namedType: io.k8s.api.core.v1.ScaleIOPersistentVolumeSource
+        elementRelationship: granular
+    - name: storageClassName
+      type:
+        scalar: string
+    - name: storageos
+      type:
+        namedType: io.k8s.api.core.v1.StorageOSPersistentVolumeSource
+        elementRelationship: granular
+    - name: volumeMode
+      type:
+        scalar: string
+    - name: vsphereVolume
+      type:
+        namedType: io.k8s.api.core.v1.VsphereVirtualDiskVolumeSource
+        elementRelationship: granular
+- name: io.k8s.api.core.v1.PersistentVolumeStatus
+  map:
+    fields:
+    - name: message
+      type:
+        scalar: string
+    - name: phase
+      type:
+        scalar: string
+    - name: reason
+      type:
+        scalar: string
+- name: io.k8s.api.core.v1.PhotonPersistentDiskVolumeSource
+  map:
+    fields:
+    - name: fsType
+      type:
+        scalar: string
+    - name: pdID
+      type:
+        scalar: string
+- name: io.k8s.api.core.v1.Pod
+  map:
+    fields:
+    - name: apiVersion
+      type:
+        scalar: string
+    - name: kind
+      type:
+        scalar: string
+    - name: metadata
+      type:
+        namedType: io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta
+        elementRelationship: granular
+    - name: spec
+      type:
+        namedType: io.k8s.api.core.v1.PodSpec
+        elementRelationship: granular
+    - name: status
+      type:
+        namedType: io.k8s.api.core.v1.PodStatus
+        elementRelationship: granular
+- name: io.k8s.api.core.v1.PodAffinity
+  map:
+    fields:
+    - name: preferredDuringSchedulingIgnoredDuringExecution
+      type:
+        list:
+          elementType:
+            namedType: io.k8s.api.core.v1.WeightedPodAffinityTerm
+          elementRelationship: atomic
+    - name: requiredDuringSchedulingIgnoredDuringExecution
+      type:
+        list:
+          elementType:
+            namedType: io.k8s.api.core.v1.PodAffinityTerm
+          elementRelationship: atomic
+- name: io.k8s.api.core.v1.PodAffinityTerm
+  map:
+    fields:
+    - name: labelSelector
+      type:
+        namedType: io.k8s.apimachinery.pkg.apis.meta.v1.LabelSelector
+        elementRelationship: granular
+    - name: namespaces
+      type:
+        list:
+          elementType:
+            scalar: string
+          elementRelationship: atomic
+    - name: topologyKey
+      type:
+        scalar: string
+- name: io.k8s.api.core.v1.PodAntiAffinity
+  map:
+    fields:
+    - name: preferredDuringSchedulingIgnoredDuringExecution
+      type:
+        list:
+          elementType:
+            namedType: io.k8s.api.core.v1.WeightedPodAffinityTerm
+          elementRelationship: atomic
+    - name: requiredDuringSchedulingIgnoredDuringExecution
+      type:
+        list:
+          elementType:
+            namedType: io.k8s.api.core.v1.PodAffinityTerm
+          elementRelationship: atomic
+- name: io.k8s.api.core.v1.PodCondition
+  map:
+    fields:
+    - name: lastProbeTime
+      type:
+        namedType: io.k8s.apimachinery.pkg.apis.meta.v1.Time
+    - name: lastTransitionTime
+      type:
+        namedType: io.k8s.apimachinery.pkg.apis.meta.v1.Time
+    - name: message
+      type:
+        scalar: string
+    - name: reason
+      type:
+        scalar: string
+    - name: status
+      type:
+        scalar: string
+    - name: type
+      type:
+        scalar: string
+- name: io.k8s.api.core.v1.PodDNSConfig
+  map:
+    fields:
+    - name: nameservers
+      type:
+        list:
+          elementType:
+            scalar: string
+          elementRelationship: atomic
+    - name: options
+      type:
+        list:
+          elementType:
+            namedType: io.k8s.api.core.v1.PodDNSConfigOption
+          elementRelationship: atomic
+    - name: searches
+      type:
+        list:
+          elementType:
+            scalar: string
+          elementRelationship: atomic
+- name: io.k8s.api.core.v1.PodDNSConfigOption
+  map:
+    fields:
+    - name: name
+      type:
+        scalar: string
+    - name: value
+      type:
+        scalar: string
+- name: io.k8s.api.core.v1.PodList
+  map:
+    fields:
+    - name: apiVersion
+      type:
+        scalar: string
+    - name: items
+      type:
+        list:
+          elementType:
+            namedType: io.k8s.api.core.v1.Pod
+          elementRelationship: atomic
+    - name: kind
+      type:
+        scalar: string
+    - name: metadata
+      type:
+        namedType: io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta
+        elementRelationship: granular
+- name: io.k8s.api.core.v1.PodReadinessGate
+  map:
+    fields:
+    - name: conditionType
+      type:
+        scalar: string
+- name: io.k8s.api.core.v1.PodSecurityContext
+  map:
+    fields:
+    - name: fsGroup
+      type:
+        scalar: numeric
+    - name: runAsGroup
+      type:
+        scalar: numeric
+    - name: runAsNonRoot
+      type:
+        scalar: boolean
+    - name: runAsUser
+      type:
+        scalar: numeric
+    - name: seLinuxOptions
+      type:
+        namedType: io.k8s.api.core.v1.SELinuxOptions
+        elementRelationship: granular
+    - name: supplementalGroups
+      type:
+        list:
+          elementType:
+            scalar: numeric
+          elementRelationship: atomic
+    - name: sysctls
+      type:
+        list:
+          elementType:
+            namedType: io.k8s.api.core.v1.Sysctl
+          elementRelationship: atomic
+- name: io.k8s.api.core.v1.PodSpec
+  map:
+    fields:
+    - name: activeDeadlineSeconds
+      type:
+        scalar: numeric
+    - name: affinity
+      type:
+        namedType: io.k8s.api.core.v1.Affinity
+        elementRelationship: granular
+    - name: automountServiceAccountToken
+      type:
+        scalar: boolean
+    - name: containers
+      type:
+        list:
+          elementType:
+            namedType: io.k8s.api.core.v1.Container
+          elementRelationship: associative
+          keys:
+          - name
+    - name: dnsConfig
+      type:
+        namedType: io.k8s.api.core.v1.PodDNSConfig
+        elementRelationship: granular
+    - name: dnsPolicy
+      type:
+        scalar: string
+    - name: enableServiceLinks
+      type:
+        scalar: boolean
+    - name: hostAliases
+      type:
+        list:
+          elementType:
+            namedType: io.k8s.api.core.v1.HostAlias
+          elementRelationship: associative
+          keys:
+          - ip
+    - name: hostIPC
+      type:
+        scalar: boolean
+    - name: hostNetwork
+      type:
+        scalar: boolean
+    - name: hostPID
+      type:
+        scalar: boolean
+    - name: hostname
+      type:
+        scalar: string
+    - name: imagePullSecrets
+      type:
+        list:
+          elementType:
+            namedType: io.k8s.api.core.v1.LocalObjectReference
+          elementRelationship: associative
+          keys:
+          - name
+    - name: initContainers
+      type:
+        list:
+          elementType:
+            namedType: io.k8s.api.core.v1.Container
+          elementRelationship: associative
+          keys:
+          - name
+    - name: nodeName
+      type:
+        scalar: string
+    - name: nodeSelector
+      type:
+        map:
+          elementType:
+            scalar: string
+    - name: priority
+      type:
+        scalar: numeric
+    - name: priorityClassName
+      type:
+        scalar: string
+    - name: readinessGates
+      type:
+        list:
+          elementType:
+            namedType: io.k8s.api.core.v1.PodReadinessGate
+          elementRelationship: atomic
+    - name: restartPolicy
+      type:
+        scalar: string
+    - name: runtimeClassName
+      type:
+        scalar: string
+    - name: schedulerName
+      type:
+        scalar: string
+    - name: securityContext
+      type:
+        namedType: io.k8s.api.core.v1.PodSecurityContext
+        elementRelationship: granular
+    - name: serviceAccount
+      type:
+        scalar: string
+    - name: serviceAccountName
+      type:
+        scalar: string
+    - name: shareProcessNamespace
+      type:
+        scalar: boolean
+    - name: subdomain
+      type:
+        scalar: string
+    - name: terminationGracePeriodSeconds
+      type:
+        scalar: numeric
+    - name: tolerations
+      type:
+        list:
+          elementType:
+            namedType: io.k8s.api.core.v1.Toleration
+          elementRelationship: atomic
+    - name: volumes
+      type:
+        list:
+          elementType:
+            namedType: io.k8s.api.core.v1.Volume
+          elementRelationship: associative
+          keys:
+          - name
+- name: io.k8s.api.core.v1.PodStatus
+  map:
+    fields:
+    - name: conditions
+      type:
+        list:
+          elementType:
+            namedType: io.k8s.api.core.v1.PodCondition
+          elementRelationship: associative
+          keys:
+          - type
+    - name: containerStatuses
+      type:
+        list:
+          elementType:
+            namedType: io.k8s.api.core.v1.ContainerStatus
+          elementRelationship: atomic
+    - name: hostIP
+      type:
+        scalar: string
+    - name: initContainerStatuses
+      type:
+        list:
+          elementType:
+            namedType: io.k8s.api.core.v1.ContainerStatus
+          elementRelationship: atomic
+    - name: message
+      type:
+        scalar: string
+    - name: nominatedNodeName
+      type:
+        scalar: string
+    - name: phase
+      type:
+        scalar: string
+    - name: podIP
+      type:
+        scalar: string
+    - name: qosClass
+      type:
+        scalar: string
+    - name: reason
+      type:
+        scalar: string
+    - name: startTime
+      type:
+        namedType: io.k8s.apimachinery.pkg.apis.meta.v1.Time
+- name: io.k8s.api.core.v1.PodTemplate
+  map:
+    fields:
+    - name: apiVersion
+      type:
+        scalar: string
+    - name: kind
+      type:
+        scalar: string
+    - name: metadata
+      type:
+        namedType: io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta
+        elementRelationship: granular
+    - name: template
+      type:
+        namedType: io.k8s.api.core.v1.PodTemplateSpec
+        elementRelationship: granular
+- name: io.k8s.api.core.v1.PodTemplateList
+  map:
+    fields:
+    - name: apiVersion
+      type:
+        scalar: string
+    - name: items
+      type:
+        list:
+          elementType:
+            namedType: io.k8s.api.core.v1.PodTemplate
+          elementRelationship: atomic
+    - name: kind
+      type:
+        scalar: string
+    - name: metadata
+      type:
+        namedType: io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta
+        elementRelationship: granular
+- name: io.k8s.api.core.v1.PodTemplateSpec
+  map:
+    fields:
+    - name: metadata
+      type:
+        namedType: io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta
+        elementRelationship: granular
+    - name: spec
+      type:
+        namedType: io.k8s.api.core.v1.PodSpec
+        elementRelationship: granular
+- name: io.k8s.api.core.v1.PortworxVolumeSource
+  map:
+    fields:
+    - name: fsType
+      type:
+        scalar: string
+    - name: readOnly
+      type:
+        scalar: boolean
+    - name: volumeID
+      type:
+        scalar: string
+- name: io.k8s.api.core.v1.PreferredSchedulingTerm
+  map:
+    fields:
+    - name: preference
+      type:
+        namedType: io.k8s.api.core.v1.NodeSelectorTerm
+        elementRelationship: granular
+    - name: weight
+      type:
+        scalar: numeric
+- name: io.k8s.api.core.v1.Probe
+  map:
+    fields:
+    - name: exec
+      type:
+        namedType: io.k8s.api.core.v1.ExecAction
+        elementRelationship: granular
+    - name: failureThreshold
+      type:
+        scalar: numeric
+    - name: httpGet
+      type:
+        namedType: io.k8s.api.core.v1.HTTPGetAction
+        elementRelationship: granular
+    - name: initialDelaySeconds
+      type:
+        scalar: numeric
+    - name: periodSeconds
+      type:
+        scalar: numeric
+    - name: successThreshold
+      type:
+        scalar: numeric
+    - name: tcpSocket
+      type:
+        namedType: io.k8s.api.core.v1.TCPSocketAction
+        elementRelationship: granular
+    - name: timeoutSeconds
+      type:
+        scalar: numeric
+- name: io.k8s.api.core.v1.ProjectedVolumeSource
+  map:
+    fields:
+    - name: defaultMode
+      type:
+        scalar: numeric
+    - name: sources
+      type:
+        list:
+          elementType:
+            namedType: io.k8s.api.core.v1.VolumeProjection
+          elementRelationship: atomic
+- name: io.k8s.api.core.v1.QuobyteVolumeSource
+  map:
+    fields:
+    - name: group
+      type:
+        scalar: string
+    - name: readOnly
+      type:
+        scalar: boolean
+    - name: registry
+      type:
+        scalar: string
+    - name: user
+      type:
+        scalar: string
+    - name: volume
+      type:
+        scalar: string
+- name: io.k8s.api.core.v1.RBDPersistentVolumeSource
+  map:
+    fields:
+    - name: fsType
+      type:
+        scalar: string
+    - name: image
+      type:
+        scalar: string
+    - name: keyring
+      type:
+        scalar: string
+    - name: monitors
+      type:
+        list:
+          elementType:
+            scalar: string
+          elementRelationship: atomic
+    - name: pool
+      type:
+        scalar: string
+    - name: readOnly
+      type:
+        scalar: boolean
+    - name: secretRef
+      type:
+        namedType: io.k8s.api.core.v1.SecretReference
+        elementRelationship: granular
+    - name: user
+      type:
+        scalar: string
+- name: io.k8s.api.core.v1.RBDVolumeSource
+  map:
+    fields:
+    - name: fsType
+      type:
+        scalar: string
+    - name: image
+      type:
+        scalar: string
+    - name: keyring
+      type:
+        scalar: string
+    - name: monitors
+      type:
+        list:
+          elementType:
+            scalar: string
+          elementRelationship: atomic
+    - name: pool
+      type:
+        scalar: string
+    - name: readOnly
+      type:
+        scalar: boolean
+    - name: secretRef
+      type:
+        namedType: io.k8s.api.core.v1.LocalObjectReference
+        elementRelationship: granular
+    - name: user
+      type:
+        scalar: string
+- name: io.k8s.api.core.v1.ReplicationController
+  map:
+    fields:
+    - name: apiVersion
+      type:
+        scalar: string
+    - name: kind
+      type:
+        scalar: string
+    - name: metadata
+      type:
+        namedType: io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta
+        elementRelationship: granular
+    - name: spec
+      type:
+        namedType: io.k8s.api.core.v1.ReplicationControllerSpec
+        elementRelationship: granular
+    - name: status
+      type:
+        namedType: io.k8s.api.core.v1.ReplicationControllerStatus
+        elementRelationship: granular
+- name: io.k8s.api.core.v1.ReplicationControllerCondition
+  map:
+    fields:
+    - name: lastTransitionTime
+      type:
+        namedType: io.k8s.apimachinery.pkg.apis.meta.v1.Time
+    - name: message
+      type:
+        scalar: string
+    - name: reason
+      type:
+        scalar: string
+    - name: status
+      type:
+        scalar: string
+    - name: type
+      type:
+        scalar: string
+- name: io.k8s.api.core.v1.ReplicationControllerList
+  map:
+    fields:
+    - name: apiVersion
+      type:
+        scalar: string
+    - name: items
+      type:
+        list:
+          elementType:
+            namedType: io.k8s.api.core.v1.ReplicationController
+          elementRelationship: atomic
+    - name: kind
+      type:
+        scalar: string
+    - name: metadata
+      type:
+        namedType: io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta
+        elementRelationship: granular
+- name: io.k8s.api.core.v1.ReplicationControllerSpec
+  map:
+    fields:
+    - name: minReadySeconds
+      type:
+        scalar: numeric
+    - name: replicas
+      type:
+        scalar: numeric
+    - name: selector
+      type:
+        map:
+          elementType:
+            scalar: string
+    - name: template
+      type:
+        namedType: io.k8s.api.core.v1.PodTemplateSpec
+        elementRelationship: granular
+- name: io.k8s.api.core.v1.ReplicationControllerStatus
+  map:
+    fields:
+    - name: availableReplicas
+      type:
+        scalar: numeric
+    - name: conditions
+      type:
+        list:
+          elementType:
+            namedType: io.k8s.api.core.v1.ReplicationControllerCondition
+          elementRelationship: associative
+          keys:
+          - type
+    - name: fullyLabeledReplicas
+      type:
+        scalar: numeric
+    - name: observedGeneration
+      type:
+        scalar: numeric
+    - name: readyReplicas
+      type:
+        scalar: numeric
+    - name: replicas
+      type:
+        scalar: numeric
+- name: io.k8s.api.core.v1.ResourceFieldSelector
+  map:
+    fields:
+    - name: containerName
+      type:
+        scalar: string
+    - name: divisor
+      type:
+        namedType: io.k8s.apimachinery.pkg.api.resource.Quantity
+        elementRelationship: granular
+    - name: resource
+      type:
+        scalar: string
+- name: io.k8s.api.core.v1.ResourceQuota
+  map:
+    fields:
+    - name: apiVersion
+      type:
+        scalar: string
+    - name: kind
+      type:
+        scalar: string
+    - name: metadata
+      type:
+        namedType: io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta
+        elementRelationship: granular
+    - name: spec
+      type:
+        namedType: io.k8s.api.core.v1.ResourceQuotaSpec
+        elementRelationship: granular
+    - name: status
+      type:
+        namedType: io.k8s.api.core.v1.ResourceQuotaStatus
+        elementRelationship: granular
+- name: io.k8s.api.core.v1.ResourceQuotaList
+  map:
+    fields:
+    - name: apiVersion
+      type:
+        scalar: string
+    - name: items
+      type:
+        list:
+          elementType:
+            namedType: io.k8s.api.core.v1.ResourceQuota
+          elementRelationship: atomic
+    - name: kind
+      type:
+        scalar: string
+    - name: metadata
+      type:
+        namedType: io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta
+        elementRelationship: granular
+- name: io.k8s.api.core.v1.ResourceQuotaSpec
+  map:
+    fields:
+    - name: hard
+      type:
+        map:
+          elementType:
+            namedType: io.k8s.apimachinery.pkg.api.resource.Quantity
+    - name: scopeSelector
+      type:
+        namedType: io.k8s.api.core.v1.ScopeSelector
+        elementRelationship: granular
+    - name: scopes
+      type:
+        list:
+          elementType:
+            scalar: string
+          elementRelationship: atomic
+- name: io.k8s.api.core.v1.ResourceQuotaStatus
+  map:
+    fields:
+    - name: hard
+      type:
+        map:
+          elementType:
+            namedType: io.k8s.apimachinery.pkg.api.resource.Quantity
+    - name: used
+      type:
+        map:
+          elementType:
+            namedType: io.k8s.apimachinery.pkg.api.resource.Quantity
+- name: io.k8s.api.core.v1.ResourceRequirements
+  map:
+    fields:
+    - name: limits
+      type:
+        map:
+          elementType:
+            namedType: io.k8s.apimachinery.pkg.api.resource.Quantity
+    - name: requests
+      type:
+        map:
+          elementType:
+            namedType: io.k8s.apimachinery.pkg.api.resource.Quantity
+- name: io.k8s.api.core.v1.SELinuxOptions
+  map:
+    fields:
+    - name: level
+      type:
+        scalar: string
+    - name: role
+      type:
+        scalar: string
+    - name: type
+      type:
+        scalar: string
+    - name: user
+      type:
+        scalar: string
+- name: io.k8s.api.core.v1.ScaleIOPersistentVolumeSource
+  map:
+    fields:
+    - name: fsType
+      type:
+        scalar: string
+    - name: gateway
+      type:
+        scalar: string
+    - name: protectionDomain
+      type:
+        scalar: string
+    - name: readOnly
+      type:
+        scalar: boolean
+    - name: secretRef
+      type:
+        namedType: io.k8s.api.core.v1.SecretReference
+        elementRelationship: granular
+    - name: sslEnabled
+      type:
+        scalar: boolean
+    - name: storageMode
+      type:
+        scalar: string
+    - name: storagePool
+      type:
+        scalar: string
+    - name: system
+      type:
+        scalar: string
+    - name: volumeName
+      type:
+        scalar: string
+- name: io.k8s.api.core.v1.ScaleIOVolumeSource
+  map:
+    fields:
+    - name: fsType
+      type:
+        scalar: string
+    - name: gateway
+      type:
+        scalar: string
+    - name: protectionDomain
+      type:
+        scalar: string
+    - name: readOnly
+      type:
+        scalar: boolean
+    - name: secretRef
+      type:
+        namedType: io.k8s.api.core.v1.LocalObjectReference
+        elementRelationship: granular
+    - name: sslEnabled
+      type:
+        scalar: boolean
+    - name: storageMode
+      type:
+        scalar: string
+    - name: storagePool
+      type:
+        scalar: string
+    - name: system
+      type:
+        scalar: string
+    - name: volumeName
+      type:
+        scalar: string
+- name: io.k8s.api.core.v1.ScopeSelector
+  map:
+    fields:
+    - name: matchExpressions
+      type:
+        list:
+          elementType:
+            namedType: io.k8s.api.core.v1.ScopedResourceSelectorRequirement
+          elementRelationship: atomic
+- name: io.k8s.api.core.v1.ScopedResourceSelectorRequirement
+  map:
+    fields:
+    - name: operator
+      type:
+        scalar: string
+    - name: scopeName
+      type:
+        scalar: string
+    - name: values
+      type:
+        list:
+          elementType:
+            scalar: string
+          elementRelationship: atomic
+- name: io.k8s.api.core.v1.Secret
+  map:
+    fields:
+    - name: apiVersion
+      type:
+        scalar: string
+    - name: data
+      type:
+        map:
+          elementType:
+            scalar: string
+    - name: kind
+      type:
+        scalar: string
+    - name: metadata
+      type:
+        namedType: io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta
+        elementRelationship: granular
+    - name: stringData
+      type:
+        map:
+          elementType:
+            scalar: string
+    - name: type
+      type:
+        scalar: string
+- name: io.k8s.api.core.v1.SecretEnvSource
+  map:
+    fields:
+    - name: name
+      type:
+        scalar: string
+    - name: optional
+      type:
+        scalar: boolean
+- name: io.k8s.api.core.v1.SecretKeySelector
+  map:
+    fields:
+    - name: key
+      type:
+        scalar: string
+    - name: name
+      type:
+        scalar: string
+    - name: optional
+      type:
+        scalar: boolean
+- name: io.k8s.api.core.v1.SecretList
+  map:
+    fields:
+    - name: apiVersion
+      type:
+        scalar: string
+    - name: items
+      type:
+        list:
+          elementType:
+            namedType: io.k8s.api.core.v1.Secret
+          elementRelationship: atomic
+    - name: kind
+      type:
+        scalar: string
+    - name: metadata
+      type:
+        namedType: io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta
+        elementRelationship: granular
+- name: io.k8s.api.core.v1.SecretProjection
+  map:
+    fields:
+    - name: items
+      type:
+        list:
+          elementType:
+            namedType: io.k8s.api.core.v1.KeyToPath
+          elementRelationship: atomic
+    - name: name
+      type:
+        scalar: string
+    - name: optional
+      type:
+        scalar: boolean
+- name: io.k8s.api.core.v1.SecretReference
+  map:
+    fields:
+    - name: name
+      type:
+        scalar: string
+    - name: namespace
+      type:
+        scalar: string
+- name: io.k8s.api.core.v1.SecretVolumeSource
+  map:
+    fields:
+    - name: defaultMode
+      type:
+        scalar: numeric
+    - name: items
+      type:
+        list:
+          elementType:
+            namedType: io.k8s.api.core.v1.KeyToPath
+          elementRelationship: atomic
+    - name: optional
+      type:
+        scalar: boolean
+    - name: secretName
+      type:
+        scalar: string
+- name: io.k8s.api.core.v1.SecurityContext
+  map:
+    fields:
+    - name: allowPrivilegeEscalation
+      type:
+        scalar: boolean
+    - name: capabilities
+      type:
+        namedType: io.k8s.api.core.v1.Capabilities
+        elementRelationship: granular
+    - name: privileged
+      type:
+        scalar: boolean
+    - name: procMount
+      type:
+        scalar: string
+    - name: readOnlyRootFilesystem
+      type:
+        scalar: boolean
+    - name: runAsGroup
+      type:
+        scalar: numeric
+    - name: runAsNonRoot
+      type:
+        scalar: boolean
+    - name: runAsUser
+      type:
+        scalar: numeric
+    - name: seLinuxOptions
+      type:
+        namedType: io.k8s.api.core.v1.SELinuxOptions
+        elementRelationship: granular
+- name: io.k8s.api.core.v1.Service
+  map:
+    fields:
+    - name: apiVersion
+      type:
+        scalar: string
+    - name: kind
+      type:
+        scalar: string
+    - name: metadata
+      type:
+        namedType: io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta
+        elementRelationship: granular
+    - name: spec
+      type:
+        namedType: io.k8s.api.core.v1.ServiceSpec
+        elementRelationship: granular
+    - name: status
+      type:
+        namedType: io.k8s.api.core.v1.ServiceStatus
+        elementRelationship: granular
+- name: io.k8s.api.core.v1.ServiceAccount
+  map:
+    fields:
+    - name: apiVersion
+      type:
+        scalar: string
+    - name: automountServiceAccountToken
+      type:
+        scalar: boolean
+    - name: imagePullSecrets
+      type:
+        list:
+          elementType:
+            namedType: io.k8s.api.core.v1.LocalObjectReference
+          elementRelationship: atomic
+    - name: kind
+      type:
+        scalar: string
+    - name: metadata
+      type:
+        namedType: io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta
+        elementRelationship: granular
+    - name: secrets
+      type:
+        list:
+          elementType:
+            namedType: io.k8s.api.core.v1.ObjectReference
+          elementRelationship: associative
+          keys:
+          - name
+- name: io.k8s.api.core.v1.ServiceAccountList
+  map:
+    fields:
+    - name: apiVersion
+      type:
+        scalar: string
+    - name: items
+      type:
+        list:
+          elementType:
+            namedType: io.k8s.api.core.v1.ServiceAccount
+          elementRelationship: atomic
+    - name: kind
+      type:
+        scalar: string
+    - name: metadata
+      type:
+        namedType: io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta
+        elementRelationship: granular
+- name: io.k8s.api.core.v1.ServiceAccountTokenProjection
+  map:
+    fields:
+    - name: audience
+      type:
+        scalar: string
+    - name: expirationSeconds
+      type:
+        scalar: numeric
+    - name: path
+      type:
+        scalar: string
+- name: io.k8s.api.core.v1.ServiceList
+  map:
+    fields:
+    - name: apiVersion
+      type:
+        scalar: string
+    - name: items
+      type:
+        list:
+          elementType:
+            namedType: io.k8s.api.core.v1.Service
+          elementRelationship: atomic
+    - name: kind
+      type:
+        scalar: string
+    - name: metadata
+      type:
+        namedType: io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta
+        elementRelationship: granular
+- name: io.k8s.api.core.v1.ServicePort
+  map:
+    fields:
+    - name: name
+      type:
+        scalar: string
+    - name: nodePort
+      type:
+        scalar: numeric
+    - name: port
+      type:
+        scalar: numeric
+    - name: protocol
+      type:
+        scalar: string
+    - name: targetPort
+      type:
+        namedType: io.k8s.apimachinery.pkg.util.intstr.IntOrString
+        elementRelationship: granular
+- name: io.k8s.api.core.v1.ServiceSpec
+  map:
+    fields:
+    - name: clusterIP
+      type:
+        scalar: string
+    - name: externalIPs
+      type:
+        list:
+          elementType:
+            scalar: string
+          elementRelationship: atomic
+    - name: externalName
+      type:
+        scalar: string
+    - name: externalTrafficPolicy
+      type:
+        scalar: string
+    - name: healthCheckNodePort
+      type:
+        scalar: numeric
+    - name: loadBalancerIP
+      type:
+        scalar: string
+    - name: loadBalancerSourceRanges
+      type:
+        list:
+          elementType:
+            scalar: string
+          elementRelationship: atomic
+    - name: ports
+      type:
+        list:
+          elementType:
+            namedType: io.k8s.api.core.v1.ServicePort
+          elementRelationship: associative
+          keys:
+          - port
+    - name: publishNotReadyAddresses
+      type:
+        scalar: boolean
+    - name: selector
+      type:
+        map:
+          elementType:
+            scalar: string
+    - name: sessionAffinity
+      type:
+        scalar: string
+    - name: sessionAffinityConfig
+      type:
+        namedType: io.k8s.api.core.v1.SessionAffinityConfig
+        elementRelationship: granular
+    - name: type
+      type:
+        scalar: string
+- name: io.k8s.api.core.v1.ServiceStatus
+  map:
+    fields:
+    - name: loadBalancer
+      type:
+        namedType: io.k8s.api.core.v1.LoadBalancerStatus
+        elementRelationship: granular
+- name: io.k8s.api.core.v1.SessionAffinityConfig
+  map:
+    fields:
+    - name: clientIP
+      type:
+        namedType: io.k8s.api.core.v1.ClientIPConfig
+        elementRelationship: granular
+- name: io.k8s.api.core.v1.StorageOSPersistentVolumeSource
+  map:
+    fields:
+    - name: fsType
+      type:
+        scalar: string
+    - name: readOnly
+      type:
+        scalar: boolean
+    - name: secretRef
+      type:
+        namedType: io.k8s.api.core.v1.ObjectReference
+        elementRelationship: granular
+    - name: volumeName
+      type:
+        scalar: string
+    - name: volumeNamespace
+      type:
+        scalar: string
+- name: io.k8s.api.core.v1.StorageOSVolumeSource
+  map:
+    fields:
+    - name: fsType
+      type:
+        scalar: string
+    - name: readOnly
+      type:
+        scalar: boolean
+    - name: secretRef
+      type:
+        namedType: io.k8s.api.core.v1.LocalObjectReference
+        elementRelationship: granular
+    - name: volumeName
+      type:
+        scalar: string
+    - name: volumeNamespace
+      type:
+        scalar: string
+- name: io.k8s.api.core.v1.Sysctl
+  map:
+    fields:
+    - name: name
+      type:
+        scalar: string
+    - name: value
+      type:
+        scalar: string
+- name: io.k8s.api.core.v1.TCPSocketAction
+  map:
+    fields:
+    - name: host
+      type:
+        scalar: string
+    - name: port
+      type:
+        namedType: io.k8s.apimachinery.pkg.util.intstr.IntOrString
+        elementRelationship: granular
+- name: io.k8s.api.core.v1.Taint
+  map:
+    fields:
+    - name: effect
+      type:
+        scalar: string
+    - name: key
+      type:
+        scalar: string
+    - name: timeAdded
+      type:
+        namedType: io.k8s.apimachinery.pkg.apis.meta.v1.Time
+    - name: value
+      type:
+        scalar: string
+- name: io.k8s.api.core.v1.Toleration
+  map:
+    fields:
+    - name: effect
+      type:
+        scalar: string
+    - name: key
+      type:
+        scalar: string
+    - name: operator
+      type:
+        scalar: string
+    - name: tolerationSeconds
+      type:
+        scalar: numeric
+    - name: value
+      type:
+        scalar: string
+- name: io.k8s.api.core.v1.TopologySelectorLabelRequirement
+  map:
+    fields:
+    - name: key
+      type:
+        scalar: string
+    - name: values
+      type:
+        list:
+          elementType:
+            scalar: string
+          elementRelationship: atomic
+- name: io.k8s.api.core.v1.TopologySelectorTerm
+  map:
+    fields:
+    - name: matchLabelExpressions
+      type:
+        list:
+          elementType:
+            namedType: io.k8s.api.core.v1.TopologySelectorLabelRequirement
+          elementRelationship: atomic
+- name: io.k8s.api.core.v1.TypedLocalObjectReference
+  map:
+    fields:
+    - name: apiGroup
+      type:
+        scalar: string
+    - name: kind
+      type:
+        scalar: string
+    - name: name
+      type:
+        scalar: string
+- name: io.k8s.api.core.v1.Volume
+  map:
+    fields:
+    - name: awsElasticBlockStore
+      type:
+        namedType: io.k8s.api.core.v1.AWSElasticBlockStoreVolumeSource
+        elementRelationship: granular
+    - name: azureDisk
+      type:
+        namedType: io.k8s.api.core.v1.AzureDiskVolumeSource
+        elementRelationship: granular
+    - name: azureFile
+      type:
+        namedType: io.k8s.api.core.v1.AzureFileVolumeSource
+        elementRelationship: granular
+    - name: cephfs
+      type:
+        namedType: io.k8s.api.core.v1.CephFSVolumeSource
+        elementRelationship: granular
+    - name: cinder
+      type:
+        namedType: io.k8s.api.core.v1.CinderVolumeSource
+        elementRelationship: granular
+    - name: configMap
+      type:
+        namedType: io.k8s.api.core.v1.ConfigMapVolumeSource
+        elementRelationship: granular
+    - name: downwardAPI
+      type:
+        namedType: io.k8s.api.core.v1.DownwardAPIVolumeSource
+        elementRelationship: granular
+    - name: emptyDir
+      type:
+        namedType: io.k8s.api.core.v1.EmptyDirVolumeSource
+        elementRelationship: granular
+    - name: fc
+      type:
+        namedType: io.k8s.api.core.v1.FCVolumeSource
+        elementRelationship: granular
+    - name: flexVolume
+      type:
+        namedType: io.k8s.api.core.v1.FlexVolumeSource
+        elementRelationship: granular
+    - name: flocker
+      type:
+        namedType: io.k8s.api.core.v1.FlockerVolumeSource
+        elementRelationship: granular
+    - name: gcePersistentDisk
+      type:
+        namedType: io.k8s.api.core.v1.GCEPersistentDiskVolumeSource
+        elementRelationship: granular
+    - name: gitRepo
+      type:
+        namedType: io.k8s.api.core.v1.GitRepoVolumeSource
+        elementRelationship: granular
+    - name: glusterfs
+      type:
+        namedType: io.k8s.api.core.v1.GlusterfsVolumeSource
+        elementRelationship: granular
+    - name: hostPath
+      type:
+        namedType: io.k8s.api.core.v1.HostPathVolumeSource
+        elementRelationship: granular
+    - name: iscsi
+      type:
+        namedType: io.k8s.api.core.v1.ISCSIVolumeSource
+        elementRelationship: granular
+    - name: name
+      type:
+        scalar: string
+    - name: nfs
+      type:
+        namedType: io.k8s.api.core.v1.NFSVolumeSource
+        elementRelationship: granular
+    - name: persistentVolumeClaim
+      type:
+        namedType: io.k8s.api.core.v1.PersistentVolumeClaimVolumeSource
+        elementRelationship: granular
+    - name: photonPersistentDisk
+      type:
+        namedType: io.k8s.api.core.v1.PhotonPersistentDiskVolumeSource
+        elementRelationship: granular
+    - name: portworxVolume
+      type:
+        namedType: io.k8s.api.core.v1.PortworxVolumeSource
+        elementRelationship: granular
+    - name: projected
+      type:
+        namedType: io.k8s.api.core.v1.ProjectedVolumeSource
+        elementRelationship: granular
+    - name: quobyte
+      type:
+        namedType: io.k8s.api.core.v1.QuobyteVolumeSource
+        elementRelationship: granular
+    - name: rbd
+      type:
+        namedType: io.k8s.api.core.v1.RBDVolumeSource
+        elementRelationship: granular
+    - name: scaleIO
+      type:
+        namedType: io.k8s.api.core.v1.ScaleIOVolumeSource
+        elementRelationship: granular
+    - name: secret
+      type:
+        namedType: io.k8s.api.core.v1.SecretVolumeSource
+        elementRelationship: granular
+    - name: storageos
+      type:
+        namedType: io.k8s.api.core.v1.StorageOSVolumeSource
+        elementRelationship: granular
+    - name: vsphereVolume
+      type:
+        namedType: io.k8s.api.core.v1.VsphereVirtualDiskVolumeSource
+        elementRelationship: granular
+    unions:
+    - fields:
+      - fieldName: awsElasticBlockStore
+        discriminatorValue: AWSElasticBlockStore
+      - fieldName: azureDisk
+        discriminatorValue: AzureDisk
+      - fieldName: azureFile
+        discriminatorValue: AzureFile
+      - fieldName: cephfs
+        discriminatorValue: CephFS
+      - fieldName: cinder
+        discriminatorValue: Cinder
+      - fieldName: configMap
+        discriminatorValue: ConfigMap
+      - fieldName: downwardAPI
+        discriminatorValue: DownwardAPI
+      - fieldName: emptyDir
+        discriminatorValue: EmptyDir
+      - fieldName: fc
+        discriminatorValue: FC
+      - fieldName: flexVolume
+        discriminatorValue: FlexVolume
+      - fieldName: flocker
+        discriminatorValue: Flocker
+      - fieldName: gcePersistentDisk
+        discriminatorValue: GCEPersistentDisk
+      - fieldName: gitRepo
+        discriminatorValue: GitRepo
+      - fieldName: glusterfs
+        discriminatorValue: Glusterfs
+      - fieldName: hostPath
+        discriminatorValue: HostPath
+      - fieldName: iscsi
+        discriminatorValue: ISCSI
+      - fieldName: nfs
+        discriminatorValue: NFS
+      - fieldName: persistentVolumeClaim
+        discriminatorValue: PersistentVolumeClaim
+      - fieldName: photonPersistentDisk
+        discriminatorValue: PhotonPersistentDisk
+      - fieldName: portworxVolume
+        discriminatorValue: PortworxVolume
+      - fieldName: projected
+        discriminatorValue: Projected
+      - fieldName: quobyte
+        discriminatorValue: Quobyte
+      - fieldName: rbd
+        discriminatorValue: RBD
+      - fieldName: scaleIO
+        discriminatorValue: ScaleIO
+      - fieldName: secret
+        discriminatorValue: Secret
+      - fieldName: storageos
+        discriminatorValue: StorageOS
+      - fieldName: vsphereVolume
+        discriminatorValue: VsphereVolume
+- name: io.k8s.api.core.v1.VolumeDevice
+  map:
+    fields:
+    - name: devicePath
+      type:
+        scalar: string
+    - name: name
+      type:
+        scalar: string
+- name: io.k8s.api.core.v1.VolumeMount
+  map:
+    fields:
+    - name: mountPath
+      type:
+        scalar: string
+    - name: mountPropagation
+      type:
+        scalar: string
+    - name: name
+      type:
+        scalar: string
+    - name: readOnly
+      type:
+        scalar: boolean
+    - name: subPath
+      type:
+        scalar: string
+- name: io.k8s.api.core.v1.VolumeNodeAffinity
+  map:
+    fields:
+    - name: required
+      type:
+        namedType: io.k8s.api.core.v1.NodeSelector
+        elementRelationship: granular
+- name: io.k8s.api.core.v1.VolumeProjection
+  map:
+    fields:
+    - name: configMap
+      type:
+        namedType: io.k8s.api.core.v1.ConfigMapProjection
+        elementRelationship: granular
+    - name: downwardAPI
+      type:
+        namedType: io.k8s.api.core.v1.DownwardAPIProjection
+        elementRelationship: granular
+    - name: secret
+      type:
+        namedType: io.k8s.api.core.v1.SecretProjection
+        elementRelationship: granular
+    - name: serviceAccountToken
+      type:
+        namedType: io.k8s.api.core.v1.ServiceAccountTokenProjection
+        elementRelationship: granular
+- name: io.k8s.api.core.v1.VsphereVirtualDiskVolumeSource
+  map:
+    fields:
+    - name: fsType
+      type:
+        scalar: string
+    - name: storagePolicyID
+      type:
+        scalar: string
+    - name: storagePolicyName
+      type:
+        scalar: string
+    - name: volumePath
+      type:
+        scalar: string
+- name: io.k8s.api.core.v1.WeightedPodAffinityTerm
+  map:
+    fields:
+    - name: podAffinityTerm
+      type:
+        namedType: io.k8s.api.core.v1.PodAffinityTerm
+        elementRelationship: granular
+    - name: weight
+      type:
+        scalar: numeric
+- name: io.k8s.api.events.v1beta1.Event
+  map:
+    fields:
+    - name: action
+      type:
+        scalar: string
+    - name: apiVersion
+      type:
+        scalar: string
+    - name: deprecatedCount
+      type:
+        scalar: numeric
+    - name: deprecatedFirstTimestamp
+      type:
+        namedType: io.k8s.apimachinery.pkg.apis.meta.v1.Time
+    - name: deprecatedLastTimestamp
+      type:
+        namedType: io.k8s.apimachinery.pkg.apis.meta.v1.Time
+    - name: deprecatedSource
+      type:
+        namedType: io.k8s.api.core.v1.EventSource
+        elementRelationship: granular
+    - name: eventTime
+      type:
+        namedType: io.k8s.apimachinery.pkg.apis.meta.v1.MicroTime
+        elementRelationship: granular
+    - name: kind
+      type:
+        scalar: string
+    - name: metadata
+      type:
+        namedType: io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta
+        elementRelationship: granular
+    - name: note
+      type:
+        scalar: string
+    - name: reason
+      type:
+        scalar: string
+    - name: regarding
+      type:
+        namedType: io.k8s.api.core.v1.ObjectReference
+        elementRelationship: granular
+    - name: related
+      type:
+        namedType: io.k8s.api.core.v1.ObjectReference
+        elementRelationship: granular
+    - name: reportingController
+      type:
+        scalar: string
+    - name: reportingInstance
+      type:
+        scalar: string
+    - name: series
+      type:
+        namedType: io.k8s.api.events.v1beta1.EventSeries
+        elementRelationship: granular
+    - name: type
+      type:
+        scalar: string
+- name: io.k8s.api.events.v1beta1.EventList
+  map:
+    fields:
+    - name: apiVersion
+      type:
+        scalar: string
+    - name: items
+      type:
+        list:
+          elementType:
+            namedType: io.k8s.api.events.v1beta1.Event
+          elementRelationship: atomic
+    - name: kind
+      type:
+        scalar: string
+    - name: metadata
+      type:
+        namedType: io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta
+        elementRelationship: granular
+- name: io.k8s.api.events.v1beta1.EventSeries
+  map:
+    fields:
+    - name: count
+      type:
+        scalar: numeric
+    - name: lastObservedTime
+      type:
+        namedType: io.k8s.apimachinery.pkg.apis.meta.v1.MicroTime
+        elementRelationship: granular
+    - name: state
+      type:
+        scalar: string
+- name: io.k8s.api.extensions.v1beta1.AllowedFlexVolume
+  map:
+    fields:
+    - name: driver
+      type:
+        scalar: string
+- name: io.k8s.api.extensions.v1beta1.AllowedHostPath
+  map:
+    fields:
+    - name: pathPrefix
+      type:
+        scalar: string
+    - name: readOnly
+      type:
+        scalar: boolean
+- name: io.k8s.api.extensions.v1beta1.DaemonSet
+  map:
+    fields:
+    - name: apiVersion
+      type:
+        scalar: string
+    - name: kind
+      type:
+        scalar: string
+    - name: metadata
+      type:
+        namedType: io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta
+        elementRelationship: granular
+    - name: spec
+      type:
+        namedType: io.k8s.api.extensions.v1beta1.DaemonSetSpec
+        elementRelationship: granular
+    - name: status
+      type:
+        namedType: io.k8s.api.extensions.v1beta1.DaemonSetStatus
+        elementRelationship: granular
+- name: io.k8s.api.extensions.v1beta1.DaemonSetCondition
+  map:
+    fields:
+    - name: lastTransitionTime
+      type:
+        namedType: io.k8s.apimachinery.pkg.apis.meta.v1.Time
+    - name: message
+      type:
+        scalar: string
+    - name: reason
+      type:
+        scalar: string
+    - name: status
+      type:
+        scalar: string
+    - name: type
+      type:
+        scalar: string
+- name: io.k8s.api.extensions.v1beta1.DaemonSetList
+  map:
+    fields:
+    - name: apiVersion
+      type:
+        scalar: string
+    - name: items
+      type:
+        list:
+          elementType:
+            namedType: io.k8s.api.extensions.v1beta1.DaemonSet
+          elementRelationship: atomic
+    - name: kind
+      type:
+        scalar: string
+    - name: metadata
+      type:
+        namedType: io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta
+        elementRelationship: granular
+- name: io.k8s.api.extensions.v1beta1.DaemonSetSpec
+  map:
+    fields:
+    - name: minReadySeconds
+      type:
+        scalar: numeric
+    - name: revisionHistoryLimit
+      type:
+        scalar: numeric
+    - name: selector
+      type:
+        namedType: io.k8s.apimachinery.pkg.apis.meta.v1.LabelSelector
+        elementRelationship: granular
+    - name: template
+      type:
+        namedType: io.k8s.api.core.v1.PodTemplateSpec
+        elementRelationship: granular
+    - name: templateGeneration
+      type:
+        scalar: numeric
+    - name: updateStrategy
+      type:
+        namedType: io.k8s.api.extensions.v1beta1.DaemonSetUpdateStrategy
+        elementRelationship: granular
+- name: io.k8s.api.extensions.v1beta1.DaemonSetStatus
+  map:
+    fields:
+    - name: collisionCount
+      type:
+        scalar: numeric
+    - name: conditions
+      type:
+        list:
+          elementType:
+            namedType: io.k8s.api.extensions.v1beta1.DaemonSetCondition
+          elementRelationship: associative
+          keys:
+          - type
+    - name: currentNumberScheduled
+      type:
+        scalar: numeric
+    - name: desiredNumberScheduled
+      type:
+        scalar: numeric
+    - name: numberAvailable
+      type:
+        scalar: numeric
+    - name: numberMisscheduled
+      type:
+        scalar: numeric
+    - name: numberReady
+      type:
+        scalar: numeric
+    - name: numberUnavailable
+      type:
+        scalar: numeric
+    - name: observedGeneration
+      type:
+        scalar: numeric
+    - name: updatedNumberScheduled
+      type:
+        scalar: numeric
+- name: io.k8s.api.extensions.v1beta1.DaemonSetUpdateStrategy
+  map:
+    fields:
+    - name: rollingUpdate
+      type:
+        namedType: io.k8s.api.extensions.v1beta1.RollingUpdateDaemonSet
+        elementRelationship: granular
+    - name: type
+      type:
+        scalar: string
+- name: io.k8s.api.extensions.v1beta1.Deployment
+  map:
+    fields:
+    - name: apiVersion
+      type:
+        scalar: string
+    - name: kind
+      type:
+        scalar: string
+    - name: metadata
+      type:
+        namedType: io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta
+        elementRelationship: granular
+    - name: spec
+      type:
+        namedType: io.k8s.api.extensions.v1beta1.DeploymentSpec
+        elementRelationship: granular
+    - name: status
+      type:
+        namedType: io.k8s.api.extensions.v1beta1.DeploymentStatus
+        elementRelationship: granular
+- name: io.k8s.api.extensions.v1beta1.DeploymentCondition
+  map:
+    fields:
+    - name: lastTransitionTime
+      type:
+        namedType: io.k8s.apimachinery.pkg.apis.meta.v1.Time
+    - name: lastUpdateTime
+      type:
+        namedType: io.k8s.apimachinery.pkg.apis.meta.v1.Time
+    - name: message
+      type:
+        scalar: string
+    - name: reason
+      type:
+        scalar: string
+    - name: status
+      type:
+        scalar: string
+    - name: type
+      type:
+        scalar: string
+- name: io.k8s.api.extensions.v1beta1.DeploymentList
+  map:
+    fields:
+    - name: apiVersion
+      type:
+        scalar: string
+    - name: items
+      type:
+        list:
+          elementType:
+            namedType: io.k8s.api.extensions.v1beta1.Deployment
+          elementRelationship: atomic
+    - name: kind
+      type:
+        scalar: string
+    - name: metadata
+      type:
+        namedType: io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta
+        elementRelationship: granular
+- name: io.k8s.api.extensions.v1beta1.DeploymentRollback
+  map:
+    fields:
+    - name: apiVersion
+      type:
+        scalar: string
+    - name: kind
+      type:
+        scalar: string
+    - name: name
+      type:
+        scalar: string
+    - name: rollbackTo
+      type:
+        namedType: io.k8s.api.extensions.v1beta1.RollbackConfig
+        elementRelationship: granular
+    - name: updatedAnnotations
+      type:
+        map:
+          elementType:
+            scalar: string
+- name: io.k8s.api.extensions.v1beta1.DeploymentSpec
+  map:
+    fields:
+    - name: minReadySeconds
+      type:
+        scalar: numeric
+    - name: paused
+      type:
+        scalar: boolean
+    - name: progressDeadlineSeconds
+      type:
+        scalar: numeric
+    - name: replicas
+      type:
+        scalar: numeric
+    - name: revisionHistoryLimit
+      type:
+        scalar: numeric
+    - name: rollbackTo
+      type:
+        namedType: io.k8s.api.extensions.v1beta1.RollbackConfig
+        elementRelationship: granular
+    - name: selector
+      type:
+        namedType: io.k8s.apimachinery.pkg.apis.meta.v1.LabelSelector
+        elementRelationship: granular
+    - name: strategy
+      type:
+        namedType: io.k8s.api.extensions.v1beta1.DeploymentStrategy
+        elementRelationship: granular
+    - name: template
+      type:
+        namedType: io.k8s.api.core.v1.PodTemplateSpec
+        elementRelationship: granular
+- name: io.k8s.api.extensions.v1beta1.DeploymentStatus
+  map:
+    fields:
+    - name: availableReplicas
+      type:
+        scalar: numeric
+    - name: collisionCount
+      type:
+        scalar: numeric
+    - name: conditions
+      type:
+        list:
+          elementType:
+            namedType: io.k8s.api.extensions.v1beta1.DeploymentCondition
+          elementRelationship: associative
+          keys:
+          - type
+    - name: observedGeneration
+      type:
+        scalar: numeric
+    - name: readyReplicas
+      type:
+        scalar: numeric
+    - name: replicas
+      type:
+        scalar: numeric
+    - name: unavailableReplicas
+      type:
+        scalar: numeric
+    - name: updatedReplicas
+      type:
+        scalar: numeric
+- name: io.k8s.api.extensions.v1beta1.DeploymentStrategy
+  map:
+    fields:
+    - name: rollingUpdate
+      type:
+        namedType: io.k8s.api.extensions.v1beta1.RollingUpdateDeployment
+        elementRelationship: granular
+    - name: type
+      type:
+        scalar: string
+- name: io.k8s.api.extensions.v1beta1.FSGroupStrategyOptions
+  map:
+    fields:
+    - name: ranges
+      type:
+        list:
+          elementType:
+            namedType: io.k8s.api.extensions.v1beta1.IDRange
+          elementRelationship: atomic
+    - name: rule
+      type:
+        scalar: string
+- name: io.k8s.api.extensions.v1beta1.HTTPIngressPath
+  map:
+    fields:
+    - name: backend
+      type:
+        namedType: io.k8s.api.extensions.v1beta1.IngressBackend
+        elementRelationship: granular
+    - name: path
+      type:
+        scalar: string
+- name: io.k8s.api.extensions.v1beta1.HTTPIngressRuleValue
+  map:
+    fields:
+    - name: paths
+      type:
+        list:
+          elementType:
+            namedType: io.k8s.api.extensions.v1beta1.HTTPIngressPath
+          elementRelationship: atomic
+- name: io.k8s.api.extensions.v1beta1.HostPortRange
+  map:
+    fields:
+    - name: max
+      type:
+        scalar: numeric
+    - name: min
+      type:
+        scalar: numeric
+- name: io.k8s.api.extensions.v1beta1.IDRange
+  map:
+    fields:
+    - name: max
+      type:
+        scalar: numeric
+    - name: min
+      type:
+        scalar: numeric
+- name: io.k8s.api.extensions.v1beta1.IPBlock
+  map:
+    fields:
+    - name: cidr
+      type:
+        scalar: string
+    - name: except
+      type:
+        list:
+          elementType:
+            scalar: string
+          elementRelationship: atomic
+- name: io.k8s.api.extensions.v1beta1.Ingress
+  map:
+    fields:
+    - name: apiVersion
+      type:
+        scalar: string
+    - name: kind
+      type:
+        scalar: string
+    - name: metadata
+      type:
+        namedType: io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta
+        elementRelationship: granular
+    - name: spec
+      type:
+        namedType: io.k8s.api.extensions.v1beta1.IngressSpec
+        elementRelationship: granular
+    - name: status
+      type:
+        namedType: io.k8s.api.extensions.v1beta1.IngressStatus
+        elementRelationship: granular
+- name: io.k8s.api.extensions.v1beta1.IngressBackend
+  map:
+    fields:
+    - name: serviceName
+      type:
+        scalar: string
+    - name: servicePort
+      type:
+        namedType: io.k8s.apimachinery.pkg.util.intstr.IntOrString
+        elementRelationship: granular
+- name: io.k8s.api.extensions.v1beta1.IngressList
+  map:
+    fields:
+    - name: apiVersion
+      type:
+        scalar: string
+    - name: items
+      type:
+        list:
+          elementType:
+            namedType: io.k8s.api.extensions.v1beta1.Ingress
+          elementRelationship: atomic
+    - name: kind
+      type:
+        scalar: string
+    - name: metadata
+      type:
+        namedType: io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta
+        elementRelationship: granular
+- name: io.k8s.api.extensions.v1beta1.IngressRule
+  map:
+    fields:
+    - name: host
+      type:
+        scalar: string
+    - name: http
+      type:
+        namedType: io.k8s.api.extensions.v1beta1.HTTPIngressRuleValue
+        elementRelationship: granular
+- name: io.k8s.api.extensions.v1beta1.IngressSpec
+  map:
+    fields:
+    - name: backend
+      type:
+        namedType: io.k8s.api.extensions.v1beta1.IngressBackend
+        elementRelationship: granular
+    - name: rules
+      type:
+        list:
+          elementType:
+            namedType: io.k8s.api.extensions.v1beta1.IngressRule
+          elementRelationship: atomic
+    - name: tls
+      type:
+        list:
+          elementType:
+            namedType: io.k8s.api.extensions.v1beta1.IngressTLS
+          elementRelationship: atomic
+- name: io.k8s.api.extensions.v1beta1.IngressStatus
+  map:
+    fields:
+    - name: loadBalancer
+      type:
+        namedType: io.k8s.api.core.v1.LoadBalancerStatus
+        elementRelationship: granular
+- name: io.k8s.api.extensions.v1beta1.IngressTLS
+  map:
+    fields:
+    - name: hosts
+      type:
+        list:
+          elementType:
+            scalar: string
+          elementRelationship: atomic
+    - name: secretName
+      type:
+        scalar: string
+- name: io.k8s.api.extensions.v1beta1.NetworkPolicy
+  map:
+    fields:
+    - name: apiVersion
+      type:
+        scalar: string
+    - name: kind
+      type:
+        scalar: string
+    - name: metadata
+      type:
+        namedType: io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta
+        elementRelationship: granular
+    - name: spec
+      type:
+        namedType: io.k8s.api.extensions.v1beta1.NetworkPolicySpec
+        elementRelationship: granular
+- name: io.k8s.api.extensions.v1beta1.NetworkPolicyEgressRule
+  map:
+    fields:
+    - name: ports
+      type:
+        list:
+          elementType:
+            namedType: io.k8s.api.extensions.v1beta1.NetworkPolicyPort
+          elementRelationship: atomic
+    - name: to
+      type:
+        list:
+          elementType:
+            namedType: io.k8s.api.extensions.v1beta1.NetworkPolicyPeer
+          elementRelationship: atomic
+- name: io.k8s.api.extensions.v1beta1.NetworkPolicyIngressRule
+  map:
+    fields:
+    - name: from
+      type:
+        list:
+          elementType:
+            namedType: io.k8s.api.extensions.v1beta1.NetworkPolicyPeer
+          elementRelationship: atomic
+    - name: ports
+      type:
+        list:
+          elementType:
+            namedType: io.k8s.api.extensions.v1beta1.NetworkPolicyPort
+          elementRelationship: atomic
+- name: io.k8s.api.extensions.v1beta1.NetworkPolicyList
+  map:
+    fields:
+    - name: apiVersion
+      type:
+        scalar: string
+    - name: items
+      type:
+        list:
+          elementType:
+            namedType: io.k8s.api.extensions.v1beta1.NetworkPolicy
+          elementRelationship: atomic
+    - name: kind
+      type:
+        scalar: string
+    - name: metadata
+      type:
+        namedType: io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta
+        elementRelationship: granular
+- name: io.k8s.api.extensions.v1beta1.NetworkPolicyPeer
+  map:
+    fields:
+    - name: ipBlock
+      type:
+        namedType: io.k8s.api.extensions.v1beta1.IPBlock
+        elementRelationship: granular
+    - name: namespaceSelector
+      type:
+        namedType: io.k8s.apimachinery.pkg.apis.meta.v1.LabelSelector
+        elementRelationship: granular
+    - name: podSelector
+      type:
+        namedType: io.k8s.apimachinery.pkg.apis.meta.v1.LabelSelector
+        elementRelationship: granular
+- name: io.k8s.api.extensions.v1beta1.NetworkPolicyPort
+  map:
+    fields:
+    - name: port
+      type:
+        namedType: io.k8s.apimachinery.pkg.util.intstr.IntOrString
+        elementRelationship: granular
+    - name: protocol
+      type:
+        scalar: string
+- name: io.k8s.api.extensions.v1beta1.NetworkPolicySpec
+  map:
+    fields:
+    - name: egress
+      type:
+        list:
+          elementType:
+            namedType: io.k8s.api.extensions.v1beta1.NetworkPolicyEgressRule
+          elementRelationship: atomic
+    - name: ingress
+      type:
+        list:
+          elementType:
+            namedType: io.k8s.api.extensions.v1beta1.NetworkPolicyIngressRule
+          elementRelationship: atomic
+    - name: podSelector
+      type:
+        namedType: io.k8s.apimachinery.pkg.apis.meta.v1.LabelSelector
+        elementRelationship: granular
+    - name: policyTypes
+      type:
+        list:
+          elementType:
+            scalar: string
+          elementRelationship: atomic
+- name: io.k8s.api.extensions.v1beta1.PodSecurityPolicy
+  map:
+    fields:
+    - name: apiVersion
+      type:
+        scalar: string
+    - name: kind
+      type:
+        scalar: string
+    - name: metadata
+      type:
+        namedType: io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta
+        elementRelationship: granular
+    - name: spec
+      type:
+        namedType: io.k8s.api.extensions.v1beta1.PodSecurityPolicySpec
+        elementRelationship: granular
+- name: io.k8s.api.extensions.v1beta1.PodSecurityPolicyList
+  map:
+    fields:
+    - name: apiVersion
+      type:
+        scalar: string
+    - name: items
+      type:
+        list:
+          elementType:
+            namedType: io.k8s.api.extensions.v1beta1.PodSecurityPolicy
+          elementRelationship: atomic
+    - name: kind
+      type:
+        scalar: string
+    - name: metadata
+      type:
+        namedType: io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta
+        elementRelationship: granular
+- name: io.k8s.api.extensions.v1beta1.PodSecurityPolicySpec
+  map:
+    fields:
+    - name: allowPrivilegeEscalation
+      type:
+        scalar: boolean
+    - name: allowedCapabilities
+      type:
+        list:
+          elementType:
+            scalar: string
+          elementRelationship: atomic
+    - name: allowedFlexVolumes
+      type:
+        list:
+          elementType:
+            namedType: io.k8s.api.extensions.v1beta1.AllowedFlexVolume
+          elementRelationship: atomic
+    - name: allowedHostPaths
+      type:
+        list:
+          elementType:
+            namedType: io.k8s.api.extensions.v1beta1.AllowedHostPath
+          elementRelationship: atomic
+    - name: allowedProcMountTypes
+      type:
+        list:
+          elementType:
+            scalar: string
+          elementRelationship: atomic
+    - name: allowedUnsafeSysctls
+      type:
+        list:
+          elementType:
+            scalar: string
+          elementRelationship: atomic
+    - name: defaultAddCapabilities
+      type:
+        list:
+          elementType:
+            scalar: string
+          elementRelationship: atomic
+    - name: defaultAllowPrivilegeEscalation
+      type:
+        scalar: boolean
+    - name: forbiddenSysctls
+      type:
+        list:
+          elementType:
+            scalar: string
+          elementRelationship: atomic
+    - name: fsGroup
+      type:
+        namedType: io.k8s.api.extensions.v1beta1.FSGroupStrategyOptions
+        elementRelationship: granular
+    - name: hostIPC
+      type:
+        scalar: boolean
+    - name: hostNetwork
+      type:
+        scalar: boolean
+    - name: hostPID
+      type:
+        scalar: boolean
+    - name: hostPorts
+      type:
+        list:
+          elementType:
+            namedType: io.k8s.api.extensions.v1beta1.HostPortRange
+          elementRelationship: atomic
+    - name: privileged
+      type:
+        scalar: boolean
+    - name: readOnlyRootFilesystem
+      type:
+        scalar: boolean
+    - name: requiredDropCapabilities
+      type:
+        list:
+          elementType:
+            scalar: string
+          elementRelationship: atomic
+    - name: runAsGroup
+      type:
+        namedType: io.k8s.api.extensions.v1beta1.RunAsGroupStrategyOptions
+        elementRelationship: granular
+    - name: runAsUser
+      type:
+        namedType: io.k8s.api.extensions.v1beta1.RunAsUserStrategyOptions
+        elementRelationship: granular
+    - name: seLinux
+      type:
+        namedType: io.k8s.api.extensions.v1beta1.SELinuxStrategyOptions
+        elementRelationship: granular
+    - name: supplementalGroups
+      type:
+        namedType: io.k8s.api.extensions.v1beta1.SupplementalGroupsStrategyOptions
+        elementRelationship: granular
+    - name: volumes
+      type:
+        list:
+          elementType:
+            scalar: string
+          elementRelationship: atomic
+- name: io.k8s.api.extensions.v1beta1.ReplicaSet
+  map:
+    fields:
+    - name: apiVersion
+      type:
+        scalar: string
+    - name: kind
+      type:
+        scalar: string
+    - name: metadata
+      type:
+        namedType: io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta
+        elementRelationship: granular
+    - name: spec
+      type:
+        namedType: io.k8s.api.extensions.v1beta1.ReplicaSetSpec
+        elementRelationship: granular
+    - name: status
+      type:
+        namedType: io.k8s.api.extensions.v1beta1.ReplicaSetStatus
+        elementRelationship: granular
+- name: io.k8s.api.extensions.v1beta1.ReplicaSetCondition
+  map:
+    fields:
+    - name: lastTransitionTime
+      type:
+        namedType: io.k8s.apimachinery.pkg.apis.meta.v1.Time
+    - name: message
+      type:
+        scalar: string
+    - name: reason
+      type:
+        scalar: string
+    - name: status
+      type:
+        scalar: string
+    - name: type
+      type:
+        scalar: string
+- name: io.k8s.api.extensions.v1beta1.ReplicaSetList
+  map:
+    fields:
+    - name: apiVersion
+      type:
+        scalar: string
+    - name: items
+      type:
+        list:
+          elementType:
+            namedType: io.k8s.api.extensions.v1beta1.ReplicaSet
+          elementRelationship: atomic
+    - name: kind
+      type:
+        scalar: string
+    - name: metadata
+      type:
+        namedType: io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta
+        elementRelationship: granular
+- name: io.k8s.api.extensions.v1beta1.ReplicaSetSpec
+  map:
+    fields:
+    - name: minReadySeconds
+      type:
+        scalar: numeric
+    - name: replicas
+      type:
+        scalar: numeric
+    - name: selector
+      type:
+        namedType: io.k8s.apimachinery.pkg.apis.meta.v1.LabelSelector
+        elementRelationship: granular
+    - name: template
+      type:
+        namedType: io.k8s.api.core.v1.PodTemplateSpec
+        elementRelationship: granular
+- name: io.k8s.api.extensions.v1beta1.ReplicaSetStatus
+  map:
+    fields:
+    - name: availableReplicas
+      type:
+        scalar: numeric
+    - name: conditions
+      type:
+        list:
+          elementType:
+            namedType: io.k8s.api.extensions.v1beta1.ReplicaSetCondition
+          elementRelationship: associative
+          keys:
+          - type
+    - name: fullyLabeledReplicas
+      type:
+        scalar: numeric
+    - name: observedGeneration
+      type:
+        scalar: numeric
+    - name: readyReplicas
+      type:
+        scalar: numeric
+    - name: replicas
+      type:
+        scalar: numeric
+- name: io.k8s.api.extensions.v1beta1.RollbackConfig
+  map:
+    fields:
+    - name: revision
+      type:
+        scalar: numeric
+- name: io.k8s.api.extensions.v1beta1.RollingUpdateDaemonSet
+  map:
+    fields:
+    - name: maxUnavailable
+      type:
+        namedType: io.k8s.apimachinery.pkg.util.intstr.IntOrString
+        elementRelationship: granular
+- name: io.k8s.api.extensions.v1beta1.RollingUpdateDeployment
+  map:
+    fields:
+    - name: maxSurge
+      type:
+        namedType: io.k8s.apimachinery.pkg.util.intstr.IntOrString
+        elementRelationship: granular
+    - name: maxUnavailable
+      type:
+        namedType: io.k8s.apimachinery.pkg.util.intstr.IntOrString
+        elementRelationship: granular
+- name: io.k8s.api.extensions.v1beta1.RunAsGroupStrategyOptions
+  map:
+    fields:
+    - name: ranges
+      type:
+        list:
+          elementType:
+            namedType: io.k8s.api.extensions.v1beta1.IDRange
+          elementRelationship: atomic
+    - name: rule
+      type:
+        scalar: string
+- name: io.k8s.api.extensions.v1beta1.RunAsUserStrategyOptions
+  map:
+    fields:
+    - name: ranges
+      type:
+        list:
+          elementType:
+            namedType: io.k8s.api.extensions.v1beta1.IDRange
+          elementRelationship: atomic
+    - name: rule
+      type:
+        scalar: string
+- name: io.k8s.api.extensions.v1beta1.SELinuxStrategyOptions
+  map:
+    fields:
+    - name: rule
+      type:
+        scalar: string
+    - name: seLinuxOptions
+      type:
+        namedType: io.k8s.api.core.v1.SELinuxOptions
+        elementRelationship: granular
+- name: io.k8s.api.extensions.v1beta1.Scale
+  map:
+    fields:
+    - name: apiVersion
+      type:
+        scalar: string
+    - name: kind
+      type:
+        scalar: string
+    - name: metadata
+      type:
+        namedType: io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta
+        elementRelationship: granular
+    - name: spec
+      type:
+        namedType: io.k8s.api.extensions.v1beta1.ScaleSpec
+        elementRelationship: granular
+    - name: status
+      type:
+        namedType: io.k8s.api.extensions.v1beta1.ScaleStatus
+        elementRelationship: granular
+- name: io.k8s.api.extensions.v1beta1.ScaleSpec
+  map:
+    fields:
+    - name: replicas
+      type:
+        scalar: numeric
+- name: io.k8s.api.extensions.v1beta1.ScaleStatus
+  map:
+    fields:
+    - name: replicas
+      type:
+        scalar: numeric
+    - name: selector
+      type:
+        map:
+          elementType:
+            scalar: string
+    - name: targetSelector
+      type:
+        scalar: string
+- name: io.k8s.api.extensions.v1beta1.SupplementalGroupsStrategyOptions
+  map:
+    fields:
+    - name: ranges
+      type:
+        list:
+          elementType:
+            namedType: io.k8s.api.extensions.v1beta1.IDRange
+          elementRelationship: atomic
+    - name: rule
+      type:
+        scalar: string
+- name: io.k8s.api.networking.v1.IPBlock
+  map:
+    fields:
+    - name: cidr
+      type:
+        scalar: string
+    - name: except
+      type:
+        list:
+          elementType:
+            scalar: string
+          elementRelationship: atomic
+- name: io.k8s.api.networking.v1.NetworkPolicy
+  map:
+    fields:
+    - name: apiVersion
+      type:
+        scalar: string
+    - name: kind
+      type:
+        scalar: string
+    - name: metadata
+      type:
+        namedType: io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta
+        elementRelationship: granular
+    - name: spec
+      type:
+        namedType: io.k8s.api.networking.v1.NetworkPolicySpec
+        elementRelationship: granular
+- name: io.k8s.api.networking.v1.NetworkPolicyEgressRule
+  map:
+    fields:
+    - name: ports
+      type:
+        list:
+          elementType:
+            namedType: io.k8s.api.networking.v1.NetworkPolicyPort
+          elementRelationship: atomic
+    - name: to
+      type:
+        list:
+          elementType:
+            namedType: io.k8s.api.networking.v1.NetworkPolicyPeer
+          elementRelationship: atomic
+- name: io.k8s.api.networking.v1.NetworkPolicyIngressRule
+  map:
+    fields:
+    - name: from
+      type:
+        list:
+          elementType:
+            namedType: io.k8s.api.networking.v1.NetworkPolicyPeer
+          elementRelationship: atomic
+    - name: ports
+      type:
+        list:
+          elementType:
+            namedType: io.k8s.api.networking.v1.NetworkPolicyPort
+          elementRelationship: atomic
+- name: io.k8s.api.networking.v1.NetworkPolicyList
+  map:
+    fields:
+    - name: apiVersion
+      type:
+        scalar: string
+    - name: items
+      type:
+        list:
+          elementType:
+            namedType: io.k8s.api.networking.v1.NetworkPolicy
+          elementRelationship: atomic
+    - name: kind
+      type:
+        scalar: string
+    - name: metadata
+      type:
+        namedType: io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta
+        elementRelationship: granular
+- name: io.k8s.api.networking.v1.NetworkPolicyPeer
+  map:
+    fields:
+    - name: ipBlock
+      type:
+        namedType: io.k8s.api.networking.v1.IPBlock
+        elementRelationship: granular
+    - name: namespaceSelector
+      type:
+        namedType: io.k8s.apimachinery.pkg.apis.meta.v1.LabelSelector
+        elementRelationship: granular
+    - name: podSelector
+      type:
+        namedType: io.k8s.apimachinery.pkg.apis.meta.v1.LabelSelector
+        elementRelationship: granular
+- name: io.k8s.api.networking.v1.NetworkPolicyPort
+  map:
+    fields:
+    - name: port
+      type:
+        namedType: io.k8s.apimachinery.pkg.util.intstr.IntOrString
+        elementRelationship: granular
+    - name: protocol
+      type:
+        scalar: string
+- name: io.k8s.api.networking.v1.NetworkPolicySpec
+  map:
+    fields:
+    - name: egress
+      type:
+        list:
+          elementType:
+            namedType: io.k8s.api.networking.v1.NetworkPolicyEgressRule
+          elementRelationship: atomic
+    - name: ingress
+      type:
+        list:
+          elementType:
+            namedType: io.k8s.api.networking.v1.NetworkPolicyIngressRule
+          elementRelationship: atomic
+    - name: podSelector
+      type:
+        namedType: io.k8s.apimachinery.pkg.apis.meta.v1.LabelSelector
+        elementRelationship: granular
+    - name: policyTypes
+      type:
+        list:
+          elementType:
+            scalar: string
+          elementRelationship: atomic
+- name: io.k8s.api.policy.v1beta1.AllowedFlexVolume
+  map:
+    fields:
+    - name: driver
+      type:
+        scalar: string
+- name: io.k8s.api.policy.v1beta1.AllowedHostPath
+  map:
+    fields:
+    - name: pathPrefix
+      type:
+        scalar: string
+    - name: readOnly
+      type:
+        scalar: boolean
+- name: io.k8s.api.policy.v1beta1.Eviction
+  map:
+    fields:
+    - name: apiVersion
+      type:
+        scalar: string
+    - name: deleteOptions
+      type:
+        namedType: io.k8s.apimachinery.pkg.apis.meta.v1.DeleteOptions
+        elementRelationship: granular
+    - name: kind
+      type:
+        scalar: string
+    - name: metadata
+      type:
+        namedType: io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta
+        elementRelationship: granular
+- name: io.k8s.api.policy.v1beta1.FSGroupStrategyOptions
+  map:
+    fields:
+    - name: ranges
+      type:
+        list:
+          elementType:
+            namedType: io.k8s.api.policy.v1beta1.IDRange
+          elementRelationship: atomic
+    - name: rule
+      type:
+        scalar: string
+- name: io.k8s.api.policy.v1beta1.HostPortRange
+  map:
+    fields:
+    - name: max
+      type:
+        scalar: numeric
+    - name: min
+      type:
+        scalar: numeric
+- name: io.k8s.api.policy.v1beta1.IDRange
+  map:
+    fields:
+    - name: max
+      type:
+        scalar: numeric
+    - name: min
+      type:
+        scalar: numeric
+- name: io.k8s.api.policy.v1beta1.PodDisruptionBudget
+  map:
+    fields:
+    - name: apiVersion
+      type:
+        scalar: string
+    - name: kind
+      type:
+        scalar: string
+    - name: metadata
+      type:
+        namedType: io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta
+        elementRelationship: granular
+    - name: spec
+      type:
+        namedType: io.k8s.api.policy.v1beta1.PodDisruptionBudgetSpec
+        elementRelationship: granular
+    - name: status
+      type:
+        namedType: io.k8s.api.policy.v1beta1.PodDisruptionBudgetStatus
+        elementRelationship: granular
+- name: io.k8s.api.policy.v1beta1.PodDisruptionBudgetList
+  map:
+    fields:
+    - name: apiVersion
+      type:
+        scalar: string
+    - name: items
+      type:
+        list:
+          elementType:
+            namedType: io.k8s.api.policy.v1beta1.PodDisruptionBudget
+          elementRelationship: atomic
+    - name: kind
+      type:
+        scalar: string
+    - name: metadata
+      type:
+        namedType: io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta
+        elementRelationship: granular
+- name: io.k8s.api.policy.v1beta1.PodDisruptionBudgetSpec
+  map:
+    fields:
+    - name: maxUnavailable
+      type:
+        namedType: io.k8s.apimachinery.pkg.util.intstr.IntOrString
+        elementRelationship: granular
+    - name: minAvailable
+      type:
+        namedType: io.k8s.apimachinery.pkg.util.intstr.IntOrString
+        elementRelationship: granular
+    - name: selector
+      type:
+        namedType: io.k8s.apimachinery.pkg.apis.meta.v1.LabelSelector
+        elementRelationship: granular
+- name: io.k8s.api.policy.v1beta1.PodDisruptionBudgetStatus
+  map:
+    fields:
+    - name: currentHealthy
+      type:
+        scalar: numeric
+    - name: desiredHealthy
+      type:
+        scalar: numeric
+    - name: disruptedPods
+      type:
+        map:
+          elementType:
+            namedType: io.k8s.apimachinery.pkg.apis.meta.v1.Time
+    - name: disruptionsAllowed
+      type:
+        scalar: numeric
+    - name: expectedPods
+      type:
+        scalar: numeric
+    - name: observedGeneration
+      type:
+        scalar: numeric
+- name: io.k8s.api.policy.v1beta1.PodSecurityPolicy
+  map:
+    fields:
+    - name: apiVersion
+      type:
+        scalar: string
+    - name: kind
+      type:
+        scalar: string
+    - name: metadata
+      type:
+        namedType: io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta
+        elementRelationship: granular
+    - name: spec
+      type:
+        namedType: io.k8s.api.policy.v1beta1.PodSecurityPolicySpec
+        elementRelationship: granular
+- name: io.k8s.api.policy.v1beta1.PodSecurityPolicyList
+  map:
+    fields:
+    - name: apiVersion
+      type:
+        scalar: string
+    - name: items
+      type:
+        list:
+          elementType:
+            namedType: io.k8s.api.policy.v1beta1.PodSecurityPolicy
+          elementRelationship: atomic
+    - name: kind
+      type:
+        scalar: string
+    - name: metadata
+      type:
+        namedType: io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta
+        elementRelationship: granular
+- name: io.k8s.api.policy.v1beta1.PodSecurityPolicySpec
+  map:
+    fields:
+    - name: allowPrivilegeEscalation
+      type:
+        scalar: boolean
+    - name: allowedCapabilities
+      type:
+        list:
+          elementType:
+            scalar: string
+          elementRelationship: atomic
+    - name: allowedFlexVolumes
+      type:
+        list:
+          elementType:
+            namedType: io.k8s.api.policy.v1beta1.AllowedFlexVolume
+          elementRelationship: atomic
+    - name: allowedHostPaths
+      type:
+        list:
+          elementType:
+            namedType: io.k8s.api.policy.v1beta1.AllowedHostPath
+          elementRelationship: atomic
+    - name: allowedProcMountTypes
+      type:
+        list:
+          elementType:
+            scalar: string
+          elementRelationship: atomic
+    - name: allowedUnsafeSysctls
+      type:
+        list:
+          elementType:
+            scalar: string
+          elementRelationship: atomic
+    - name: defaultAddCapabilities
+      type:
+        list:
+          elementType:
+            scalar: string
+          elementRelationship: atomic
+    - name: defaultAllowPrivilegeEscalation
+      type:
+        scalar: boolean
+    - name: forbiddenSysctls
+      type:
+        list:
+          elementType:
+            scalar: string
+          elementRelationship: atomic
+    - name: fsGroup
+      type:
+        namedType: io.k8s.api.policy.v1beta1.FSGroupStrategyOptions
+        elementRelationship: granular
+    - name: hostIPC
+      type:
+        scalar: boolean
+    - name: hostNetwork
+      type:
+        scalar: boolean
+    - name: hostPID
+      type:
+        scalar: boolean
+    - name: hostPorts
+      type:
+        list:
+          elementType:
+            namedType: io.k8s.api.policy.v1beta1.HostPortRange
+          elementRelationship: atomic
+    - name: privileged
+      type:
+        scalar: boolean
+    - name: readOnlyRootFilesystem
+      type:
+        scalar: boolean
+    - name: requiredDropCapabilities
+      type:
+        list:
+          elementType:
+            scalar: string
+          elementRelationship: atomic
+    - name: runAsGroup
+      type:
+        namedType: io.k8s.api.policy.v1beta1.RunAsGroupStrategyOptions
+        elementRelationship: granular
+    - name: runAsUser
+      type:
+        namedType: io.k8s.api.policy.v1beta1.RunAsUserStrategyOptions
+        elementRelationship: granular
+    - name: seLinux
+      type:
+        namedType: io.k8s.api.policy.v1beta1.SELinuxStrategyOptions
+        elementRelationship: granular
+    - name: supplementalGroups
+      type:
+        namedType: io.k8s.api.policy.v1beta1.SupplementalGroupsStrategyOptions
+        elementRelationship: granular
+    - name: volumes
+      type:
+        list:
+          elementType:
+            scalar: string
+          elementRelationship: atomic
+- name: io.k8s.api.policy.v1beta1.RunAsGroupStrategyOptions
+  map:
+    fields:
+    - name: ranges
+      type:
+        list:
+          elementType:
+            namedType: io.k8s.api.policy.v1beta1.IDRange
+          elementRelationship: atomic
+    - name: rule
+      type:
+        scalar: string
+- name: io.k8s.api.policy.v1beta1.RunAsUserStrategyOptions
+  map:
+    fields:
+    - name: ranges
+      type:
+        list:
+          elementType:
+            namedType: io.k8s.api.policy.v1beta1.IDRange
+          elementRelationship: atomic
+    - name: rule
+      type:
+        scalar: string
+- name: io.k8s.api.policy.v1beta1.SELinuxStrategyOptions
+  map:
+    fields:
+    - name: rule
+      type:
+        scalar: string
+    - name: seLinuxOptions
+      type:
+        namedType: io.k8s.api.core.v1.SELinuxOptions
+        elementRelationship: granular
+- name: io.k8s.api.policy.v1beta1.SupplementalGroupsStrategyOptions
+  map:
+    fields:
+    - name: ranges
+      type:
+        list:
+          elementType:
+            namedType: io.k8s.api.policy.v1beta1.IDRange
+          elementRelationship: atomic
+    - name: rule
+      type:
+        scalar: string
+- name: io.k8s.api.rbac.v1.AggregationRule
+  map:
+    fields:
+    - name: clusterRoleSelectors
+      type:
+        list:
+          elementType:
+            namedType: io.k8s.apimachinery.pkg.apis.meta.v1.LabelSelector
+          elementRelationship: atomic
+- name: io.k8s.api.rbac.v1.ClusterRole
+  map:
+    fields:
+    - name: aggregationRule
+      type:
+        namedType: io.k8s.api.rbac.v1.AggregationRule
+        elementRelationship: granular
+    - name: apiVersion
+      type:
+        scalar: string
+    - name: kind
+      type:
+        scalar: string
+    - name: metadata
+      type:
+        namedType: io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta
+        elementRelationship: granular
+    - name: rules
+      type:
+        list:
+          elementType:
+            namedType: io.k8s.api.rbac.v1.PolicyRule
+          elementRelationship: atomic
+- name: io.k8s.api.rbac.v1.ClusterRoleBinding
+  map:
+    fields:
+    - name: apiVersion
+      type:
+        scalar: string
+    - name: kind
+      type:
+        scalar: string
+    - name: metadata
+      type:
+        namedType: io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta
+        elementRelationship: granular
+    - name: roleRef
+      type:
+        namedType: io.k8s.api.rbac.v1.RoleRef
+        elementRelationship: granular
+    - name: subjects
+      type:
+        list:
+          elementType:
+            namedType: io.k8s.api.rbac.v1.Subject
+          elementRelationship: atomic
+- name: io.k8s.api.rbac.v1.ClusterRoleBindingList
+  map:
+    fields:
+    - name: apiVersion
+      type:
+        scalar: string
+    - name: items
+      type:
+        list:
+          elementType:
+            namedType: io.k8s.api.rbac.v1.ClusterRoleBinding
+          elementRelationship: atomic
+    - name: kind
+      type:
+        scalar: string
+    - name: metadata
+      type:
+        namedType: io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta
+        elementRelationship: granular
+- name: io.k8s.api.rbac.v1.ClusterRoleList
+  map:
+    fields:
+    - name: apiVersion
+      type:
+        scalar: string
+    - name: items
+      type:
+        list:
+          elementType:
+            namedType: io.k8s.api.rbac.v1.ClusterRole
+          elementRelationship: atomic
+    - name: kind
+      type:
+        scalar: string
+    - name: metadata
+      type:
+        namedType: io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta
+        elementRelationship: granular
+- name: io.k8s.api.rbac.v1.PolicyRule
+  map:
+    fields:
+    - name: apiGroups
+      type:
+        list:
+          elementType:
+            scalar: string
+          elementRelationship: atomic
+    - name: nonResourceURLs
+      type:
+        list:
+          elementType:
+            scalar: string
+          elementRelationship: atomic
+    - name: resourceNames
+      type:
+        list:
+          elementType:
+            scalar: string
+          elementRelationship: atomic
+    - name: resources
+      type:
+        list:
+          elementType:
+            scalar: string
+          elementRelationship: atomic
+    - name: verbs
+      type:
+        list:
+          elementType:
+            scalar: string
+          elementRelationship: atomic
+- name: io.k8s.api.rbac.v1.Role
+  map:
+    fields:
+    - name: apiVersion
+      type:
+        scalar: string
+    - name: kind
+      type:
+        scalar: string
+    - name: metadata
+      type:
+        namedType: io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta
+        elementRelationship: granular
+    - name: rules
+      type:
+        list:
+          elementType:
+            namedType: io.k8s.api.rbac.v1.PolicyRule
+          elementRelationship: atomic
+- name: io.k8s.api.rbac.v1.RoleBinding
+  map:
+    fields:
+    - name: apiVersion
+      type:
+        scalar: string
+    - name: kind
+      type:
+        scalar: string
+    - name: metadata
+      type:
+        namedType: io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta
+        elementRelationship: granular
+    - name: roleRef
+      type:
+        namedType: io.k8s.api.rbac.v1.RoleRef
+        elementRelationship: granular
+    - name: subjects
+      type:
+        list:
+          elementType:
+            namedType: io.k8s.api.rbac.v1.Subject
+          elementRelationship: atomic
+- name: io.k8s.api.rbac.v1.RoleBindingList
+  map:
+    fields:
+    - name: apiVersion
+      type:
+        scalar: string
+    - name: items
+      type:
+        list:
+          elementType:
+            namedType: io.k8s.api.rbac.v1.RoleBinding
+          elementRelationship: atomic
+    - name: kind
+      type:
+        scalar: string
+    - name: metadata
+      type:
+        namedType: io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta
+        elementRelationship: granular
+- name: io.k8s.api.rbac.v1.RoleList
+  map:
+    fields:
+    - name: apiVersion
+      type:
+        scalar: string
+    - name: items
+      type:
+        list:
+          elementType:
+            namedType: io.k8s.api.rbac.v1.Role
+          elementRelationship: atomic
+    - name: kind
+      type:
+        scalar: string
+    - name: metadata
+      type:
+        namedType: io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta
+        elementRelationship: granular
+- name: io.k8s.api.rbac.v1.RoleRef
+  map:
+    fields:
+    - name: apiGroup
+      type:
+        scalar: string
+    - name: kind
+      type:
+        scalar: string
+    - name: name
+      type:
+        scalar: string
+- name: io.k8s.api.rbac.v1.Subject
+  map:
+    fields:
+    - name: apiGroup
+      type:
+        scalar: string
+    - name: kind
+      type:
+        scalar: string
+    - name: name
+      type:
+        scalar: string
+    - name: namespace
+      type:
+        scalar: string
+- name: io.k8s.api.rbac.v1alpha1.AggregationRule
+  map:
+    fields:
+    - name: clusterRoleSelectors
+      type:
+        list:
+          elementType:
+            namedType: io.k8s.apimachinery.pkg.apis.meta.v1.LabelSelector
+          elementRelationship: atomic
+- name: io.k8s.api.rbac.v1alpha1.ClusterRole
+  map:
+    fields:
+    - name: aggregationRule
+      type:
+        namedType: io.k8s.api.rbac.v1alpha1.AggregationRule
+        elementRelationship: granular
+    - name: apiVersion
+      type:
+        scalar: string
+    - name: kind
+      type:
+        scalar: string
+    - name: metadata
+      type:
+        namedType: io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta
+        elementRelationship: granular
+    - name: rules
+      type:
+        list:
+          elementType:
+            namedType: io.k8s.api.rbac.v1alpha1.PolicyRule
+          elementRelationship: atomic
+- name: io.k8s.api.rbac.v1alpha1.ClusterRoleBinding
+  map:
+    fields:
+    - name: apiVersion
+      type:
+        scalar: string
+    - name: kind
+      type:
+        scalar: string
+    - name: metadata
+      type:
+        namedType: io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta
+        elementRelationship: granular
+    - name: roleRef
+      type:
+        namedType: io.k8s.api.rbac.v1alpha1.RoleRef
+        elementRelationship: granular
+    - name: subjects
+      type:
+        list:
+          elementType:
+            namedType: io.k8s.api.rbac.v1alpha1.Subject
+          elementRelationship: atomic
+- name: io.k8s.api.rbac.v1alpha1.ClusterRoleBindingList
+  map:
+    fields:
+    - name: apiVersion
+      type:
+        scalar: string
+    - name: items
+      type:
+        list:
+          elementType:
+            namedType: io.k8s.api.rbac.v1alpha1.ClusterRoleBinding
+          elementRelationship: atomic
+    - name: kind
+      type:
+        scalar: string
+    - name: metadata
+      type:
+        namedType: io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta
+        elementRelationship: granular
+- name: io.k8s.api.rbac.v1alpha1.ClusterRoleList
+  map:
+    fields:
+    - name: apiVersion
+      type:
+        scalar: string
+    - name: items
+      type:
+        list:
+          elementType:
+            namedType: io.k8s.api.rbac.v1alpha1.ClusterRole
+          elementRelationship: atomic
+    - name: kind
+      type:
+        scalar: string
+    - name: metadata
+      type:
+        namedType: io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta
+        elementRelationship: granular
+- name: io.k8s.api.rbac.v1alpha1.PolicyRule
+  map:
+    fields:
+    - name: apiGroups
+      type:
+        list:
+          elementType:
+            scalar: string
+          elementRelationship: atomic
+    - name: nonResourceURLs
+      type:
+        list:
+          elementType:
+            scalar: string
+          elementRelationship: atomic
+    - name: resourceNames
+      type:
+        list:
+          elementType:
+            scalar: string
+          elementRelationship: atomic
+    - name: resources
+      type:
+        list:
+          elementType:
+            scalar: string
+          elementRelationship: atomic
+    - name: verbs
+      type:
+        list:
+          elementType:
+            scalar: string
+          elementRelationship: atomic
+- name: io.k8s.api.rbac.v1alpha1.Role
+  map:
+    fields:
+    - name: apiVersion
+      type:
+        scalar: string
+    - name: kind
+      type:
+        scalar: string
+    - name: metadata
+      type:
+        namedType: io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta
+        elementRelationship: granular
+    - name: rules
+      type:
+        list:
+          elementType:
+            namedType: io.k8s.api.rbac.v1alpha1.PolicyRule
+          elementRelationship: atomic
+- name: io.k8s.api.rbac.v1alpha1.RoleBinding
+  map:
+    fields:
+    - name: apiVersion
+      type:
+        scalar: string
+    - name: kind
+      type:
+        scalar: string
+    - name: metadata
+      type:
+        namedType: io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta
+        elementRelationship: granular
+    - name: roleRef
+      type:
+        namedType: io.k8s.api.rbac.v1alpha1.RoleRef
+        elementRelationship: granular
+    - name: subjects
+      type:
+        list:
+          elementType:
+            namedType: io.k8s.api.rbac.v1alpha1.Subject
+          elementRelationship: atomic
+- name: io.k8s.api.rbac.v1alpha1.RoleBindingList
+  map:
+    fields:
+    - name: apiVersion
+      type:
+        scalar: string
+    - name: items
+      type:
+        list:
+          elementType:
+            namedType: io.k8s.api.rbac.v1alpha1.RoleBinding
+          elementRelationship: atomic
+    - name: kind
+      type:
+        scalar: string
+    - name: metadata
+      type:
+        namedType: io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta
+        elementRelationship: granular
+- name: io.k8s.api.rbac.v1alpha1.RoleList
+  map:
+    fields:
+    - name: apiVersion
+      type:
+        scalar: string
+    - name: items
+      type:
+        list:
+          elementType:
+            namedType: io.k8s.api.rbac.v1alpha1.Role
+          elementRelationship: atomic
+    - name: kind
+      type:
+        scalar: string
+    - name: metadata
+      type:
+        namedType: io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta
+        elementRelationship: granular
+- name: io.k8s.api.rbac.v1alpha1.RoleRef
+  map:
+    fields:
+    - name: apiGroup
+      type:
+        scalar: string
+    - name: kind
+      type:
+        scalar: string
+    - name: name
+      type:
+        scalar: string
+- name: io.k8s.api.rbac.v1alpha1.Subject
+  map:
+    fields:
+    - name: apiVersion
+      type:
+        scalar: string
+    - name: kind
+      type:
+        scalar: string
+    - name: name
+      type:
+        scalar: string
+    - name: namespace
+      type:
+        scalar: string
+- name: io.k8s.api.rbac.v1beta1.AggregationRule
+  map:
+    fields:
+    - name: clusterRoleSelectors
+      type:
+        list:
+          elementType:
+            namedType: io.k8s.apimachinery.pkg.apis.meta.v1.LabelSelector
+          elementRelationship: atomic
+- name: io.k8s.api.rbac.v1beta1.ClusterRole
+  map:
+    fields:
+    - name: aggregationRule
+      type:
+        namedType: io.k8s.api.rbac.v1beta1.AggregationRule
+        elementRelationship: granular
+    - name: apiVersion
+      type:
+        scalar: string
+    - name: kind
+      type:
+        scalar: string
+    - name: metadata
+      type:
+        namedType: io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta
+        elementRelationship: granular
+    - name: rules
+      type:
+        list:
+          elementType:
+            namedType: io.k8s.api.rbac.v1beta1.PolicyRule
+          elementRelationship: atomic
+- name: io.k8s.api.rbac.v1beta1.ClusterRoleBinding
+  map:
+    fields:
+    - name: apiVersion
+      type:
+        scalar: string
+    - name: kind
+      type:
+        scalar: string
+    - name: metadata
+      type:
+        namedType: io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta
+        elementRelationship: granular
+    - name: roleRef
+      type:
+        namedType: io.k8s.api.rbac.v1beta1.RoleRef
+        elementRelationship: granular
+    - name: subjects
+      type:
+        list:
+          elementType:
+            namedType: io.k8s.api.rbac.v1beta1.Subject
+          elementRelationship: atomic
+- name: io.k8s.api.rbac.v1beta1.ClusterRoleBindingList
+  map:
+    fields:
+    - name: apiVersion
+      type:
+        scalar: string
+    - name: items
+      type:
+        list:
+          elementType:
+            namedType: io.k8s.api.rbac.v1beta1.ClusterRoleBinding
+          elementRelationship: atomic
+    - name: kind
+      type:
+        scalar: string
+    - name: metadata
+      type:
+        namedType: io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta
+        elementRelationship: granular
+- name: io.k8s.api.rbac.v1beta1.ClusterRoleList
+  map:
+    fields:
+    - name: apiVersion
+      type:
+        scalar: string
+    - name: items
+      type:
+        list:
+          elementType:
+            namedType: io.k8s.api.rbac.v1beta1.ClusterRole
+          elementRelationship: atomic
+    - name: kind
+      type:
+        scalar: string
+    - name: metadata
+      type:
+        namedType: io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta
+        elementRelationship: granular
+- name: io.k8s.api.rbac.v1beta1.PolicyRule
+  map:
+    fields:
+    - name: apiGroups
+      type:
+        list:
+          elementType:
+            scalar: string
+          elementRelationship: atomic
+    - name: nonResourceURLs
+      type:
+        list:
+          elementType:
+            scalar: string
+          elementRelationship: atomic
+    - name: resourceNames
+      type:
+        list:
+          elementType:
+            scalar: string
+          elementRelationship: atomic
+    - name: resources
+      type:
+        list:
+          elementType:
+            scalar: string
+          elementRelationship: atomic
+    - name: verbs
+      type:
+        list:
+          elementType:
+            scalar: string
+          elementRelationship: atomic
+- name: io.k8s.api.rbac.v1beta1.Role
+  map:
+    fields:
+    - name: apiVersion
+      type:
+        scalar: string
+    - name: kind
+      type:
+        scalar: string
+    - name: metadata
+      type:
+        namedType: io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta
+        elementRelationship: granular
+    - name: rules
+      type:
+        list:
+          elementType:
+            namedType: io.k8s.api.rbac.v1beta1.PolicyRule
+          elementRelationship: atomic
+- name: io.k8s.api.rbac.v1beta1.RoleBinding
+  map:
+    fields:
+    - name: apiVersion
+      type:
+        scalar: string
+    - name: kind
+      type:
+        scalar: string
+    - name: metadata
+      type:
+        namedType: io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta
+        elementRelationship: granular
+    - name: roleRef
+      type:
+        namedType: io.k8s.api.rbac.v1beta1.RoleRef
+        elementRelationship: granular
+    - name: subjects
+      type:
+        list:
+          elementType:
+            namedType: io.k8s.api.rbac.v1beta1.Subject
+          elementRelationship: atomic
+- name: io.k8s.api.rbac.v1beta1.RoleBindingList
+  map:
+    fields:
+    - name: apiVersion
+      type:
+        scalar: string
+    - name: items
+      type:
+        list:
+          elementType:
+            namedType: io.k8s.api.rbac.v1beta1.RoleBinding
+          elementRelationship: atomic
+    - name: kind
+      type:
+        scalar: string
+    - name: metadata
+      type:
+        namedType: io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta
+        elementRelationship: granular
+- name: io.k8s.api.rbac.v1beta1.RoleList
+  map:
+    fields:
+    - name: apiVersion
+      type:
+        scalar: string
+    - name: items
+      type:
+        list:
+          elementType:
+            namedType: io.k8s.api.rbac.v1beta1.Role
+          elementRelationship: atomic
+    - name: kind
+      type:
+        scalar: string
+    - name: metadata
+      type:
+        namedType: io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta
+        elementRelationship: granular
+- name: io.k8s.api.rbac.v1beta1.RoleRef
+  map:
+    fields:
+    - name: apiGroup
+      type:
+        scalar: string
+    - name: kind
+      type:
+        scalar: string
+    - name: name
+      type:
+        scalar: string
+- name: io.k8s.api.rbac.v1beta1.Subject
+  map:
+    fields:
+    - name: apiGroup
+      type:
+        scalar: string
+    - name: kind
+      type:
+        scalar: string
+    - name: name
+      type:
+        scalar: string
+    - name: namespace
+      type:
+        scalar: string
+- name: io.k8s.api.scheduling.v1alpha1.PriorityClass
+  map:
+    fields:
+    - name: apiVersion
+      type:
+        scalar: string
+    - name: description
+      type:
+        scalar: string
+    - name: globalDefault
+      type:
+        scalar: boolean
+    - name: kind
+      type:
+        scalar: string
+    - name: metadata
+      type:
+        namedType: io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta
+        elementRelationship: granular
+    - name: value
+      type:
+        scalar: numeric
+- name: io.k8s.api.scheduling.v1alpha1.PriorityClassList
+  map:
+    fields:
+    - name: apiVersion
+      type:
+        scalar: string
+    - name: items
+      type:
+        list:
+          elementType:
+            namedType: io.k8s.api.scheduling.v1alpha1.PriorityClass
+          elementRelationship: atomic
+    - name: kind
+      type:
+        scalar: string
+    - name: metadata
+      type:
+        namedType: io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta
+        elementRelationship: granular
+- name: io.k8s.api.scheduling.v1beta1.PriorityClass
+  map:
+    fields:
+    - name: apiVersion
+      type:
+        scalar: string
+    - name: description
+      type:
+        scalar: string
+    - name: globalDefault
+      type:
+        scalar: boolean
+    - name: kind
+      type:
+        scalar: string
+    - name: metadata
+      type:
+        namedType: io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta
+        elementRelationship: granular
+    - name: value
+      type:
+        scalar: numeric
+- name: io.k8s.api.scheduling.v1beta1.PriorityClassList
+  map:
+    fields:
+    - name: apiVersion
+      type:
+        scalar: string
+    - name: items
+      type:
+        list:
+          elementType:
+            namedType: io.k8s.api.scheduling.v1beta1.PriorityClass
+          elementRelationship: atomic
+    - name: kind
+      type:
+        scalar: string
+    - name: metadata
+      type:
+        namedType: io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta
+        elementRelationship: granular
+- name: io.k8s.api.settings.v1alpha1.PodPreset
+  map:
+    fields:
+    - name: apiVersion
+      type:
+        scalar: string
+    - name: kind
+      type:
+        scalar: string
+    - name: metadata
+      type:
+        namedType: io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta
+        elementRelationship: granular
+    - name: spec
+      type:
+        namedType: io.k8s.api.settings.v1alpha1.PodPresetSpec
+        elementRelationship: granular
+- name: io.k8s.api.settings.v1alpha1.PodPresetList
+  map:
+    fields:
+    - name: apiVersion
+      type:
+        scalar: string
+    - name: items
+      type:
+        list:
+          elementType:
+            namedType: io.k8s.api.settings.v1alpha1.PodPreset
+          elementRelationship: atomic
+    - name: kind
+      type:
+        scalar: string
+    - name: metadata
+      type:
+        namedType: io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta
+        elementRelationship: granular
+- name: io.k8s.api.settings.v1alpha1.PodPresetSpec
+  map:
+    fields:
+    - name: env
+      type:
+        list:
+          elementType:
+            namedType: io.k8s.api.core.v1.EnvVar
+          elementRelationship: atomic
+    - name: envFrom
+      type:
+        list:
+          elementType:
+            namedType: io.k8s.api.core.v1.EnvFromSource
+          elementRelationship: atomic
+    - name: selector
+      type:
+        namedType: io.k8s.apimachinery.pkg.apis.meta.v1.LabelSelector
+        elementRelationship: granular
+    - name: volumeMounts
+      type:
+        list:
+          elementType:
+            namedType: io.k8s.api.core.v1.VolumeMount
+          elementRelationship: atomic
+    - name: volumes
+      type:
+        list:
+          elementType:
+            namedType: io.k8s.api.core.v1.Volume
+          elementRelationship: atomic
+- name: io.k8s.api.storage.v1.StorageClass
+  map:
+    fields:
+    - name: allowVolumeExpansion
+      type:
+        scalar: boolean
+    - name: allowedTopologies
+      type:
+        list:
+          elementType:
+            namedType: io.k8s.api.core.v1.TopologySelectorTerm
+          elementRelationship: atomic
+    - name: apiVersion
+      type:
+        scalar: string
+    - name: kind
+      type:
+        scalar: string
+    - name: metadata
+      type:
+        namedType: io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta
+        elementRelationship: granular
+    - name: mountOptions
+      type:
+        list:
+          elementType:
+            scalar: string
+          elementRelationship: atomic
+    - name: parameters
+      type:
+        map:
+          elementType:
+            scalar: string
+    - name: provisioner
+      type:
+        scalar: string
+    - name: reclaimPolicy
+      type:
+        scalar: string
+    - name: volumeBindingMode
+      type:
+        scalar: string
+- name: io.k8s.api.storage.v1.StorageClassList
+  map:
+    fields:
+    - name: apiVersion
+      type:
+        scalar: string
+    - name: items
+      type:
+        list:
+          elementType:
+            namedType: io.k8s.api.storage.v1.StorageClass
+          elementRelationship: atomic
+    - name: kind
+      type:
+        scalar: string
+    - name: metadata
+      type:
+        namedType: io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta
+        elementRelationship: granular
+- name: io.k8s.api.storage.v1alpha1.VolumeAttachment
+  map:
+    fields:
+    - name: apiVersion
+      type:
+        scalar: string
+    - name: kind
+      type:
+        scalar: string
+    - name: metadata
+      type:
+        namedType: io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta
+        elementRelationship: granular
+    - name: spec
+      type:
+        namedType: io.k8s.api.storage.v1alpha1.VolumeAttachmentSpec
+        elementRelationship: granular
+    - name: status
+      type:
+        namedType: io.k8s.api.storage.v1alpha1.VolumeAttachmentStatus
+        elementRelationship: granular
+- name: io.k8s.api.storage.v1alpha1.VolumeAttachmentList
+  map:
+    fields:
+    - name: apiVersion
+      type:
+        scalar: string
+    - name: items
+      type:
+        list:
+          elementType:
+            namedType: io.k8s.api.storage.v1alpha1.VolumeAttachment
+          elementRelationship: atomic
+    - name: kind
+      type:
+        scalar: string
+    - name: metadata
+      type:
+        namedType: io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta
+        elementRelationship: granular
+- name: io.k8s.api.storage.v1alpha1.VolumeAttachmentSource
+  map:
+    fields:
+    - name: persistentVolumeName
+      type:
+        scalar: string
+- name: io.k8s.api.storage.v1alpha1.VolumeAttachmentSpec
+  map:
+    fields:
+    - name: attacher
+      type:
+        scalar: string
+    - name: nodeName
+      type:
+        scalar: string
+    - name: source
+      type:
+        namedType: io.k8s.api.storage.v1alpha1.VolumeAttachmentSource
+        elementRelationship: granular
+- name: io.k8s.api.storage.v1alpha1.VolumeAttachmentStatus
+  map:
+    fields:
+    - name: attachError
+      type:
+        namedType: io.k8s.api.storage.v1alpha1.VolumeError
+        elementRelationship: granular
+    - name: attached
+      type:
+        scalar: boolean
+    - name: attachmentMetadata
+      type:
+        map:
+          elementType:
+            scalar: string
+    - name: detachError
+      type:
+        namedType: io.k8s.api.storage.v1alpha1.VolumeError
+        elementRelationship: granular
+- name: io.k8s.api.storage.v1alpha1.VolumeError
+  map:
+    fields:
+    - name: message
+      type:
+        scalar: string
+    - name: time
+      type:
+        namedType: io.k8s.apimachinery.pkg.apis.meta.v1.Time
+- name: io.k8s.api.storage.v1beta1.StorageClass
+  map:
+    fields:
+    - name: allowVolumeExpansion
+      type:
+        scalar: boolean
+    - name: allowedTopologies
+      type:
+        list:
+          elementType:
+            namedType: io.k8s.api.core.v1.TopologySelectorTerm
+          elementRelationship: atomic
+    - name: apiVersion
+      type:
+        scalar: string
+    - name: kind
+      type:
+        scalar: string
+    - name: metadata
+      type:
+        namedType: io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta
+        elementRelationship: granular
+    - name: mountOptions
+      type:
+        list:
+          elementType:
+            scalar: string
+          elementRelationship: atomic
+    - name: parameters
+      type:
+        map:
+          elementType:
+            scalar: string
+    - name: provisioner
+      type:
+        scalar: string
+    - name: reclaimPolicy
+      type:
+        scalar: string
+    - name: volumeBindingMode
+      type:
+        scalar: string
+- name: io.k8s.api.storage.v1beta1.StorageClassList
+  map:
+    fields:
+    - name: apiVersion
+      type:
+        scalar: string
+    - name: items
+      type:
+        list:
+          elementType:
+            namedType: io.k8s.api.storage.v1beta1.StorageClass
+          elementRelationship: atomic
+    - name: kind
+      type:
+        scalar: string
+    - name: metadata
+      type:
+        namedType: io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta
+        elementRelationship: granular
+- name: io.k8s.api.storage.v1beta1.VolumeAttachment
+  map:
+    fields:
+    - name: apiVersion
+      type:
+        scalar: string
+    - name: kind
+      type:
+        scalar: string
+    - name: metadata
+      type:
+        namedType: io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta
+        elementRelationship: granular
+    - name: spec
+      type:
+        namedType: io.k8s.api.storage.v1beta1.VolumeAttachmentSpec
+        elementRelationship: granular
+    - name: status
+      type:
+        namedType: io.k8s.api.storage.v1beta1.VolumeAttachmentStatus
+        elementRelationship: granular
+- name: io.k8s.api.storage.v1beta1.VolumeAttachmentList
+  map:
+    fields:
+    - name: apiVersion
+      type:
+        scalar: string
+    - name: items
+      type:
+        list:
+          elementType:
+            namedType: io.k8s.api.storage.v1beta1.VolumeAttachment
+          elementRelationship: atomic
+    - name: kind
+      type:
+        scalar: string
+    - name: metadata
+      type:
+        namedType: io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta
+        elementRelationship: granular
+- name: io.k8s.api.storage.v1beta1.VolumeAttachmentSource
+  map:
+    fields:
+    - name: persistentVolumeName
+      type:
+        scalar: string
+- name: io.k8s.api.storage.v1beta1.VolumeAttachmentSpec
+  map:
+    fields:
+    - name: attacher
+      type:
+        scalar: string
+    - name: nodeName
+      type:
+        scalar: string
+    - name: source
+      type:
+        namedType: io.k8s.api.storage.v1beta1.VolumeAttachmentSource
+        elementRelationship: granular
+- name: io.k8s.api.storage.v1beta1.VolumeAttachmentStatus
+  map:
+    fields:
+    - name: attachError
+      type:
+        namedType: io.k8s.api.storage.v1beta1.VolumeError
+        elementRelationship: granular
+    - name: attached
+      type:
+        scalar: boolean
+    - name: attachmentMetadata
+      type:
+        map:
+          elementType:
+            scalar: string
+    - name: detachError
+      type:
+        namedType: io.k8s.api.storage.v1beta1.VolumeError
+        elementRelationship: granular
+- name: io.k8s.api.storage.v1beta1.VolumeError
+  map:
+    fields:
+    - name: message
+      type:
+        scalar: string
+    - name: time
+      type:
+        namedType: io.k8s.apimachinery.pkg.apis.meta.v1.Time
+- name: io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1beta1.CustomResourceColumnDefinition
+  map:
+    fields:
+    - name: JSONPath
+      type:
+        scalar: string
+    - name: description
+      type:
+        scalar: string
+    - name: format
+      type:
+        scalar: string
+    - name: name
+      type:
+        scalar: string
+    - name: priority
+      type:
+        scalar: numeric
+    - name: type
+      type:
+        scalar: string
+- name: io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1beta1.CustomResourceDefinition
+  map:
+    fields:
+    - name: apiVersion
+      type:
+        scalar: string
+    - name: kind
+      type:
+        scalar: string
+    - name: metadata
+      type:
+        namedType: io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta
+        elementRelationship: granular
+    - name: spec
+      type:
+        namedType: io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1beta1.CustomResourceDefinitionSpec
+        elementRelationship: granular
+    - name: status
+      type:
+        namedType: io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1beta1.CustomResourceDefinitionStatus
+        elementRelationship: granular
+- name: io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1beta1.CustomResourceDefinitionCondition
+  map:
+    fields:
+    - name: lastTransitionTime
+      type:
+        namedType: io.k8s.apimachinery.pkg.apis.meta.v1.Time
+    - name: message
+      type:
+        scalar: string
+    - name: reason
+      type:
+        scalar: string
+    - name: status
+      type:
+        scalar: string
+    - name: type
+      type:
+        scalar: string
+- name: io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1beta1.CustomResourceDefinitionList
+  map:
+    fields:
+    - name: apiVersion
+      type:
+        scalar: string
+    - name: items
+      type:
+        list:
+          elementType:
+            namedType: io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1beta1.CustomResourceDefinition
+          elementRelationship: atomic
+    - name: kind
+      type:
+        scalar: string
+    - name: metadata
+      type:
+        namedType: io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta
+        elementRelationship: granular
+- name: io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1beta1.CustomResourceDefinitionNames
+  map:
+    fields:
+    - name: categories
+      type:
+        list:
+          elementType:
+            scalar: string
+          elementRelationship: atomic
+    - name: kind
+      type:
+        scalar: string
+    - name: listKind
+      type:
+        scalar: string
+    - name: plural
+      type:
+        scalar: string
+    - name: shortNames
+      type:
+        list:
+          elementType:
+            scalar: string
+          elementRelationship: atomic
+    - name: singular
+      type:
+        scalar: string
+- name: io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1beta1.CustomResourceDefinitionSpec
+  map:
+    fields:
+    - name: additionalPrinterColumns
+      type:
+        list:
+          elementType:
+            namedType: io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1beta1.CustomResourceColumnDefinition
+          elementRelationship: atomic
+    - name: group
+      type:
+        scalar: string
+    - name: names
+      type:
+        namedType: io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1beta1.CustomResourceDefinitionNames
+        elementRelationship: granular
+    - name: scope
+      type:
+        scalar: string
+    - name: subresources
+      type:
+        namedType: io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1beta1.CustomResourceSubresources
+        elementRelationship: granular
+    - name: validation
+      type:
+        namedType: io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1beta1.CustomResourceValidation
+        elementRelationship: granular
+    - name: version
+      type:
+        scalar: string
+    - name: versions
+      type:
+        list:
+          elementType:
+            namedType: io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1beta1.CustomResourceDefinitionVersion
+          elementRelationship: atomic
+- name: io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1beta1.CustomResourceDefinitionStatus
+  map:
+    fields:
+    - name: acceptedNames
+      type:
+        namedType: io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1beta1.CustomResourceDefinitionNames
+        elementRelationship: granular
+    - name: conditions
+      type:
+        list:
+          elementType:
+            namedType: io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1beta1.CustomResourceDefinitionCondition
+          elementRelationship: atomic
+    - name: storedVersions
+      type:
+        list:
+          elementType:
+            scalar: string
+          elementRelationship: atomic
+- name: io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1beta1.CustomResourceDefinitionVersion
+  map:
+    fields:
+    - name: name
+      type:
+        scalar: string
+    - name: served
+      type:
+        scalar: boolean
+    - name: storage
+      type:
+        scalar: boolean
+- name: io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1beta1.CustomResourceSubresourceScale
+  map:
+    fields:
+    - name: labelSelectorPath
+      type:
+        scalar: string
+    - name: specReplicasPath
+      type:
+        scalar: string
+    - name: statusReplicasPath
+      type:
+        scalar: string
+- name: io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1beta1.CustomResourceSubresourceStatus
+  scalar: untyped
+  list:
+    elementType:
+      namedType: __untyped_atomic_
+    elementRelationship: atomic
+  map:
+    elementType:
+      namedType: __untyped_atomic_
+    elementRelationship: atomic
+- name: io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1beta1.CustomResourceSubresources
+  map:
+    fields:
+    - name: scale
+      type:
+        namedType: io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1beta1.CustomResourceSubresourceScale
+        elementRelationship: granular
+    - name: status
+      type:
+        namedType: io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1beta1.CustomResourceSubresourceStatus
+        elementRelationship: granular
+- name: io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1beta1.CustomResourceValidation
+  map:
+    fields:
+    - name: openAPIV3Schema
+      type:
+        namedType: io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1beta1.JSONSchemaProps
+        elementRelationship: granular
+- name: io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1beta1.ExternalDocumentation
+  map:
+    fields:
+    - name: description
+      type:
+        scalar: string
+    - name: url
+      type:
+        scalar: string
+- name: io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1beta1.JSON
+  scalar: untyped
+  list:
+    elementType:
+      namedType: __untyped_atomic_
+    elementRelationship: atomic
+  map:
+    elementType:
+      namedType: __untyped_atomic_
+    elementRelationship: atomic
+- name: io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1beta1.JSONSchemaProps
+  map:
+    fields:
+    - name: $ref
+      type:
+        scalar: string
+    - name: $schema
+      type:
+        scalar: string
+    - name: additionalItems
+      type:
+        namedType: io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1beta1.JSONSchemaPropsOrBool
+        elementRelationship: granular
+    - name: additionalProperties
+      type:
+        namedType: io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1beta1.JSONSchemaPropsOrBool
+        elementRelationship: granular
+    - name: allOf
+      type:
+        list:
+          elementType:
+            namedType: io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1beta1.JSONSchemaProps
+          elementRelationship: atomic
+    - name: anyOf
+      type:
+        list:
+          elementType:
+            namedType: io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1beta1.JSONSchemaProps
+          elementRelationship: atomic
+    - name: default
+      type:
+        namedType: io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1beta1.JSON
+        elementRelationship: granular
+    - name: definitions
+      type:
+        map:
+          elementType:
+            namedType: io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1beta1.JSONSchemaProps
+    - name: dependencies
+      type:
+        map:
+          elementType:
+            namedType: io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1beta1.JSONSchemaPropsOrStringArray
+    - name: description
+      type:
+        scalar: string
+    - name: enum
+      type:
+        list:
+          elementType:
+            namedType: io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1beta1.JSON
+          elementRelationship: atomic
+    - name: example
+      type:
+        namedType: io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1beta1.JSON
+        elementRelationship: granular
+    - name: exclusiveMaximum
+      type:
+        scalar: boolean
+    - name: exclusiveMinimum
+      type:
+        scalar: boolean
+    - name: externalDocs
+      type:
+        namedType: io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1beta1.ExternalDocumentation
+        elementRelationship: granular
+    - name: format
+      type:
+        scalar: string
+    - name: id
+      type:
+        scalar: string
+    - name: items
+      type:
+        namedType: io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1beta1.JSONSchemaPropsOrArray
+        elementRelationship: granular
+    - name: maxItems
+      type:
+        scalar: numeric
+    - name: maxLength
+      type:
+        scalar: numeric
+    - name: maxProperties
+      type:
+        scalar: numeric
+    - name: maximum
+      type:
+        scalar: numeric
+    - name: minItems
+      type:
+        scalar: numeric
+    - name: minLength
+      type:
+        scalar: numeric
+    - name: minProperties
+      type:
+        scalar: numeric
+    - name: minimum
+      type:
+        scalar: numeric
+    - name: multipleOf
+      type:
+        scalar: numeric
+    - name: not
+      type:
+        namedType: io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1beta1.JSONSchemaProps
+        elementRelationship: granular
+    - name: oneOf
+      type:
+        list:
+          elementType:
+            namedType: io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1beta1.JSONSchemaProps
+          elementRelationship: atomic
+    - name: pattern
+      type:
+        scalar: string
+    - name: patternProperties
+      type:
+        map:
+          elementType:
+            namedType: io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1beta1.JSONSchemaProps
+    - name: properties
+      type:
+        map:
+          elementType:
+            namedType: io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1beta1.JSONSchemaProps
+    - name: required
+      type:
+        list:
+          elementType:
+            scalar: string
+          elementRelationship: atomic
+    - name: title
+      type:
+        scalar: string
+    - name: type
+      type:
+        scalar: string
+    - name: uniqueItems
+      type:
+        scalar: boolean
+- name: io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1beta1.JSONSchemaPropsOrArray
+  scalar: untyped
+  list:
+    elementType:
+      namedType: __untyped_atomic_
+    elementRelationship: atomic
+  map:
+    elementType:
+      namedType: __untyped_atomic_
+    elementRelationship: atomic
+- name: io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1beta1.JSONSchemaPropsOrBool
+  scalar: untyped
+  list:
+    elementType:
+      namedType: __untyped_atomic_
+    elementRelationship: atomic
+  map:
+    elementType:
+      namedType: __untyped_atomic_
+    elementRelationship: atomic
+- name: io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1beta1.JSONSchemaPropsOrStringArray
+  scalar: untyped
+  list:
+    elementType:
+      namedType: __untyped_atomic_
+    elementRelationship: atomic
+  map:
+    elementType:
+      namedType: __untyped_atomic_
+    elementRelationship: atomic
+- name: io.k8s.apimachinery.pkg.api.resource.Quantity
+  scalar: string
+- name: io.k8s.apimachinery.pkg.apis.meta.v1.APIGroup
+  map:
+    fields:
+    - name: apiVersion
+      type:
+        scalar: string
+    - name: kind
+      type:
+        scalar: string
+    - name: name
+      type:
+        scalar: string
+    - name: preferredVersion
+      type:
+        namedType: io.k8s.apimachinery.pkg.apis.meta.v1.GroupVersionForDiscovery
+        elementRelationship: granular
+    - name: serverAddressByClientCIDRs
+      type:
+        list:
+          elementType:
+            namedType: io.k8s.apimachinery.pkg.apis.meta.v1.ServerAddressByClientCIDR
+          elementRelationship: atomic
+    - name: versions
+      type:
+        list:
+          elementType:
+            namedType: io.k8s.apimachinery.pkg.apis.meta.v1.GroupVersionForDiscovery
+          elementRelationship: atomic
+- name: io.k8s.apimachinery.pkg.apis.meta.v1.APIGroupList
+  map:
+    fields:
+    - name: apiVersion
+      type:
+        scalar: string
+    - name: groups
+      type:
+        list:
+          elementType:
+            namedType: io.k8s.apimachinery.pkg.apis.meta.v1.APIGroup
+          elementRelationship: atomic
+    - name: kind
+      type:
+        scalar: string
+- name: io.k8s.apimachinery.pkg.apis.meta.v1.APIResource
+  map:
+    fields:
+    - name: categories
+      type:
+        list:
+          elementType:
+            scalar: string
+          elementRelationship: atomic
+    - name: group
+      type:
+        scalar: string
+    - name: kind
+      type:
+        scalar: string
+    - name: name
+      type:
+        scalar: string
+    - name: namespaced
+      type:
+        scalar: boolean
+    - name: shortNames
+      type:
+        list:
+          elementType:
+            scalar: string
+          elementRelationship: atomic
+    - name: singularName
+      type:
+        scalar: string
+    - name: verbs
+      type:
+        list:
+          elementType:
+            scalar: string
+          elementRelationship: atomic
+    - name: version
+      type:
+        scalar: string
+- name: io.k8s.apimachinery.pkg.apis.meta.v1.APIResourceList
+  map:
+    fields:
+    - name: apiVersion
+      type:
+        scalar: string
+    - name: groupVersion
+      type:
+        scalar: string
+    - name: kind
+      type:
+        scalar: string
+    - name: resources
+      type:
+        list:
+          elementType:
+            namedType: io.k8s.apimachinery.pkg.apis.meta.v1.APIResource
+          elementRelationship: atomic
+- name: io.k8s.apimachinery.pkg.apis.meta.v1.APIVersions
+  map:
+    fields:
+    - name: apiVersion
+      type:
+        scalar: string
+    - name: kind
+      type:
+        scalar: string
+    - name: serverAddressByClientCIDRs
+      type:
+        list:
+          elementType:
+            namedType: io.k8s.apimachinery.pkg.apis.meta.v1.ServerAddressByClientCIDR
+          elementRelationship: atomic
+    - name: versions
+      type:
+        list:
+          elementType:
+            scalar: string
+          elementRelationship: atomic
+- name: io.k8s.apimachinery.pkg.apis.meta.v1.DeleteOptions
+  map:
+    fields:
+    - name: apiVersion
+      type:
+        scalar: string
+    - name: dryRun
+      type:
+        list:
+          elementType:
+            scalar: string
+          elementRelationship: atomic
+    - name: gracePeriodSeconds
+      type:
+        scalar: numeric
+    - name: kind
+      type:
+        scalar: string
+    - name: orphanDependents
+      type:
+        scalar: boolean
+    - name: preconditions
+      type:
+        namedType: io.k8s.apimachinery.pkg.apis.meta.v1.Preconditions
+        elementRelationship: granular
+    - name: propagationPolicy
+      type:
+        scalar: string
+- name: io.k8s.apimachinery.pkg.apis.meta.v1.GroupVersionForDiscovery
+  map:
+    fields:
+    - name: groupVersion
+      type:
+        scalar: string
+    - name: version
+      type:
+        scalar: string
+- name: io.k8s.apimachinery.pkg.apis.meta.v1.Initializer
+  map:
+    fields:
+    - name: name
+      type:
+        scalar: string
+- name: io.k8s.apimachinery.pkg.apis.meta.v1.Initializers
+  map:
+    fields:
+    - name: pending
+      type:
+        list:
+          elementType:
+            namedType: io.k8s.apimachinery.pkg.apis.meta.v1.Initializer
+          elementRelationship: associative
+          keys:
+          - name
+    - name: result
+      type:
+        namedType: io.k8s.apimachinery.pkg.apis.meta.v1.Status
+        elementRelationship: granular
+- name: io.k8s.apimachinery.pkg.apis.meta.v1.LabelSelector
+  map:
+    fields:
+    - name: matchExpressions
+      type:
+        list:
+          elementType:
+            namedType: io.k8s.apimachinery.pkg.apis.meta.v1.LabelSelectorRequirement
+          elementRelationship: atomic
+    - name: matchLabels
+      type:
+        map:
+          elementType:
+            scalar: string
+- name: io.k8s.apimachinery.pkg.apis.meta.v1.LabelSelectorRequirement
+  map:
+    fields:
+    - name: key
+      type:
+        scalar: string
+    - name: operator
+      type:
+        scalar: string
+    - name: values
+      type:
+        list:
+          elementType:
+            scalar: string
+          elementRelationship: atomic
+- name: io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta
+  map:
+    fields:
+    - name: continue
+      type:
+        scalar: string
+    - name: resourceVersion
+      type:
+        scalar: string
+    - name: selfLink
+      type:
+        scalar: string
+- name: io.k8s.apimachinery.pkg.apis.meta.v1.MicroTime
+  scalar: untyped
+- name: io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta
+  map:
+    fields:
+    - name: annotations
+      type:
+        map:
+          elementType:
+            scalar: string
+    - name: clusterName
+      type:
+        scalar: string
+    - name: creationTimestamp
+      type:
+        namedType: io.k8s.apimachinery.pkg.apis.meta.v1.Time
+    - name: deletionGracePeriodSeconds
+      type:
+        scalar: numeric
+    - name: deletionTimestamp
+      type:
+        namedType: io.k8s.apimachinery.pkg.apis.meta.v1.Time
+    - name: finalizers
+      type:
+        list:
+          elementType:
+            scalar: string
+          elementRelationship: associative
+    - name: generateName
+      type:
+        scalar: string
+    - name: generation
+      type:
+        scalar: numeric
+    - name: initializers
+      type:
+        namedType: io.k8s.apimachinery.pkg.apis.meta.v1.Initializers
+        elementRelationship: granular
+    - name: labels
+      type:
+        map:
+          elementType:
+            scalar: string
+    - name: name
+      type:
+        scalar: string
+    - name: namespace
+      type:
+        scalar: string
+    - name: ownerReferences
+      type:
+        list:
+          elementType:
+            namedType: io.k8s.apimachinery.pkg.apis.meta.v1.OwnerReference
+          elementRelationship: associative
+          keys:
+          - uid
+    - name: resourceVersion
+      type:
+        scalar: string
+    - name: selfLink
+      type:
+        scalar: string
+    - name: uid
+      type:
+        scalar: string
+- name: io.k8s.apimachinery.pkg.apis.meta.v1.OwnerReference
+  map:
+    fields:
+    - name: apiVersion
+      type:
+        scalar: string
+    - name: blockOwnerDeletion
+      type:
+        scalar: boolean
+    - name: controller
+      type:
+        scalar: boolean
+    - name: kind
+      type:
+        scalar: string
+    - name: name
+      type:
+        scalar: string
+    - name: uid
+      type:
+        scalar: string
+- name: io.k8s.apimachinery.pkg.apis.meta.v1.Patch
+  scalar: untyped
+  list:
+    elementType:
+      namedType: __untyped_atomic_
+    elementRelationship: atomic
+  map:
+    elementType:
+      namedType: __untyped_atomic_
+    elementRelationship: atomic
+- name: io.k8s.apimachinery.pkg.apis.meta.v1.Preconditions
+  map:
+    fields:
+    - name: uid
+      type:
+        scalar: string
+- name: io.k8s.apimachinery.pkg.apis.meta.v1.ServerAddressByClientCIDR
+  map:
+    fields:
+    - name: clientCIDR
+      type:
+        scalar: string
+    - name: serverAddress
+      type:
+        scalar: string
+- name: io.k8s.apimachinery.pkg.apis.meta.v1.Status
+  map:
+    fields:
+    - name: apiVersion
+      type:
+        scalar: string
+    - name: code
+      type:
+        scalar: numeric
+    - name: details
+      type:
+        namedType: io.k8s.apimachinery.pkg.apis.meta.v1.StatusDetails
+        elementRelationship: granular
+    - name: kind
+      type:
+        scalar: string
+    - name: message
+      type:
+        scalar: string
+    - name: metadata
+      type:
+        namedType: io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta
+        elementRelationship: granular
+    - name: reason
+      type:
+        scalar: string
+    - name: status
+      type:
+        scalar: string
+- name: io.k8s.apimachinery.pkg.apis.meta.v1.StatusCause
+  map:
+    fields:
+    - name: field
+      type:
+        scalar: string
+    - name: message
+      type:
+        scalar: string
+    - name: reason
+      type:
+        scalar: string
+- name: io.k8s.apimachinery.pkg.apis.meta.v1.StatusDetails
+  map:
+    fields:
+    - name: causes
+      type:
+        list:
+          elementType:
+            namedType: io.k8s.apimachinery.pkg.apis.meta.v1.StatusCause
+          elementRelationship: atomic
+    - name: group
+      type:
+        scalar: string
+    - name: kind
+      type:
+        scalar: string
+    - name: name
+      type:
+        scalar: string
+    - name: retryAfterSeconds
+      type:
+        scalar: numeric
+    - name: uid
+      type:
+        scalar: string
+- name: io.k8s.apimachinery.pkg.apis.meta.v1.Time
+  scalar: untyped
+- name: io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent
+  map:
+    fields:
+    - name: object
+      type:
+        namedType: __untyped_atomic_
+        elementRelationship: granular
+    - name: type
+      type:
+        scalar: string
+- name: io.k8s.apimachinery.pkg.runtime.RawExtension
+  map:
+    fields:
+    - name: Raw
+      type:
+        scalar: string
+- name: io.k8s.apimachinery.pkg.util.intstr.IntOrString
+  scalar: untyped
+- name: io.k8s.apimachinery.pkg.version.Info
+  map:
+    fields:
+    - name: buildDate
+      type:
+        scalar: string
+    - name: compiler
+      type:
+        scalar: string
+    - name: gitCommit
+      type:
+        scalar: string
+    - name: gitTreeState
+      type:
+        scalar: string
+    - name: gitVersion
+      type:
+        scalar: string
+    - name: goVersion
+      type:
+        scalar: string
+    - name: major
+      type:
+        scalar: string
+    - name: minor
+      type:
+        scalar: string
+    - name: platform
+      type:
+        scalar: string
+- name: io.k8s.kube-aggregator.pkg.apis.apiregistration.v1.APIService
+  map:
+    fields:
+    - name: apiVersion
+      type:
+        scalar: string
+    - name: kind
+      type:
+        scalar: string
+    - name: metadata
+      type:
+        namedType: io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta
+        elementRelationship: granular
+    - name: spec
+      type:
+        namedType: io.k8s.kube-aggregator.pkg.apis.apiregistration.v1.APIServiceSpec
+        elementRelationship: granular
+    - name: status
+      type:
+        namedType: io.k8s.kube-aggregator.pkg.apis.apiregistration.v1.APIServiceStatus
+        elementRelationship: granular
+- name: io.k8s.kube-aggregator.pkg.apis.apiregistration.v1.APIServiceCondition
+  map:
+    fields:
+    - name: lastTransitionTime
+      type:
+        namedType: io.k8s.apimachinery.pkg.apis.meta.v1.Time
+    - name: message
+      type:
+        scalar: string
+    - name: reason
+      type:
+        scalar: string
+    - name: status
+      type:
+        scalar: string
+    - name: type
+      type:
+        scalar: string
+- name: io.k8s.kube-aggregator.pkg.apis.apiregistration.v1.APIServiceList
+  map:
+    fields:
+    - name: apiVersion
+      type:
+        scalar: string
+    - name: items
+      type:
+        list:
+          elementType:
+            namedType: io.k8s.kube-aggregator.pkg.apis.apiregistration.v1.APIService
+          elementRelationship: atomic
+    - name: kind
+      type:
+        scalar: string
+    - name: metadata
+      type:
+        namedType: io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta
+        elementRelationship: granular
+- name: io.k8s.kube-aggregator.pkg.apis.apiregistration.v1.APIServiceSpec
+  map:
+    fields:
+    - name: caBundle
+      type:
+        scalar: string
+    - name: group
+      type:
+        scalar: string
+    - name: groupPriorityMinimum
+      type:
+        scalar: numeric
+    - name: insecureSkipTLSVerify
+      type:
+        scalar: boolean
+    - name: service
+      type:
+        namedType: io.k8s.kube-aggregator.pkg.apis.apiregistration.v1.ServiceReference
+        elementRelationship: granular
+    - name: version
+      type:
+        scalar: string
+    - name: versionPriority
+      type:
+        scalar: numeric
+- name: io.k8s.kube-aggregator.pkg.apis.apiregistration.v1.APIServiceStatus
+  map:
+    fields:
+    - name: conditions
+      type:
+        list:
+          elementType:
+            namedType: io.k8s.kube-aggregator.pkg.apis.apiregistration.v1.APIServiceCondition
+          elementRelationship: associative
+          keys:
+          - type
+- name: io.k8s.kube-aggregator.pkg.apis.apiregistration.v1.ServiceReference
+  map:
+    fields:
+    - name: name
+      type:
+        scalar: string
+    - name: namespace
+      type:
+        scalar: string
+- name: io.k8s.kube-aggregator.pkg.apis.apiregistration.v1beta1.APIService
+  map:
+    fields:
+    - name: apiVersion
+      type:
+        scalar: string
+    - name: kind
+      type:
+        scalar: string
+    - name: metadata
+      type:
+        namedType: io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta
+        elementRelationship: granular
+    - name: spec
+      type:
+        namedType: io.k8s.kube-aggregator.pkg.apis.apiregistration.v1beta1.APIServiceSpec
+        elementRelationship: granular
+    - name: status
+      type:
+        namedType: io.k8s.kube-aggregator.pkg.apis.apiregistration.v1beta1.APIServiceStatus
+        elementRelationship: granular
+- name: io.k8s.kube-aggregator.pkg.apis.apiregistration.v1beta1.APIServiceCondition
+  map:
+    fields:
+    - name: lastTransitionTime
+      type:
+        namedType: io.k8s.apimachinery.pkg.apis.meta.v1.Time
+    - name: message
+      type:
+        scalar: string
+    - name: reason
+      type:
+        scalar: string
+    - name: status
+      type:
+        scalar: string
+    - name: type
+      type:
+        scalar: string
+- name: io.k8s.kube-aggregator.pkg.apis.apiregistration.v1beta1.APIServiceList
+  map:
+    fields:
+    - name: apiVersion
+      type:
+        scalar: string
+    - name: items
+      type:
+        list:
+          elementType:
+            namedType: io.k8s.kube-aggregator.pkg.apis.apiregistration.v1beta1.APIService
+          elementRelationship: atomic
+    - name: kind
+      type:
+        scalar: string
+    - name: metadata
+      type:
+        namedType: io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta
+        elementRelationship: granular
+- name: io.k8s.kube-aggregator.pkg.apis.apiregistration.v1beta1.APIServiceSpec
+  map:
+    fields:
+    - name: caBundle
+      type:
+        scalar: string
+    - name: group
+      type:
+        scalar: string
+    - name: groupPriorityMinimum
+      type:
+        scalar: numeric
+    - name: insecureSkipTLSVerify
+      type:
+        scalar: boolean
+    - name: service
+      type:
+        namedType: io.k8s.kube-aggregator.pkg.apis.apiregistration.v1beta1.ServiceReference
+        elementRelationship: granular
+    - name: version
+      type:
+        scalar: string
+    - name: versionPriority
+      type:
+        scalar: numeric
+- name: io.k8s.kube-aggregator.pkg.apis.apiregistration.v1beta1.APIServiceStatus
+  map:
+    fields:
+    - name: conditions
+      type:
+        list:
+          elementType:
+            namedType: io.k8s.kube-aggregator.pkg.apis.apiregistration.v1beta1.APIServiceCondition
+          elementRelationship: associative
+          keys:
+          - type
+- name: io.k8s.kube-aggregator.pkg.apis.apiregistration.v1beta1.ServiceReference
+  map:
+    fields:
+    - name: name
+      type:
+        scalar: string
+    - name: namespace
+      type:
+        scalar: string
+- name: __untyped_atomic_
+  scalar: untyped
+  list:
+    elementType:
+      namedType: __untyped_atomic_
+    elementRelationship: atomic
+  map:
+    elementType:
+      namedType: __untyped_atomic_
+    elementRelationship: atomic

--- a/internal/testdata/k8s-schema-10pct-fieldoverride.yaml
+++ b/internal/testdata/k8s-schema-10pct-fieldoverride.yaml
@@ -1,0 +1,10323 @@
+types:
+- name: io.k8s.api.admissionregistration.v1alpha1.Initializer
+  map:
+    fields:
+    - name: name
+      type:
+        scalar: string
+    - name: rules
+      type:
+        list:
+          elementType:
+            namedType: io.k8s.api.admissionregistration.v1alpha1.Rule
+          elementRelationship: atomic
+- name: io.k8s.api.admissionregistration.v1alpha1.InitializerConfiguration
+  map:
+    fields:
+    - name: apiVersion
+      type:
+        scalar: string
+    - name: initializers
+      type:
+        list:
+          elementType:
+            namedType: io.k8s.api.admissionregistration.v1alpha1.Initializer
+          elementRelationship: associative
+          keys:
+          - name
+    - name: kind
+      type:
+        scalar: string
+    - name: metadata
+      type:
+        namedType: io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta
+- name: io.k8s.api.admissionregistration.v1alpha1.InitializerConfigurationList
+  map:
+    fields:
+    - name: apiVersion
+      type:
+        scalar: string
+    - name: items
+      type:
+        list:
+          elementType:
+            namedType: io.k8s.api.admissionregistration.v1alpha1.InitializerConfiguration
+          elementRelationship: atomic
+    - name: kind
+      type:
+        scalar: string
+    - name: metadata
+      type:
+        namedType: io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta
+        elementRelationship: granular
+- name: io.k8s.api.admissionregistration.v1alpha1.Rule
+  map:
+    fields:
+    - name: apiGroups
+      type:
+        list:
+          elementType:
+            scalar: string
+          elementRelationship: atomic
+    - name: apiVersions
+      type:
+        list:
+          elementType:
+            scalar: string
+          elementRelationship: atomic
+    - name: resources
+      type:
+        list:
+          elementType:
+            scalar: string
+          elementRelationship: atomic
+- name: io.k8s.api.admissionregistration.v1beta1.MutatingWebhookConfiguration
+  map:
+    fields:
+    - name: apiVersion
+      type:
+        scalar: string
+    - name: kind
+      type:
+        scalar: string
+    - name: metadata
+      type:
+        namedType: io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta
+    - name: webhooks
+      type:
+        list:
+          elementType:
+            namedType: io.k8s.api.admissionregistration.v1beta1.Webhook
+          elementRelationship: associative
+          keys:
+          - name
+- name: io.k8s.api.admissionregistration.v1beta1.MutatingWebhookConfigurationList
+  map:
+    fields:
+    - name: apiVersion
+      type:
+        scalar: string
+    - name: items
+      type:
+        list:
+          elementType:
+            namedType: io.k8s.api.admissionregistration.v1beta1.MutatingWebhookConfiguration
+          elementRelationship: atomic
+    - name: kind
+      type:
+        scalar: string
+    - name: metadata
+      type:
+        namedType: io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta
+- name: io.k8s.api.admissionregistration.v1beta1.RuleWithOperations
+  map:
+    fields:
+    - name: apiGroups
+      type:
+        list:
+          elementType:
+            scalar: string
+          elementRelationship: atomic
+    - name: apiVersions
+      type:
+        list:
+          elementType:
+            scalar: string
+          elementRelationship: atomic
+    - name: operations
+      type:
+        list:
+          elementType:
+            scalar: string
+          elementRelationship: atomic
+    - name: resources
+      type:
+        list:
+          elementType:
+            scalar: string
+          elementRelationship: atomic
+- name: io.k8s.api.admissionregistration.v1beta1.ServiceReference
+  map:
+    fields:
+    - name: name
+      type:
+        scalar: string
+    - name: namespace
+      type:
+        scalar: string
+    - name: path
+      type:
+        scalar: string
+- name: io.k8s.api.admissionregistration.v1beta1.ValidatingWebhookConfiguration
+  map:
+    fields:
+    - name: apiVersion
+      type:
+        scalar: string
+    - name: kind
+      type:
+        scalar: string
+    - name: metadata
+      type:
+        namedType: io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta
+    - name: webhooks
+      type:
+        list:
+          elementType:
+            namedType: io.k8s.api.admissionregistration.v1beta1.Webhook
+          elementRelationship: associative
+          keys:
+          - name
+- name: io.k8s.api.admissionregistration.v1beta1.ValidatingWebhookConfigurationList
+  map:
+    fields:
+    - name: apiVersion
+      type:
+        scalar: string
+    - name: items
+      type:
+        list:
+          elementType:
+            namedType: io.k8s.api.admissionregistration.v1beta1.ValidatingWebhookConfiguration
+          elementRelationship: atomic
+    - name: kind
+      type:
+        scalar: string
+    - name: metadata
+      type:
+        namedType: io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta
+- name: io.k8s.api.admissionregistration.v1beta1.Webhook
+  map:
+    fields:
+    - name: clientConfig
+      type:
+        namedType: io.k8s.api.admissionregistration.v1beta1.WebhookClientConfig
+    - name: failurePolicy
+      type:
+        scalar: string
+    - name: name
+      type:
+        scalar: string
+    - name: namespaceSelector
+      type:
+        namedType: io.k8s.apimachinery.pkg.apis.meta.v1.LabelSelector
+    - name: rules
+      type:
+        list:
+          elementType:
+            namedType: io.k8s.api.admissionregistration.v1beta1.RuleWithOperations
+          elementRelationship: atomic
+    - name: sideEffects
+      type:
+        scalar: string
+- name: io.k8s.api.admissionregistration.v1beta1.WebhookClientConfig
+  map:
+    fields:
+    - name: caBundle
+      type:
+        scalar: string
+    - name: service
+      type:
+        namedType: io.k8s.api.admissionregistration.v1beta1.ServiceReference
+        elementRelationship: granular
+    - name: url
+      type:
+        scalar: string
+- name: io.k8s.api.apps.v1.ControllerRevision
+  map:
+    fields:
+    - name: apiVersion
+      type:
+        scalar: string
+    - name: data
+      type:
+        namedType: __untyped_atomic_
+    - name: kind
+      type:
+        scalar: string
+    - name: metadata
+      type:
+        namedType: io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta
+    - name: revision
+      type:
+        scalar: numeric
+- name: io.k8s.api.apps.v1.ControllerRevisionList
+  map:
+    fields:
+    - name: apiVersion
+      type:
+        scalar: string
+    - name: items
+      type:
+        list:
+          elementType:
+            namedType: io.k8s.api.apps.v1.ControllerRevision
+          elementRelationship: atomic
+    - name: kind
+      type:
+        scalar: string
+    - name: metadata
+      type:
+        namedType: io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta
+- name: io.k8s.api.apps.v1.DaemonSet
+  map:
+    fields:
+    - name: apiVersion
+      type:
+        scalar: string
+    - name: kind
+      type:
+        scalar: string
+    - name: metadata
+      type:
+        namedType: io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta
+    - name: spec
+      type:
+        namedType: io.k8s.api.apps.v1.DaemonSetSpec
+    - name: status
+      type:
+        namedType: io.k8s.api.apps.v1.DaemonSetStatus
+- name: io.k8s.api.apps.v1.DaemonSetCondition
+  map:
+    fields:
+    - name: lastTransitionTime
+      type:
+        namedType: io.k8s.apimachinery.pkg.apis.meta.v1.Time
+    - name: message
+      type:
+        scalar: string
+    - name: reason
+      type:
+        scalar: string
+    - name: status
+      type:
+        scalar: string
+    - name: type
+      type:
+        scalar: string
+- name: io.k8s.api.apps.v1.DaemonSetList
+  map:
+    fields:
+    - name: apiVersion
+      type:
+        scalar: string
+    - name: items
+      type:
+        list:
+          elementType:
+            namedType: io.k8s.api.apps.v1.DaemonSet
+          elementRelationship: atomic
+    - name: kind
+      type:
+        scalar: string
+    - name: metadata
+      type:
+        namedType: io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta
+- name: io.k8s.api.apps.v1.DaemonSetSpec
+  map:
+    fields:
+    - name: minReadySeconds
+      type:
+        scalar: numeric
+    - name: revisionHistoryLimit
+      type:
+        scalar: numeric
+    - name: selector
+      type:
+        namedType: io.k8s.apimachinery.pkg.apis.meta.v1.LabelSelector
+        elementRelationship: granular
+    - name: template
+      type:
+        namedType: io.k8s.api.core.v1.PodTemplateSpec
+    - name: updateStrategy
+      type:
+        namedType: io.k8s.api.apps.v1.DaemonSetUpdateStrategy
+- name: io.k8s.api.apps.v1.DaemonSetStatus
+  map:
+    fields:
+    - name: collisionCount
+      type:
+        scalar: numeric
+    - name: conditions
+      type:
+        list:
+          elementType:
+            namedType: io.k8s.api.apps.v1.DaemonSetCondition
+          elementRelationship: associative
+          keys:
+          - type
+    - name: currentNumberScheduled
+      type:
+        scalar: numeric
+    - name: desiredNumberScheduled
+      type:
+        scalar: numeric
+    - name: numberAvailable
+      type:
+        scalar: numeric
+    - name: numberMisscheduled
+      type:
+        scalar: numeric
+    - name: numberReady
+      type:
+        scalar: numeric
+    - name: numberUnavailable
+      type:
+        scalar: numeric
+    - name: observedGeneration
+      type:
+        scalar: numeric
+    - name: updatedNumberScheduled
+      type:
+        scalar: numeric
+- name: io.k8s.api.apps.v1.DaemonSetUpdateStrategy
+  map:
+    fields:
+    - name: rollingUpdate
+      type:
+        namedType: io.k8s.api.apps.v1.RollingUpdateDaemonSet
+    - name: type
+      type:
+        scalar: string
+- name: io.k8s.api.apps.v1.Deployment
+  map:
+    fields:
+    - name: apiVersion
+      type:
+        scalar: string
+    - name: kind
+      type:
+        scalar: string
+    - name: metadata
+      type:
+        namedType: io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta
+    - name: spec
+      type:
+        namedType: io.k8s.api.apps.v1.DeploymentSpec
+    - name: status
+      type:
+        namedType: io.k8s.api.apps.v1.DeploymentStatus
+- name: io.k8s.api.apps.v1.DeploymentCondition
+  map:
+    fields:
+    - name: lastTransitionTime
+      type:
+        namedType: io.k8s.apimachinery.pkg.apis.meta.v1.Time
+    - name: lastUpdateTime
+      type:
+        namedType: io.k8s.apimachinery.pkg.apis.meta.v1.Time
+    - name: message
+      type:
+        scalar: string
+    - name: reason
+      type:
+        scalar: string
+    - name: status
+      type:
+        scalar: string
+    - name: type
+      type:
+        scalar: string
+- name: io.k8s.api.apps.v1.DeploymentList
+  map:
+    fields:
+    - name: apiVersion
+      type:
+        scalar: string
+    - name: items
+      type:
+        list:
+          elementType:
+            namedType: io.k8s.api.apps.v1.Deployment
+          elementRelationship: atomic
+    - name: kind
+      type:
+        scalar: string
+    - name: metadata
+      type:
+        namedType: io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta
+- name: io.k8s.api.apps.v1.DeploymentSpec
+  map:
+    fields:
+    - name: minReadySeconds
+      type:
+        scalar: numeric
+    - name: paused
+      type:
+        scalar: boolean
+    - name: progressDeadlineSeconds
+      type:
+        scalar: numeric
+    - name: replicas
+      type:
+        scalar: numeric
+    - name: revisionHistoryLimit
+      type:
+        scalar: numeric
+    - name: selector
+      type:
+        namedType: io.k8s.apimachinery.pkg.apis.meta.v1.LabelSelector
+    - name: strategy
+      type:
+        namedType: io.k8s.api.apps.v1.DeploymentStrategy
+    - name: template
+      type:
+        namedType: io.k8s.api.core.v1.PodTemplateSpec
+- name: io.k8s.api.apps.v1.DeploymentStatus
+  map:
+    fields:
+    - name: availableReplicas
+      type:
+        scalar: numeric
+    - name: collisionCount
+      type:
+        scalar: numeric
+    - name: conditions
+      type:
+        list:
+          elementType:
+            namedType: io.k8s.api.apps.v1.DeploymentCondition
+          elementRelationship: associative
+          keys:
+          - type
+    - name: observedGeneration
+      type:
+        scalar: numeric
+    - name: readyReplicas
+      type:
+        scalar: numeric
+    - name: replicas
+      type:
+        scalar: numeric
+    - name: unavailableReplicas
+      type:
+        scalar: numeric
+    - name: updatedReplicas
+      type:
+        scalar: numeric
+- name: io.k8s.api.apps.v1.DeploymentStrategy
+  map:
+    fields:
+    - name: rollingUpdate
+      type:
+        namedType: io.k8s.api.apps.v1.RollingUpdateDeployment
+        elementRelationship: granular
+    - name: type
+      type:
+        scalar: string
+- name: io.k8s.api.apps.v1.ReplicaSet
+  map:
+    fields:
+    - name: apiVersion
+      type:
+        scalar: string
+    - name: kind
+      type:
+        scalar: string
+    - name: metadata
+      type:
+        namedType: io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta
+    - name: spec
+      type:
+        namedType: io.k8s.api.apps.v1.ReplicaSetSpec
+    - name: status
+      type:
+        namedType: io.k8s.api.apps.v1.ReplicaSetStatus
+- name: io.k8s.api.apps.v1.ReplicaSetCondition
+  map:
+    fields:
+    - name: lastTransitionTime
+      type:
+        namedType: io.k8s.apimachinery.pkg.apis.meta.v1.Time
+    - name: message
+      type:
+        scalar: string
+    - name: reason
+      type:
+        scalar: string
+    - name: status
+      type:
+        scalar: string
+    - name: type
+      type:
+        scalar: string
+- name: io.k8s.api.apps.v1.ReplicaSetList
+  map:
+    fields:
+    - name: apiVersion
+      type:
+        scalar: string
+    - name: items
+      type:
+        list:
+          elementType:
+            namedType: io.k8s.api.apps.v1.ReplicaSet
+          elementRelationship: atomic
+    - name: kind
+      type:
+        scalar: string
+    - name: metadata
+      type:
+        namedType: io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta
+- name: io.k8s.api.apps.v1.ReplicaSetSpec
+  map:
+    fields:
+    - name: minReadySeconds
+      type:
+        scalar: numeric
+    - name: replicas
+      type:
+        scalar: numeric
+    - name: selector
+      type:
+        namedType: io.k8s.apimachinery.pkg.apis.meta.v1.LabelSelector
+    - name: template
+      type:
+        namedType: io.k8s.api.core.v1.PodTemplateSpec
+- name: io.k8s.api.apps.v1.ReplicaSetStatus
+  map:
+    fields:
+    - name: availableReplicas
+      type:
+        scalar: numeric
+    - name: conditions
+      type:
+        list:
+          elementType:
+            namedType: io.k8s.api.apps.v1.ReplicaSetCondition
+          elementRelationship: associative
+          keys:
+          - type
+    - name: fullyLabeledReplicas
+      type:
+        scalar: numeric
+    - name: observedGeneration
+      type:
+        scalar: numeric
+    - name: readyReplicas
+      type:
+        scalar: numeric
+    - name: replicas
+      type:
+        scalar: numeric
+- name: io.k8s.api.apps.v1.RollingUpdateDaemonSet
+  map:
+    fields:
+    - name: maxUnavailable
+      type:
+        namedType: io.k8s.apimachinery.pkg.util.intstr.IntOrString
+- name: io.k8s.api.apps.v1.RollingUpdateDeployment
+  map:
+    fields:
+    - name: maxSurge
+      type:
+        namedType: io.k8s.apimachinery.pkg.util.intstr.IntOrString
+    - name: maxUnavailable
+      type:
+        namedType: io.k8s.apimachinery.pkg.util.intstr.IntOrString
+- name: io.k8s.api.apps.v1.RollingUpdateStatefulSetStrategy
+  map:
+    fields:
+    - name: partition
+      type:
+        scalar: numeric
+- name: io.k8s.api.apps.v1.StatefulSet
+  map:
+    fields:
+    - name: apiVersion
+      type:
+        scalar: string
+    - name: kind
+      type:
+        scalar: string
+    - name: metadata
+      type:
+        namedType: io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta
+        elementRelationship: granular
+    - name: spec
+      type:
+        namedType: io.k8s.api.apps.v1.StatefulSetSpec
+    - name: status
+      type:
+        namedType: io.k8s.api.apps.v1.StatefulSetStatus
+- name: io.k8s.api.apps.v1.StatefulSetCondition
+  map:
+    fields:
+    - name: lastTransitionTime
+      type:
+        namedType: io.k8s.apimachinery.pkg.apis.meta.v1.Time
+    - name: message
+      type:
+        scalar: string
+    - name: reason
+      type:
+        scalar: string
+    - name: status
+      type:
+        scalar: string
+    - name: type
+      type:
+        scalar: string
+- name: io.k8s.api.apps.v1.StatefulSetList
+  map:
+    fields:
+    - name: apiVersion
+      type:
+        scalar: string
+    - name: items
+      type:
+        list:
+          elementType:
+            namedType: io.k8s.api.apps.v1.StatefulSet
+          elementRelationship: atomic
+    - name: kind
+      type:
+        scalar: string
+    - name: metadata
+      type:
+        namedType: io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta
+- name: io.k8s.api.apps.v1.StatefulSetSpec
+  map:
+    fields:
+    - name: podManagementPolicy
+      type:
+        scalar: string
+    - name: replicas
+      type:
+        scalar: numeric
+    - name: revisionHistoryLimit
+      type:
+        scalar: numeric
+    - name: selector
+      type:
+        namedType: io.k8s.apimachinery.pkg.apis.meta.v1.LabelSelector
+    - name: serviceName
+      type:
+        scalar: string
+    - name: template
+      type:
+        namedType: io.k8s.api.core.v1.PodTemplateSpec
+    - name: updateStrategy
+      type:
+        namedType: io.k8s.api.apps.v1.StatefulSetUpdateStrategy
+    - name: volumeClaimTemplates
+      type:
+        list:
+          elementType:
+            namedType: io.k8s.api.core.v1.PersistentVolumeClaim
+          elementRelationship: atomic
+- name: io.k8s.api.apps.v1.StatefulSetStatus
+  map:
+    fields:
+    - name: collisionCount
+      type:
+        scalar: numeric
+    - name: conditions
+      type:
+        list:
+          elementType:
+            namedType: io.k8s.api.apps.v1.StatefulSetCondition
+          elementRelationship: associative
+          keys:
+          - type
+    - name: currentReplicas
+      type:
+        scalar: numeric
+    - name: currentRevision
+      type:
+        scalar: string
+    - name: observedGeneration
+      type:
+        scalar: numeric
+    - name: readyReplicas
+      type:
+        scalar: numeric
+    - name: replicas
+      type:
+        scalar: numeric
+    - name: updateRevision
+      type:
+        scalar: string
+    - name: updatedReplicas
+      type:
+        scalar: numeric
+- name: io.k8s.api.apps.v1.StatefulSetUpdateStrategy
+  map:
+    fields:
+    - name: rollingUpdate
+      type:
+        namedType: io.k8s.api.apps.v1.RollingUpdateStatefulSetStrategy
+    - name: type
+      type:
+        scalar: string
+- name: io.k8s.api.apps.v1beta1.ControllerRevision
+  map:
+    fields:
+    - name: apiVersion
+      type:
+        scalar: string
+    - name: data
+      type:
+        namedType: __untyped_atomic_
+    - name: kind
+      type:
+        scalar: string
+    - name: metadata
+      type:
+        namedType: io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta
+    - name: revision
+      type:
+        scalar: numeric
+- name: io.k8s.api.apps.v1beta1.ControllerRevisionList
+  map:
+    fields:
+    - name: apiVersion
+      type:
+        scalar: string
+    - name: items
+      type:
+        list:
+          elementType:
+            namedType: io.k8s.api.apps.v1beta1.ControllerRevision
+          elementRelationship: atomic
+    - name: kind
+      type:
+        scalar: string
+    - name: metadata
+      type:
+        namedType: io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta
+        elementRelationship: granular
+- name: io.k8s.api.apps.v1beta1.Deployment
+  map:
+    fields:
+    - name: apiVersion
+      type:
+        scalar: string
+    - name: kind
+      type:
+        scalar: string
+    - name: metadata
+      type:
+        namedType: io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta
+    - name: spec
+      type:
+        namedType: io.k8s.api.apps.v1beta1.DeploymentSpec
+    - name: status
+      type:
+        namedType: io.k8s.api.apps.v1beta1.DeploymentStatus
+- name: io.k8s.api.apps.v1beta1.DeploymentCondition
+  map:
+    fields:
+    - name: lastTransitionTime
+      type:
+        namedType: io.k8s.apimachinery.pkg.apis.meta.v1.Time
+    - name: lastUpdateTime
+      type:
+        namedType: io.k8s.apimachinery.pkg.apis.meta.v1.Time
+    - name: message
+      type:
+        scalar: string
+    - name: reason
+      type:
+        scalar: string
+    - name: status
+      type:
+        scalar: string
+    - name: type
+      type:
+        scalar: string
+- name: io.k8s.api.apps.v1beta1.DeploymentList
+  map:
+    fields:
+    - name: apiVersion
+      type:
+        scalar: string
+    - name: items
+      type:
+        list:
+          elementType:
+            namedType: io.k8s.api.apps.v1beta1.Deployment
+          elementRelationship: atomic
+    - name: kind
+      type:
+        scalar: string
+    - name: metadata
+      type:
+        namedType: io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta
+- name: io.k8s.api.apps.v1beta1.DeploymentRollback
+  map:
+    fields:
+    - name: apiVersion
+      type:
+        scalar: string
+    - name: kind
+      type:
+        scalar: string
+    - name: name
+      type:
+        scalar: string
+    - name: rollbackTo
+      type:
+        namedType: io.k8s.api.apps.v1beta1.RollbackConfig
+    - name: updatedAnnotations
+      type:
+        map:
+          elementType:
+            scalar: string
+- name: io.k8s.api.apps.v1beta1.DeploymentSpec
+  map:
+    fields:
+    - name: minReadySeconds
+      type:
+        scalar: numeric
+    - name: paused
+      type:
+        scalar: boolean
+    - name: progressDeadlineSeconds
+      type:
+        scalar: numeric
+    - name: replicas
+      type:
+        scalar: numeric
+    - name: revisionHistoryLimit
+      type:
+        scalar: numeric
+    - name: rollbackTo
+      type:
+        namedType: io.k8s.api.apps.v1beta1.RollbackConfig
+    - name: selector
+      type:
+        namedType: io.k8s.apimachinery.pkg.apis.meta.v1.LabelSelector
+    - name: strategy
+      type:
+        namedType: io.k8s.api.apps.v1beta1.DeploymentStrategy
+    - name: template
+      type:
+        namedType: io.k8s.api.core.v1.PodTemplateSpec
+- name: io.k8s.api.apps.v1beta1.DeploymentStatus
+  map:
+    fields:
+    - name: availableReplicas
+      type:
+        scalar: numeric
+    - name: collisionCount
+      type:
+        scalar: numeric
+    - name: conditions
+      type:
+        list:
+          elementType:
+            namedType: io.k8s.api.apps.v1beta1.DeploymentCondition
+          elementRelationship: associative
+          keys:
+          - type
+    - name: observedGeneration
+      type:
+        scalar: numeric
+    - name: readyReplicas
+      type:
+        scalar: numeric
+    - name: replicas
+      type:
+        scalar: numeric
+    - name: unavailableReplicas
+      type:
+        scalar: numeric
+    - name: updatedReplicas
+      type:
+        scalar: numeric
+- name: io.k8s.api.apps.v1beta1.DeploymentStrategy
+  map:
+    fields:
+    - name: rollingUpdate
+      type:
+        namedType: io.k8s.api.apps.v1beta1.RollingUpdateDeployment
+    - name: type
+      type:
+        scalar: string
+    unions:
+    - discriminator: type
+      fields:
+      - fieldName: rollingUpdate
+        discriminatorValue: RollingUpdate
+- name: io.k8s.api.apps.v1beta1.RollbackConfig
+  map:
+    fields:
+    - name: revision
+      type:
+        scalar: numeric
+- name: io.k8s.api.apps.v1beta1.RollingUpdateDeployment
+  map:
+    fields:
+    - name: maxSurge
+      type:
+        namedType: io.k8s.apimachinery.pkg.util.intstr.IntOrString
+        elementRelationship: granular
+    - name: maxUnavailable
+      type:
+        namedType: io.k8s.apimachinery.pkg.util.intstr.IntOrString
+- name: io.k8s.api.apps.v1beta1.RollingUpdateStatefulSetStrategy
+  map:
+    fields:
+    - name: partition
+      type:
+        scalar: numeric
+- name: io.k8s.api.apps.v1beta1.Scale
+  map:
+    fields:
+    - name: apiVersion
+      type:
+        scalar: string
+    - name: kind
+      type:
+        scalar: string
+    - name: metadata
+      type:
+        namedType: io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta
+    - name: spec
+      type:
+        namedType: io.k8s.api.apps.v1beta1.ScaleSpec
+    - name: status
+      type:
+        namedType: io.k8s.api.apps.v1beta1.ScaleStatus
+- name: io.k8s.api.apps.v1beta1.ScaleSpec
+  map:
+    fields:
+    - name: replicas
+      type:
+        scalar: numeric
+- name: io.k8s.api.apps.v1beta1.ScaleStatus
+  map:
+    fields:
+    - name: replicas
+      type:
+        scalar: numeric
+    - name: selector
+      type:
+        map:
+          elementType:
+            scalar: string
+    - name: targetSelector
+      type:
+        scalar: string
+- name: io.k8s.api.apps.v1beta1.StatefulSet
+  map:
+    fields:
+    - name: apiVersion
+      type:
+        scalar: string
+    - name: kind
+      type:
+        scalar: string
+    - name: metadata
+      type:
+        namedType: io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta
+    - name: spec
+      type:
+        namedType: io.k8s.api.apps.v1beta1.StatefulSetSpec
+        elementRelationship: granular
+    - name: status
+      type:
+        namedType: io.k8s.api.apps.v1beta1.StatefulSetStatus
+- name: io.k8s.api.apps.v1beta1.StatefulSetCondition
+  map:
+    fields:
+    - name: lastTransitionTime
+      type:
+        namedType: io.k8s.apimachinery.pkg.apis.meta.v1.Time
+    - name: message
+      type:
+        scalar: string
+    - name: reason
+      type:
+        scalar: string
+    - name: status
+      type:
+        scalar: string
+    - name: type
+      type:
+        scalar: string
+- name: io.k8s.api.apps.v1beta1.StatefulSetList
+  map:
+    fields:
+    - name: apiVersion
+      type:
+        scalar: string
+    - name: items
+      type:
+        list:
+          elementType:
+            namedType: io.k8s.api.apps.v1beta1.StatefulSet
+          elementRelationship: atomic
+    - name: kind
+      type:
+        scalar: string
+    - name: metadata
+      type:
+        namedType: io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta
+- name: io.k8s.api.apps.v1beta1.StatefulSetSpec
+  map:
+    fields:
+    - name: podManagementPolicy
+      type:
+        scalar: string
+    - name: replicas
+      type:
+        scalar: numeric
+    - name: revisionHistoryLimit
+      type:
+        scalar: numeric
+    - name: selector
+      type:
+        namedType: io.k8s.apimachinery.pkg.apis.meta.v1.LabelSelector
+    - name: serviceName
+      type:
+        scalar: string
+    - name: template
+      type:
+        namedType: io.k8s.api.core.v1.PodTemplateSpec
+        elementRelationship: granular
+    - name: updateStrategy
+      type:
+        namedType: io.k8s.api.apps.v1beta1.StatefulSetUpdateStrategy
+    - name: volumeClaimTemplates
+      type:
+        list:
+          elementType:
+            namedType: io.k8s.api.core.v1.PersistentVolumeClaim
+          elementRelationship: atomic
+- name: io.k8s.api.apps.v1beta1.StatefulSetStatus
+  map:
+    fields:
+    - name: collisionCount
+      type:
+        scalar: numeric
+    - name: conditions
+      type:
+        list:
+          elementType:
+            namedType: io.k8s.api.apps.v1beta1.StatefulSetCondition
+          elementRelationship: associative
+          keys:
+          - type
+    - name: currentReplicas
+      type:
+        scalar: numeric
+    - name: currentRevision
+      type:
+        scalar: string
+    - name: observedGeneration
+      type:
+        scalar: numeric
+    - name: readyReplicas
+      type:
+        scalar: numeric
+    - name: replicas
+      type:
+        scalar: numeric
+    - name: updateRevision
+      type:
+        scalar: string
+    - name: updatedReplicas
+      type:
+        scalar: numeric
+- name: io.k8s.api.apps.v1beta1.StatefulSetUpdateStrategy
+  map:
+    fields:
+    - name: rollingUpdate
+      type:
+        namedType: io.k8s.api.apps.v1beta1.RollingUpdateStatefulSetStrategy
+    - name: type
+      type:
+        scalar: string
+- name: io.k8s.api.apps.v1beta2.ControllerRevision
+  map:
+    fields:
+    - name: apiVersion
+      type:
+        scalar: string
+    - name: data
+      type:
+        namedType: __untyped_atomic_
+    - name: kind
+      type:
+        scalar: string
+    - name: metadata
+      type:
+        namedType: io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta
+    - name: revision
+      type:
+        scalar: numeric
+- name: io.k8s.api.apps.v1beta2.ControllerRevisionList
+  map:
+    fields:
+    - name: apiVersion
+      type:
+        scalar: string
+    - name: items
+      type:
+        list:
+          elementType:
+            namedType: io.k8s.api.apps.v1beta2.ControllerRevision
+          elementRelationship: atomic
+    - name: kind
+      type:
+        scalar: string
+    - name: metadata
+      type:
+        namedType: io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta
+- name: io.k8s.api.apps.v1beta2.DaemonSet
+  map:
+    fields:
+    - name: apiVersion
+      type:
+        scalar: string
+    - name: kind
+      type:
+        scalar: string
+    - name: metadata
+      type:
+        namedType: io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta
+    - name: spec
+      type:
+        namedType: io.k8s.api.apps.v1beta2.DaemonSetSpec
+    - name: status
+      type:
+        namedType: io.k8s.api.apps.v1beta2.DaemonSetStatus
+- name: io.k8s.api.apps.v1beta2.DaemonSetCondition
+  map:
+    fields:
+    - name: lastTransitionTime
+      type:
+        namedType: io.k8s.apimachinery.pkg.apis.meta.v1.Time
+    - name: message
+      type:
+        scalar: string
+    - name: reason
+      type:
+        scalar: string
+    - name: status
+      type:
+        scalar: string
+    - name: type
+      type:
+        scalar: string
+- name: io.k8s.api.apps.v1beta2.DaemonSetList
+  map:
+    fields:
+    - name: apiVersion
+      type:
+        scalar: string
+    - name: items
+      type:
+        list:
+          elementType:
+            namedType: io.k8s.api.apps.v1beta2.DaemonSet
+          elementRelationship: atomic
+    - name: kind
+      type:
+        scalar: string
+    - name: metadata
+      type:
+        namedType: io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta
+        elementRelationship: granular
+- name: io.k8s.api.apps.v1beta2.DaemonSetSpec
+  map:
+    fields:
+    - name: minReadySeconds
+      type:
+        scalar: numeric
+    - name: revisionHistoryLimit
+      type:
+        scalar: numeric
+    - name: selector
+      type:
+        namedType: io.k8s.apimachinery.pkg.apis.meta.v1.LabelSelector
+    - name: template
+      type:
+        namedType: io.k8s.api.core.v1.PodTemplateSpec
+    - name: updateStrategy
+      type:
+        namedType: io.k8s.api.apps.v1beta2.DaemonSetUpdateStrategy
+- name: io.k8s.api.apps.v1beta2.DaemonSetStatus
+  map:
+    fields:
+    - name: collisionCount
+      type:
+        scalar: numeric
+    - name: conditions
+      type:
+        list:
+          elementType:
+            namedType: io.k8s.api.apps.v1beta2.DaemonSetCondition
+          elementRelationship: associative
+          keys:
+          - type
+    - name: currentNumberScheduled
+      type:
+        scalar: numeric
+    - name: desiredNumberScheduled
+      type:
+        scalar: numeric
+    - name: numberAvailable
+      type:
+        scalar: numeric
+    - name: numberMisscheduled
+      type:
+        scalar: numeric
+    - name: numberReady
+      type:
+        scalar: numeric
+    - name: numberUnavailable
+      type:
+        scalar: numeric
+    - name: observedGeneration
+      type:
+        scalar: numeric
+    - name: updatedNumberScheduled
+      type:
+        scalar: numeric
+- name: io.k8s.api.apps.v1beta2.DaemonSetUpdateStrategy
+  map:
+    fields:
+    - name: rollingUpdate
+      type:
+        namedType: io.k8s.api.apps.v1beta2.RollingUpdateDaemonSet
+    - name: type
+      type:
+        scalar: string
+- name: io.k8s.api.apps.v1beta2.Deployment
+  map:
+    fields:
+    - name: apiVersion
+      type:
+        scalar: string
+    - name: kind
+      type:
+        scalar: string
+    - name: metadata
+      type:
+        namedType: io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta
+    - name: spec
+      type:
+        namedType: io.k8s.api.apps.v1beta2.DeploymentSpec
+    - name: status
+      type:
+        namedType: io.k8s.api.apps.v1beta2.DeploymentStatus
+- name: io.k8s.api.apps.v1beta2.DeploymentCondition
+  map:
+    fields:
+    - name: lastTransitionTime
+      type:
+        namedType: io.k8s.apimachinery.pkg.apis.meta.v1.Time
+    - name: lastUpdateTime
+      type:
+        namedType: io.k8s.apimachinery.pkg.apis.meta.v1.Time
+    - name: message
+      type:
+        scalar: string
+    - name: reason
+      type:
+        scalar: string
+    - name: status
+      type:
+        scalar: string
+    - name: type
+      type:
+        scalar: string
+- name: io.k8s.api.apps.v1beta2.DeploymentList
+  map:
+    fields:
+    - name: apiVersion
+      type:
+        scalar: string
+    - name: items
+      type:
+        list:
+          elementType:
+            namedType: io.k8s.api.apps.v1beta2.Deployment
+          elementRelationship: atomic
+    - name: kind
+      type:
+        scalar: string
+    - name: metadata
+      type:
+        namedType: io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta
+- name: io.k8s.api.apps.v1beta2.DeploymentSpec
+  map:
+    fields:
+    - name: minReadySeconds
+      type:
+        scalar: numeric
+    - name: paused
+      type:
+        scalar: boolean
+    - name: progressDeadlineSeconds
+      type:
+        scalar: numeric
+    - name: replicas
+      type:
+        scalar: numeric
+    - name: revisionHistoryLimit
+      type:
+        scalar: numeric
+    - name: selector
+      type:
+        namedType: io.k8s.apimachinery.pkg.apis.meta.v1.LabelSelector
+    - name: strategy
+      type:
+        namedType: io.k8s.api.apps.v1beta2.DeploymentStrategy
+    - name: template
+      type:
+        namedType: io.k8s.api.core.v1.PodTemplateSpec
+- name: io.k8s.api.apps.v1beta2.DeploymentStatus
+  map:
+    fields:
+    - name: availableReplicas
+      type:
+        scalar: numeric
+    - name: collisionCount
+      type:
+        scalar: numeric
+    - name: conditions
+      type:
+        list:
+          elementType:
+            namedType: io.k8s.api.apps.v1beta2.DeploymentCondition
+          elementRelationship: associative
+          keys:
+          - type
+    - name: observedGeneration
+      type:
+        scalar: numeric
+    - name: readyReplicas
+      type:
+        scalar: numeric
+    - name: replicas
+      type:
+        scalar: numeric
+    - name: unavailableReplicas
+      type:
+        scalar: numeric
+    - name: updatedReplicas
+      type:
+        scalar: numeric
+- name: io.k8s.api.apps.v1beta2.DeploymentStrategy
+  map:
+    fields:
+    - name: rollingUpdate
+      type:
+        namedType: io.k8s.api.apps.v1beta2.RollingUpdateDeployment
+    - name: type
+      type:
+        scalar: string
+- name: io.k8s.api.apps.v1beta2.ReplicaSet
+  map:
+    fields:
+    - name: apiVersion
+      type:
+        scalar: string
+    - name: kind
+      type:
+        scalar: string
+    - name: metadata
+      type:
+        namedType: io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta
+    - name: spec
+      type:
+        namedType: io.k8s.api.apps.v1beta2.ReplicaSetSpec
+    - name: status
+      type:
+        namedType: io.k8s.api.apps.v1beta2.ReplicaSetStatus
+- name: io.k8s.api.apps.v1beta2.ReplicaSetCondition
+  map:
+    fields:
+    - name: lastTransitionTime
+      type:
+        namedType: io.k8s.apimachinery.pkg.apis.meta.v1.Time
+    - name: message
+      type:
+        scalar: string
+    - name: reason
+      type:
+        scalar: string
+    - name: status
+      type:
+        scalar: string
+    - name: type
+      type:
+        scalar: string
+- name: io.k8s.api.apps.v1beta2.ReplicaSetList
+  map:
+    fields:
+    - name: apiVersion
+      type:
+        scalar: string
+    - name: items
+      type:
+        list:
+          elementType:
+            namedType: io.k8s.api.apps.v1beta2.ReplicaSet
+          elementRelationship: atomic
+    - name: kind
+      type:
+        scalar: string
+    - name: metadata
+      type:
+        namedType: io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta
+- name: io.k8s.api.apps.v1beta2.ReplicaSetSpec
+  map:
+    fields:
+    - name: minReadySeconds
+      type:
+        scalar: numeric
+    - name: replicas
+      type:
+        scalar: numeric
+    - name: selector
+      type:
+        namedType: io.k8s.apimachinery.pkg.apis.meta.v1.LabelSelector
+    - name: template
+      type:
+        namedType: io.k8s.api.core.v1.PodTemplateSpec
+- name: io.k8s.api.apps.v1beta2.ReplicaSetStatus
+  map:
+    fields:
+    - name: availableReplicas
+      type:
+        scalar: numeric
+    - name: conditions
+      type:
+        list:
+          elementType:
+            namedType: io.k8s.api.apps.v1beta2.ReplicaSetCondition
+          elementRelationship: associative
+          keys:
+          - type
+    - name: fullyLabeledReplicas
+      type:
+        scalar: numeric
+    - name: observedGeneration
+      type:
+        scalar: numeric
+    - name: readyReplicas
+      type:
+        scalar: numeric
+    - name: replicas
+      type:
+        scalar: numeric
+- name: io.k8s.api.apps.v1beta2.RollingUpdateDaemonSet
+  map:
+    fields:
+    - name: maxUnavailable
+      type:
+        namedType: io.k8s.apimachinery.pkg.util.intstr.IntOrString
+- name: io.k8s.api.apps.v1beta2.RollingUpdateDeployment
+  map:
+    fields:
+    - name: maxSurge
+      type:
+        namedType: io.k8s.apimachinery.pkg.util.intstr.IntOrString
+    - name: maxUnavailable
+      type:
+        namedType: io.k8s.apimachinery.pkg.util.intstr.IntOrString
+- name: io.k8s.api.apps.v1beta2.RollingUpdateStatefulSetStrategy
+  map:
+    fields:
+    - name: partition
+      type:
+        scalar: numeric
+- name: io.k8s.api.apps.v1beta2.Scale
+  map:
+    fields:
+    - name: apiVersion
+      type:
+        scalar: string
+    - name: kind
+      type:
+        scalar: string
+    - name: metadata
+      type:
+        namedType: io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta
+    - name: spec
+      type:
+        namedType: io.k8s.api.apps.v1beta2.ScaleSpec
+        elementRelationship: granular
+    - name: status
+      type:
+        namedType: io.k8s.api.apps.v1beta2.ScaleStatus
+- name: io.k8s.api.apps.v1beta2.ScaleSpec
+  map:
+    fields:
+    - name: replicas
+      type:
+        scalar: numeric
+- name: io.k8s.api.apps.v1beta2.ScaleStatus
+  map:
+    fields:
+    - name: replicas
+      type:
+        scalar: numeric
+    - name: selector
+      type:
+        map:
+          elementType:
+            scalar: string
+    - name: targetSelector
+      type:
+        scalar: string
+- name: io.k8s.api.apps.v1beta2.StatefulSet
+  map:
+    fields:
+    - name: apiVersion
+      type:
+        scalar: string
+    - name: kind
+      type:
+        scalar: string
+    - name: metadata
+      type:
+        namedType: io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta
+    - name: spec
+      type:
+        namedType: io.k8s.api.apps.v1beta2.StatefulSetSpec
+    - name: status
+      type:
+        namedType: io.k8s.api.apps.v1beta2.StatefulSetStatus
+- name: io.k8s.api.apps.v1beta2.StatefulSetCondition
+  map:
+    fields:
+    - name: lastTransitionTime
+      type:
+        namedType: io.k8s.apimachinery.pkg.apis.meta.v1.Time
+    - name: message
+      type:
+        scalar: string
+    - name: reason
+      type:
+        scalar: string
+    - name: status
+      type:
+        scalar: string
+    - name: type
+      type:
+        scalar: string
+- name: io.k8s.api.apps.v1beta2.StatefulSetList
+  map:
+    fields:
+    - name: apiVersion
+      type:
+        scalar: string
+    - name: items
+      type:
+        list:
+          elementType:
+            namedType: io.k8s.api.apps.v1beta2.StatefulSet
+          elementRelationship: atomic
+    - name: kind
+      type:
+        scalar: string
+    - name: metadata
+      type:
+        namedType: io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta
+- name: io.k8s.api.apps.v1beta2.StatefulSetSpec
+  map:
+    fields:
+    - name: podManagementPolicy
+      type:
+        scalar: string
+    - name: replicas
+      type:
+        scalar: numeric
+    - name: revisionHistoryLimit
+      type:
+        scalar: numeric
+    - name: selector
+      type:
+        namedType: io.k8s.apimachinery.pkg.apis.meta.v1.LabelSelector
+    - name: serviceName
+      type:
+        scalar: string
+    - name: template
+      type:
+        namedType: io.k8s.api.core.v1.PodTemplateSpec
+    - name: updateStrategy
+      type:
+        namedType: io.k8s.api.apps.v1beta2.StatefulSetUpdateStrategy
+        elementRelationship: granular
+    - name: volumeClaimTemplates
+      type:
+        list:
+          elementType:
+            namedType: io.k8s.api.core.v1.PersistentVolumeClaim
+          elementRelationship: atomic
+- name: io.k8s.api.apps.v1beta2.StatefulSetStatus
+  map:
+    fields:
+    - name: collisionCount
+      type:
+        scalar: numeric
+    - name: conditions
+      type:
+        list:
+          elementType:
+            namedType: io.k8s.api.apps.v1beta2.StatefulSetCondition
+          elementRelationship: associative
+          keys:
+          - type
+    - name: currentReplicas
+      type:
+        scalar: numeric
+    - name: currentRevision
+      type:
+        scalar: string
+    - name: observedGeneration
+      type:
+        scalar: numeric
+    - name: readyReplicas
+      type:
+        scalar: numeric
+    - name: replicas
+      type:
+        scalar: numeric
+    - name: updateRevision
+      type:
+        scalar: string
+    - name: updatedReplicas
+      type:
+        scalar: numeric
+- name: io.k8s.api.apps.v1beta2.StatefulSetUpdateStrategy
+  map:
+    fields:
+    - name: rollingUpdate
+      type:
+        namedType: io.k8s.api.apps.v1beta2.RollingUpdateStatefulSetStrategy
+    - name: type
+      type:
+        scalar: string
+- name: io.k8s.api.auditregistration.v1alpha1.AuditSink
+  map:
+    fields:
+    - name: apiVersion
+      type:
+        scalar: string
+    - name: kind
+      type:
+        scalar: string
+    - name: metadata
+      type:
+        namedType: io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta
+    - name: spec
+      type:
+        namedType: io.k8s.api.auditregistration.v1alpha1.AuditSinkSpec
+- name: io.k8s.api.auditregistration.v1alpha1.AuditSinkList
+  map:
+    fields:
+    - name: apiVersion
+      type:
+        scalar: string
+    - name: items
+      type:
+        list:
+          elementType:
+            namedType: io.k8s.api.auditregistration.v1alpha1.AuditSink
+          elementRelationship: atomic
+    - name: kind
+      type:
+        scalar: string
+    - name: metadata
+      type:
+        namedType: io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta
+- name: io.k8s.api.auditregistration.v1alpha1.AuditSinkSpec
+  map:
+    fields:
+    - name: policy
+      type:
+        namedType: io.k8s.api.auditregistration.v1alpha1.Policy
+    - name: webhook
+      type:
+        namedType: io.k8s.api.auditregistration.v1alpha1.Webhook
+- name: io.k8s.api.auditregistration.v1alpha1.Policy
+  map:
+    fields:
+    - name: level
+      type:
+        scalar: string
+    - name: stages
+      type:
+        list:
+          elementType:
+            scalar: string
+          elementRelationship: atomic
+- name: io.k8s.api.auditregistration.v1alpha1.ServiceReference
+  map:
+    fields:
+    - name: name
+      type:
+        scalar: string
+    - name: namespace
+      type:
+        scalar: string
+    - name: path
+      type:
+        scalar: string
+- name: io.k8s.api.auditregistration.v1alpha1.Webhook
+  map:
+    fields:
+    - name: clientConfig
+      type:
+        namedType: io.k8s.api.auditregistration.v1alpha1.WebhookClientConfig
+    - name: throttle
+      type:
+        namedType: io.k8s.api.auditregistration.v1alpha1.WebhookThrottleConfig
+- name: io.k8s.api.auditregistration.v1alpha1.WebhookClientConfig
+  map:
+    fields:
+    - name: caBundle
+      type:
+        scalar: string
+    - name: service
+      type:
+        namedType: io.k8s.api.auditregistration.v1alpha1.ServiceReference
+    - name: url
+      type:
+        scalar: string
+- name: io.k8s.api.auditregistration.v1alpha1.WebhookThrottleConfig
+  map:
+    fields:
+    - name: burst
+      type:
+        scalar: numeric
+    - name: qps
+      type:
+        scalar: numeric
+- name: io.k8s.api.authentication.v1.TokenReview
+  map:
+    fields:
+    - name: apiVersion
+      type:
+        scalar: string
+    - name: kind
+      type:
+        scalar: string
+    - name: metadata
+      type:
+        namedType: io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta
+    - name: spec
+      type:
+        namedType: io.k8s.api.authentication.v1.TokenReviewSpec
+    - name: status
+      type:
+        namedType: io.k8s.api.authentication.v1.TokenReviewStatus
+- name: io.k8s.api.authentication.v1.TokenReviewSpec
+  map:
+    fields:
+    - name: token
+      type:
+        scalar: string
+- name: io.k8s.api.authentication.v1.TokenReviewStatus
+  map:
+    fields:
+    - name: authenticated
+      type:
+        scalar: boolean
+    - name: error
+      type:
+        scalar: string
+    - name: user
+      type:
+        namedType: io.k8s.api.authentication.v1.UserInfo
+- name: io.k8s.api.authentication.v1.UserInfo
+  map:
+    fields:
+    - name: extra
+      type:
+        map:
+          elementType:
+            list:
+              elementType:
+                scalar: string
+              elementRelationship: atomic
+    - name: groups
+      type:
+        list:
+          elementType:
+            scalar: string
+          elementRelationship: atomic
+    - name: uid
+      type:
+        scalar: string
+    - name: username
+      type:
+        scalar: string
+- name: io.k8s.api.authentication.v1beta1.TokenReview
+  map:
+    fields:
+    - name: apiVersion
+      type:
+        scalar: string
+    - name: kind
+      type:
+        scalar: string
+    - name: metadata
+      type:
+        namedType: io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta
+        elementRelationship: granular
+    - name: spec
+      type:
+        namedType: io.k8s.api.authentication.v1beta1.TokenReviewSpec
+    - name: status
+      type:
+        namedType: io.k8s.api.authentication.v1beta1.TokenReviewStatus
+- name: io.k8s.api.authentication.v1beta1.TokenReviewSpec
+  map:
+    fields:
+    - name: token
+      type:
+        scalar: string
+- name: io.k8s.api.authentication.v1beta1.TokenReviewStatus
+  map:
+    fields:
+    - name: authenticated
+      type:
+        scalar: boolean
+    - name: error
+      type:
+        scalar: string
+    - name: user
+      type:
+        namedType: io.k8s.api.authentication.v1beta1.UserInfo
+- name: io.k8s.api.authentication.v1beta1.UserInfo
+  map:
+    fields:
+    - name: extra
+      type:
+        map:
+          elementType:
+            list:
+              elementType:
+                scalar: string
+              elementRelationship: atomic
+    - name: groups
+      type:
+        list:
+          elementType:
+            scalar: string
+          elementRelationship: atomic
+    - name: uid
+      type:
+        scalar: string
+    - name: username
+      type:
+        scalar: string
+- name: io.k8s.api.authorization.v1.LocalSubjectAccessReview
+  map:
+    fields:
+    - name: apiVersion
+      type:
+        scalar: string
+    - name: kind
+      type:
+        scalar: string
+    - name: metadata
+      type:
+        namedType: io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta
+    - name: spec
+      type:
+        namedType: io.k8s.api.authorization.v1.SubjectAccessReviewSpec
+    - name: status
+      type:
+        namedType: io.k8s.api.authorization.v1.SubjectAccessReviewStatus
+- name: io.k8s.api.authorization.v1.NonResourceAttributes
+  map:
+    fields:
+    - name: path
+      type:
+        scalar: string
+    - name: verb
+      type:
+        scalar: string
+- name: io.k8s.api.authorization.v1.NonResourceRule
+  map:
+    fields:
+    - name: nonResourceURLs
+      type:
+        list:
+          elementType:
+            scalar: string
+          elementRelationship: atomic
+    - name: verbs
+      type:
+        list:
+          elementType:
+            scalar: string
+          elementRelationship: atomic
+- name: io.k8s.api.authorization.v1.ResourceAttributes
+  map:
+    fields:
+    - name: group
+      type:
+        scalar: string
+    - name: name
+      type:
+        scalar: string
+    - name: namespace
+      type:
+        scalar: string
+    - name: resource
+      type:
+        scalar: string
+    - name: subresource
+      type:
+        scalar: string
+    - name: verb
+      type:
+        scalar: string
+    - name: version
+      type:
+        scalar: string
+- name: io.k8s.api.authorization.v1.ResourceRule
+  map:
+    fields:
+    - name: apiGroups
+      type:
+        list:
+          elementType:
+            scalar: string
+          elementRelationship: atomic
+    - name: resourceNames
+      type:
+        list:
+          elementType:
+            scalar: string
+          elementRelationship: atomic
+    - name: resources
+      type:
+        list:
+          elementType:
+            scalar: string
+          elementRelationship: atomic
+    - name: verbs
+      type:
+        list:
+          elementType:
+            scalar: string
+          elementRelationship: atomic
+- name: io.k8s.api.authorization.v1.SelfSubjectAccessReview
+  map:
+    fields:
+    - name: apiVersion
+      type:
+        scalar: string
+    - name: kind
+      type:
+        scalar: string
+    - name: metadata
+      type:
+        namedType: io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta
+    - name: spec
+      type:
+        namedType: io.k8s.api.authorization.v1.SelfSubjectAccessReviewSpec
+    - name: status
+      type:
+        namedType: io.k8s.api.authorization.v1.SubjectAccessReviewStatus
+- name: io.k8s.api.authorization.v1.SelfSubjectAccessReviewSpec
+  map:
+    fields:
+    - name: nonResourceAttributes
+      type:
+        namedType: io.k8s.api.authorization.v1.NonResourceAttributes
+    - name: resourceAttributes
+      type:
+        namedType: io.k8s.api.authorization.v1.ResourceAttributes
+        elementRelationship: granular
+- name: io.k8s.api.authorization.v1.SelfSubjectRulesReview
+  map:
+    fields:
+    - name: apiVersion
+      type:
+        scalar: string
+    - name: kind
+      type:
+        scalar: string
+    - name: metadata
+      type:
+        namedType: io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta
+    - name: spec
+      type:
+        namedType: io.k8s.api.authorization.v1.SelfSubjectRulesReviewSpec
+    - name: status
+      type:
+        namedType: io.k8s.api.authorization.v1.SubjectRulesReviewStatus
+- name: io.k8s.api.authorization.v1.SelfSubjectRulesReviewSpec
+  map:
+    fields:
+    - name: namespace
+      type:
+        scalar: string
+- name: io.k8s.api.authorization.v1.SubjectAccessReview
+  map:
+    fields:
+    - name: apiVersion
+      type:
+        scalar: string
+    - name: kind
+      type:
+        scalar: string
+    - name: metadata
+      type:
+        namedType: io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta
+    - name: spec
+      type:
+        namedType: io.k8s.api.authorization.v1.SubjectAccessReviewSpec
+    - name: status
+      type:
+        namedType: io.k8s.api.authorization.v1.SubjectAccessReviewStatus
+- name: io.k8s.api.authorization.v1.SubjectAccessReviewSpec
+  map:
+    fields:
+    - name: extra
+      type:
+        map:
+          elementType:
+            list:
+              elementType:
+                scalar: string
+              elementRelationship: atomic
+    - name: groups
+      type:
+        list:
+          elementType:
+            scalar: string
+          elementRelationship: atomic
+    - name: nonResourceAttributes
+      type:
+        namedType: io.k8s.api.authorization.v1.NonResourceAttributes
+    - name: resourceAttributes
+      type:
+        namedType: io.k8s.api.authorization.v1.ResourceAttributes
+    - name: uid
+      type:
+        scalar: string
+    - name: user
+      type:
+        scalar: string
+- name: io.k8s.api.authorization.v1.SubjectAccessReviewStatus
+  map:
+    fields:
+    - name: allowed
+      type:
+        scalar: boolean
+    - name: denied
+      type:
+        scalar: boolean
+    - name: evaluationError
+      type:
+        scalar: string
+    - name: reason
+      type:
+        scalar: string
+- name: io.k8s.api.authorization.v1.SubjectRulesReviewStatus
+  map:
+    fields:
+    - name: evaluationError
+      type:
+        scalar: string
+    - name: incomplete
+      type:
+        scalar: boolean
+    - name: nonResourceRules
+      type:
+        list:
+          elementType:
+            namedType: io.k8s.api.authorization.v1.NonResourceRule
+          elementRelationship: atomic
+    - name: resourceRules
+      type:
+        list:
+          elementType:
+            namedType: io.k8s.api.authorization.v1.ResourceRule
+          elementRelationship: atomic
+- name: io.k8s.api.authorization.v1beta1.LocalSubjectAccessReview
+  map:
+    fields:
+    - name: apiVersion
+      type:
+        scalar: string
+    - name: kind
+      type:
+        scalar: string
+    - name: metadata
+      type:
+        namedType: io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta
+    - name: spec
+      type:
+        namedType: io.k8s.api.authorization.v1beta1.SubjectAccessReviewSpec
+    - name: status
+      type:
+        namedType: io.k8s.api.authorization.v1beta1.SubjectAccessReviewStatus
+- name: io.k8s.api.authorization.v1beta1.NonResourceAttributes
+  map:
+    fields:
+    - name: path
+      type:
+        scalar: string
+    - name: verb
+      type:
+        scalar: string
+- name: io.k8s.api.authorization.v1beta1.NonResourceRule
+  map:
+    fields:
+    - name: nonResourceURLs
+      type:
+        list:
+          elementType:
+            scalar: string
+          elementRelationship: atomic
+    - name: verbs
+      type:
+        list:
+          elementType:
+            scalar: string
+          elementRelationship: atomic
+- name: io.k8s.api.authorization.v1beta1.ResourceAttributes
+  map:
+    fields:
+    - name: group
+      type:
+        scalar: string
+    - name: name
+      type:
+        scalar: string
+    - name: namespace
+      type:
+        scalar: string
+    - name: resource
+      type:
+        scalar: string
+    - name: subresource
+      type:
+        scalar: string
+    - name: verb
+      type:
+        scalar: string
+    - name: version
+      type:
+        scalar: string
+- name: io.k8s.api.authorization.v1beta1.ResourceRule
+  map:
+    fields:
+    - name: apiGroups
+      type:
+        list:
+          elementType:
+            scalar: string
+          elementRelationship: atomic
+    - name: resourceNames
+      type:
+        list:
+          elementType:
+            scalar: string
+          elementRelationship: atomic
+    - name: resources
+      type:
+        list:
+          elementType:
+            scalar: string
+          elementRelationship: atomic
+    - name: verbs
+      type:
+        list:
+          elementType:
+            scalar: string
+          elementRelationship: atomic
+- name: io.k8s.api.authorization.v1beta1.SelfSubjectAccessReview
+  map:
+    fields:
+    - name: apiVersion
+      type:
+        scalar: string
+    - name: kind
+      type:
+        scalar: string
+    - name: metadata
+      type:
+        namedType: io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta
+        elementRelationship: granular
+    - name: spec
+      type:
+        namedType: io.k8s.api.authorization.v1beta1.SelfSubjectAccessReviewSpec
+    - name: status
+      type:
+        namedType: io.k8s.api.authorization.v1beta1.SubjectAccessReviewStatus
+- name: io.k8s.api.authorization.v1beta1.SelfSubjectAccessReviewSpec
+  map:
+    fields:
+    - name: nonResourceAttributes
+      type:
+        namedType: io.k8s.api.authorization.v1beta1.NonResourceAttributes
+    - name: resourceAttributes
+      type:
+        namedType: io.k8s.api.authorization.v1beta1.ResourceAttributes
+- name: io.k8s.api.authorization.v1beta1.SelfSubjectRulesReview
+  map:
+    fields:
+    - name: apiVersion
+      type:
+        scalar: string
+    - name: kind
+      type:
+        scalar: string
+    - name: metadata
+      type:
+        namedType: io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta
+    - name: spec
+      type:
+        namedType: io.k8s.api.authorization.v1beta1.SelfSubjectRulesReviewSpec
+    - name: status
+      type:
+        namedType: io.k8s.api.authorization.v1beta1.SubjectRulesReviewStatus
+- name: io.k8s.api.authorization.v1beta1.SelfSubjectRulesReviewSpec
+  map:
+    fields:
+    - name: namespace
+      type:
+        scalar: string
+- name: io.k8s.api.authorization.v1beta1.SubjectAccessReview
+  map:
+    fields:
+    - name: apiVersion
+      type:
+        scalar: string
+    - name: kind
+      type:
+        scalar: string
+    - name: metadata
+      type:
+        namedType: io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta
+    - name: spec
+      type:
+        namedType: io.k8s.api.authorization.v1beta1.SubjectAccessReviewSpec
+        elementRelationship: granular
+    - name: status
+      type:
+        namedType: io.k8s.api.authorization.v1beta1.SubjectAccessReviewStatus
+- name: io.k8s.api.authorization.v1beta1.SubjectAccessReviewSpec
+  map:
+    fields:
+    - name: extra
+      type:
+        map:
+          elementType:
+            list:
+              elementType:
+                scalar: string
+              elementRelationship: atomic
+    - name: group
+      type:
+        list:
+          elementType:
+            scalar: string
+          elementRelationship: atomic
+    - name: nonResourceAttributes
+      type:
+        namedType: io.k8s.api.authorization.v1beta1.NonResourceAttributes
+    - name: resourceAttributes
+      type:
+        namedType: io.k8s.api.authorization.v1beta1.ResourceAttributes
+    - name: uid
+      type:
+        scalar: string
+    - name: user
+      type:
+        scalar: string
+- name: io.k8s.api.authorization.v1beta1.SubjectAccessReviewStatus
+  map:
+    fields:
+    - name: allowed
+      type:
+        scalar: boolean
+    - name: denied
+      type:
+        scalar: boolean
+    - name: evaluationError
+      type:
+        scalar: string
+    - name: reason
+      type:
+        scalar: string
+- name: io.k8s.api.authorization.v1beta1.SubjectRulesReviewStatus
+  map:
+    fields:
+    - name: evaluationError
+      type:
+        scalar: string
+    - name: incomplete
+      type:
+        scalar: boolean
+    - name: nonResourceRules
+      type:
+        list:
+          elementType:
+            namedType: io.k8s.api.authorization.v1beta1.NonResourceRule
+          elementRelationship: atomic
+    - name: resourceRules
+      type:
+        list:
+          elementType:
+            namedType: io.k8s.api.authorization.v1beta1.ResourceRule
+          elementRelationship: atomic
+- name: io.k8s.api.autoscaling.v1.CrossVersionObjectReference
+  map:
+    fields:
+    - name: apiVersion
+      type:
+        scalar: string
+    - name: kind
+      type:
+        scalar: string
+    - name: name
+      type:
+        scalar: string
+- name: io.k8s.api.autoscaling.v1.HorizontalPodAutoscaler
+  map:
+    fields:
+    - name: apiVersion
+      type:
+        scalar: string
+    - name: kind
+      type:
+        scalar: string
+    - name: metadata
+      type:
+        namedType: io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta
+    - name: spec
+      type:
+        namedType: io.k8s.api.autoscaling.v1.HorizontalPodAutoscalerSpec
+    - name: status
+      type:
+        namedType: io.k8s.api.autoscaling.v1.HorizontalPodAutoscalerStatus
+- name: io.k8s.api.autoscaling.v1.HorizontalPodAutoscalerList
+  map:
+    fields:
+    - name: apiVersion
+      type:
+        scalar: string
+    - name: items
+      type:
+        list:
+          elementType:
+            namedType: io.k8s.api.autoscaling.v1.HorizontalPodAutoscaler
+          elementRelationship: atomic
+    - name: kind
+      type:
+        scalar: string
+    - name: metadata
+      type:
+        namedType: io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta
+- name: io.k8s.api.autoscaling.v1.HorizontalPodAutoscalerSpec
+  map:
+    fields:
+    - name: maxReplicas
+      type:
+        scalar: numeric
+    - name: minReplicas
+      type:
+        scalar: numeric
+    - name: scaleTargetRef
+      type:
+        namedType: io.k8s.api.autoscaling.v1.CrossVersionObjectReference
+    - name: targetCPUUtilizationPercentage
+      type:
+        scalar: numeric
+- name: io.k8s.api.autoscaling.v1.HorizontalPodAutoscalerStatus
+  map:
+    fields:
+    - name: currentCPUUtilizationPercentage
+      type:
+        scalar: numeric
+    - name: currentReplicas
+      type:
+        scalar: numeric
+    - name: desiredReplicas
+      type:
+        scalar: numeric
+    - name: lastScaleTime
+      type:
+        namedType: io.k8s.apimachinery.pkg.apis.meta.v1.Time
+    - name: observedGeneration
+      type:
+        scalar: numeric
+- name: io.k8s.api.autoscaling.v1.Scale
+  map:
+    fields:
+    - name: apiVersion
+      type:
+        scalar: string
+    - name: kind
+      type:
+        scalar: string
+    - name: metadata
+      type:
+        namedType: io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta
+    - name: spec
+      type:
+        namedType: io.k8s.api.autoscaling.v1.ScaleSpec
+    - name: status
+      type:
+        namedType: io.k8s.api.autoscaling.v1.ScaleStatus
+        elementRelationship: granular
+- name: io.k8s.api.autoscaling.v1.ScaleSpec
+  map:
+    fields:
+    - name: replicas
+      type:
+        scalar: numeric
+- name: io.k8s.api.autoscaling.v1.ScaleStatus
+  map:
+    fields:
+    - name: replicas
+      type:
+        scalar: numeric
+    - name: selector
+      type:
+        scalar: string
+- name: io.k8s.api.autoscaling.v2beta1.CrossVersionObjectReference
+  map:
+    fields:
+    - name: apiVersion
+      type:
+        scalar: string
+    - name: kind
+      type:
+        scalar: string
+    - name: name
+      type:
+        scalar: string
+- name: io.k8s.api.autoscaling.v2beta1.ExternalMetricSource
+  map:
+    fields:
+    - name: metricName
+      type:
+        scalar: string
+    - name: metricSelector
+      type:
+        namedType: io.k8s.apimachinery.pkg.apis.meta.v1.LabelSelector
+    - name: targetAverageValue
+      type:
+        namedType: io.k8s.apimachinery.pkg.api.resource.Quantity
+    - name: targetValue
+      type:
+        namedType: io.k8s.apimachinery.pkg.api.resource.Quantity
+- name: io.k8s.api.autoscaling.v2beta1.ExternalMetricStatus
+  map:
+    fields:
+    - name: currentAverageValue
+      type:
+        namedType: io.k8s.apimachinery.pkg.api.resource.Quantity
+    - name: currentValue
+      type:
+        namedType: io.k8s.apimachinery.pkg.api.resource.Quantity
+    - name: metricName
+      type:
+        scalar: string
+    - name: metricSelector
+      type:
+        namedType: io.k8s.apimachinery.pkg.apis.meta.v1.LabelSelector
+- name: io.k8s.api.autoscaling.v2beta1.HorizontalPodAutoscaler
+  map:
+    fields:
+    - name: apiVersion
+      type:
+        scalar: string
+    - name: kind
+      type:
+        scalar: string
+    - name: metadata
+      type:
+        namedType: io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta
+    - name: spec
+      type:
+        namedType: io.k8s.api.autoscaling.v2beta1.HorizontalPodAutoscalerSpec
+        elementRelationship: granular
+    - name: status
+      type:
+        namedType: io.k8s.api.autoscaling.v2beta1.HorizontalPodAutoscalerStatus
+- name: io.k8s.api.autoscaling.v2beta1.HorizontalPodAutoscalerCondition
+  map:
+    fields:
+    - name: lastTransitionTime
+      type:
+        namedType: io.k8s.apimachinery.pkg.apis.meta.v1.Time
+    - name: message
+      type:
+        scalar: string
+    - name: reason
+      type:
+        scalar: string
+    - name: status
+      type:
+        scalar: string
+    - name: type
+      type:
+        scalar: string
+- name: io.k8s.api.autoscaling.v2beta1.HorizontalPodAutoscalerList
+  map:
+    fields:
+    - name: apiVersion
+      type:
+        scalar: string
+    - name: items
+      type:
+        list:
+          elementType:
+            namedType: io.k8s.api.autoscaling.v2beta1.HorizontalPodAutoscaler
+          elementRelationship: atomic
+    - name: kind
+      type:
+        scalar: string
+    - name: metadata
+      type:
+        namedType: io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta
+- name: io.k8s.api.autoscaling.v2beta1.HorizontalPodAutoscalerSpec
+  map:
+    fields:
+    - name: maxReplicas
+      type:
+        scalar: numeric
+    - name: metrics
+      type:
+        list:
+          elementType:
+            namedType: io.k8s.api.autoscaling.v2beta1.MetricSpec
+          elementRelationship: atomic
+    - name: minReplicas
+      type:
+        scalar: numeric
+    - name: scaleTargetRef
+      type:
+        namedType: io.k8s.api.autoscaling.v2beta1.CrossVersionObjectReference
+- name: io.k8s.api.autoscaling.v2beta1.HorizontalPodAutoscalerStatus
+  map:
+    fields:
+    - name: conditions
+      type:
+        list:
+          elementType:
+            namedType: io.k8s.api.autoscaling.v2beta1.HorizontalPodAutoscalerCondition
+          elementRelationship: atomic
+    - name: currentMetrics
+      type:
+        list:
+          elementType:
+            namedType: io.k8s.api.autoscaling.v2beta1.MetricStatus
+          elementRelationship: atomic
+    - name: currentReplicas
+      type:
+        scalar: numeric
+    - name: desiredReplicas
+      type:
+        scalar: numeric
+    - name: lastScaleTime
+      type:
+        namedType: io.k8s.apimachinery.pkg.apis.meta.v1.Time
+    - name: observedGeneration
+      type:
+        scalar: numeric
+- name: io.k8s.api.autoscaling.v2beta1.MetricSpec
+  map:
+    fields:
+    - name: external
+      type:
+        namedType: io.k8s.api.autoscaling.v2beta1.ExternalMetricSource
+    - name: object
+      type:
+        namedType: io.k8s.api.autoscaling.v2beta1.ObjectMetricSource
+    - name: pods
+      type:
+        namedType: io.k8s.api.autoscaling.v2beta1.PodsMetricSource
+    - name: resource
+      type:
+        namedType: io.k8s.api.autoscaling.v2beta1.ResourceMetricSource
+    - name: type
+      type:
+        scalar: string
+- name: io.k8s.api.autoscaling.v2beta1.MetricStatus
+  map:
+    fields:
+    - name: external
+      type:
+        namedType: io.k8s.api.autoscaling.v2beta1.ExternalMetricStatus
+        elementRelationship: granular
+    - name: object
+      type:
+        namedType: io.k8s.api.autoscaling.v2beta1.ObjectMetricStatus
+    - name: pods
+      type:
+        namedType: io.k8s.api.autoscaling.v2beta1.PodsMetricStatus
+    - name: resource
+      type:
+        namedType: io.k8s.api.autoscaling.v2beta1.ResourceMetricStatus
+    - name: type
+      type:
+        scalar: string
+- name: io.k8s.api.autoscaling.v2beta1.ObjectMetricSource
+  map:
+    fields:
+    - name: averageValue
+      type:
+        namedType: io.k8s.apimachinery.pkg.api.resource.Quantity
+    - name: metricName
+      type:
+        scalar: string
+    - name: selector
+      type:
+        namedType: io.k8s.apimachinery.pkg.apis.meta.v1.LabelSelector
+        elementRelationship: granular
+    - name: target
+      type:
+        namedType: io.k8s.api.autoscaling.v2beta1.CrossVersionObjectReference
+    - name: targetValue
+      type:
+        namedType: io.k8s.apimachinery.pkg.api.resource.Quantity
+- name: io.k8s.api.autoscaling.v2beta1.ObjectMetricStatus
+  map:
+    fields:
+    - name: averageValue
+      type:
+        namedType: io.k8s.apimachinery.pkg.api.resource.Quantity
+    - name: currentValue
+      type:
+        namedType: io.k8s.apimachinery.pkg.api.resource.Quantity
+    - name: metricName
+      type:
+        scalar: string
+    - name: selector
+      type:
+        namedType: io.k8s.apimachinery.pkg.apis.meta.v1.LabelSelector
+        elementRelationship: granular
+    - name: target
+      type:
+        namedType: io.k8s.api.autoscaling.v2beta1.CrossVersionObjectReference
+- name: io.k8s.api.autoscaling.v2beta1.PodsMetricSource
+  map:
+    fields:
+    - name: metricName
+      type:
+        scalar: string
+    - name: selector
+      type:
+        namedType: io.k8s.apimachinery.pkg.apis.meta.v1.LabelSelector
+    - name: targetAverageValue
+      type:
+        namedType: io.k8s.apimachinery.pkg.api.resource.Quantity
+- name: io.k8s.api.autoscaling.v2beta1.PodsMetricStatus
+  map:
+    fields:
+    - name: currentAverageValue
+      type:
+        namedType: io.k8s.apimachinery.pkg.api.resource.Quantity
+    - name: metricName
+      type:
+        scalar: string
+    - name: selector
+      type:
+        namedType: io.k8s.apimachinery.pkg.apis.meta.v1.LabelSelector
+- name: io.k8s.api.autoscaling.v2beta1.ResourceMetricSource
+  map:
+    fields:
+    - name: name
+      type:
+        scalar: string
+    - name: targetAverageUtilization
+      type:
+        scalar: numeric
+    - name: targetAverageValue
+      type:
+        namedType: io.k8s.apimachinery.pkg.api.resource.Quantity
+- name: io.k8s.api.autoscaling.v2beta1.ResourceMetricStatus
+  map:
+    fields:
+    - name: currentAverageUtilization
+      type:
+        scalar: numeric
+    - name: currentAverageValue
+      type:
+        namedType: io.k8s.apimachinery.pkg.api.resource.Quantity
+    - name: name
+      type:
+        scalar: string
+- name: io.k8s.api.autoscaling.v2beta2.CrossVersionObjectReference
+  map:
+    fields:
+    - name: apiVersion
+      type:
+        scalar: string
+    - name: kind
+      type:
+        scalar: string
+    - name: name
+      type:
+        scalar: string
+- name: io.k8s.api.autoscaling.v2beta2.ExternalMetricSource
+  map:
+    fields:
+    - name: metric
+      type:
+        namedType: io.k8s.api.autoscaling.v2beta2.MetricIdentifier
+    - name: target
+      type:
+        namedType: io.k8s.api.autoscaling.v2beta2.MetricTarget
+- name: io.k8s.api.autoscaling.v2beta2.ExternalMetricStatus
+  map:
+    fields:
+    - name: current
+      type:
+        namedType: io.k8s.api.autoscaling.v2beta2.MetricValueStatus
+    - name: metric
+      type:
+        namedType: io.k8s.api.autoscaling.v2beta2.MetricIdentifier
+- name: io.k8s.api.autoscaling.v2beta2.HorizontalPodAutoscaler
+  map:
+    fields:
+    - name: apiVersion
+      type:
+        scalar: string
+    - name: kind
+      type:
+        scalar: string
+    - name: metadata
+      type:
+        namedType: io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta
+    - name: spec
+      type:
+        namedType: io.k8s.api.autoscaling.v2beta2.HorizontalPodAutoscalerSpec
+    - name: status
+      type:
+        namedType: io.k8s.api.autoscaling.v2beta2.HorizontalPodAutoscalerStatus
+- name: io.k8s.api.autoscaling.v2beta2.HorizontalPodAutoscalerCondition
+  map:
+    fields:
+    - name: lastTransitionTime
+      type:
+        namedType: io.k8s.apimachinery.pkg.apis.meta.v1.Time
+    - name: message
+      type:
+        scalar: string
+    - name: reason
+      type:
+        scalar: string
+    - name: status
+      type:
+        scalar: string
+    - name: type
+      type:
+        scalar: string
+- name: io.k8s.api.autoscaling.v2beta2.HorizontalPodAutoscalerList
+  map:
+    fields:
+    - name: apiVersion
+      type:
+        scalar: string
+    - name: items
+      type:
+        list:
+          elementType:
+            namedType: io.k8s.api.autoscaling.v2beta2.HorizontalPodAutoscaler
+          elementRelationship: atomic
+    - name: kind
+      type:
+        scalar: string
+    - name: metadata
+      type:
+        namedType: io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta
+- name: io.k8s.api.autoscaling.v2beta2.HorizontalPodAutoscalerSpec
+  map:
+    fields:
+    - name: maxReplicas
+      type:
+        scalar: numeric
+    - name: metrics
+      type:
+        list:
+          elementType:
+            namedType: io.k8s.api.autoscaling.v2beta2.MetricSpec
+          elementRelationship: atomic
+    - name: minReplicas
+      type:
+        scalar: numeric
+    - name: scaleTargetRef
+      type:
+        namedType: io.k8s.api.autoscaling.v2beta2.CrossVersionObjectReference
+        elementRelationship: granular
+- name: io.k8s.api.autoscaling.v2beta2.HorizontalPodAutoscalerStatus
+  map:
+    fields:
+    - name: conditions
+      type:
+        list:
+          elementType:
+            namedType: io.k8s.api.autoscaling.v2beta2.HorizontalPodAutoscalerCondition
+          elementRelationship: atomic
+    - name: currentMetrics
+      type:
+        list:
+          elementType:
+            namedType: io.k8s.api.autoscaling.v2beta2.MetricStatus
+          elementRelationship: atomic
+    - name: currentReplicas
+      type:
+        scalar: numeric
+    - name: desiredReplicas
+      type:
+        scalar: numeric
+    - name: lastScaleTime
+      type:
+        namedType: io.k8s.apimachinery.pkg.apis.meta.v1.Time
+    - name: observedGeneration
+      type:
+        scalar: numeric
+- name: io.k8s.api.autoscaling.v2beta2.MetricIdentifier
+  map:
+    fields:
+    - name: name
+      type:
+        scalar: string
+    - name: selector
+      type:
+        namedType: io.k8s.apimachinery.pkg.apis.meta.v1.LabelSelector
+- name: io.k8s.api.autoscaling.v2beta2.MetricSpec
+  map:
+    fields:
+    - name: external
+      type:
+        namedType: io.k8s.api.autoscaling.v2beta2.ExternalMetricSource
+    - name: object
+      type:
+        namedType: io.k8s.api.autoscaling.v2beta2.ObjectMetricSource
+    - name: pods
+      type:
+        namedType: io.k8s.api.autoscaling.v2beta2.PodsMetricSource
+    - name: resource
+      type:
+        namedType: io.k8s.api.autoscaling.v2beta2.ResourceMetricSource
+    - name: type
+      type:
+        scalar: string
+- name: io.k8s.api.autoscaling.v2beta2.MetricStatus
+  map:
+    fields:
+    - name: external
+      type:
+        namedType: io.k8s.api.autoscaling.v2beta2.ExternalMetricStatus
+    - name: object
+      type:
+        namedType: io.k8s.api.autoscaling.v2beta2.ObjectMetricStatus
+    - name: pods
+      type:
+        namedType: io.k8s.api.autoscaling.v2beta2.PodsMetricStatus
+    - name: resource
+      type:
+        namedType: io.k8s.api.autoscaling.v2beta2.ResourceMetricStatus
+    - name: type
+      type:
+        scalar: string
+- name: io.k8s.api.autoscaling.v2beta2.MetricTarget
+  map:
+    fields:
+    - name: averageUtilization
+      type:
+        scalar: numeric
+    - name: averageValue
+      type:
+        namedType: io.k8s.apimachinery.pkg.api.resource.Quantity
+    - name: type
+      type:
+        scalar: string
+    - name: value
+      type:
+        namedType: io.k8s.apimachinery.pkg.api.resource.Quantity
+- name: io.k8s.api.autoscaling.v2beta2.MetricValueStatus
+  map:
+    fields:
+    - name: averageUtilization
+      type:
+        scalar: numeric
+    - name: averageValue
+      type:
+        namedType: io.k8s.apimachinery.pkg.api.resource.Quantity
+    - name: value
+      type:
+        namedType: io.k8s.apimachinery.pkg.api.resource.Quantity
+- name: io.k8s.api.autoscaling.v2beta2.ObjectMetricSource
+  map:
+    fields:
+    - name: describedObject
+      type:
+        namedType: io.k8s.api.autoscaling.v2beta2.CrossVersionObjectReference
+    - name: metric
+      type:
+        namedType: io.k8s.api.autoscaling.v2beta2.MetricIdentifier
+    - name: target
+      type:
+        namedType: io.k8s.api.autoscaling.v2beta2.MetricTarget
+- name: io.k8s.api.autoscaling.v2beta2.ObjectMetricStatus
+  map:
+    fields:
+    - name: current
+      type:
+        namedType: io.k8s.api.autoscaling.v2beta2.MetricValueStatus
+    - name: describedObject
+      type:
+        namedType: io.k8s.api.autoscaling.v2beta2.CrossVersionObjectReference
+    - name: metric
+      type:
+        namedType: io.k8s.api.autoscaling.v2beta2.MetricIdentifier
+- name: io.k8s.api.autoscaling.v2beta2.PodsMetricSource
+  map:
+    fields:
+    - name: metric
+      type:
+        namedType: io.k8s.api.autoscaling.v2beta2.MetricIdentifier
+    - name: target
+      type:
+        namedType: io.k8s.api.autoscaling.v2beta2.MetricTarget
+- name: io.k8s.api.autoscaling.v2beta2.PodsMetricStatus
+  map:
+    fields:
+    - name: current
+      type:
+        namedType: io.k8s.api.autoscaling.v2beta2.MetricValueStatus
+    - name: metric
+      type:
+        namedType: io.k8s.api.autoscaling.v2beta2.MetricIdentifier
+- name: io.k8s.api.autoscaling.v2beta2.ResourceMetricSource
+  map:
+    fields:
+    - name: name
+      type:
+        scalar: string
+    - name: target
+      type:
+        namedType: io.k8s.api.autoscaling.v2beta2.MetricTarget
+- name: io.k8s.api.autoscaling.v2beta2.ResourceMetricStatus
+  map:
+    fields:
+    - name: current
+      type:
+        namedType: io.k8s.api.autoscaling.v2beta2.MetricValueStatus
+    - name: name
+      type:
+        scalar: string
+- name: io.k8s.api.batch.v1.Job
+  map:
+    fields:
+    - name: apiVersion
+      type:
+        scalar: string
+    - name: kind
+      type:
+        scalar: string
+    - name: metadata
+      type:
+        namedType: io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta
+    - name: spec
+      type:
+        namedType: io.k8s.api.batch.v1.JobSpec
+    - name: status
+      type:
+        namedType: io.k8s.api.batch.v1.JobStatus
+        elementRelationship: granular
+- name: io.k8s.api.batch.v1.JobCondition
+  map:
+    fields:
+    - name: lastProbeTime
+      type:
+        namedType: io.k8s.apimachinery.pkg.apis.meta.v1.Time
+    - name: lastTransitionTime
+      type:
+        namedType: io.k8s.apimachinery.pkg.apis.meta.v1.Time
+    - name: message
+      type:
+        scalar: string
+    - name: reason
+      type:
+        scalar: string
+    - name: status
+      type:
+        scalar: string
+    - name: type
+      type:
+        scalar: string
+- name: io.k8s.api.batch.v1.JobList
+  map:
+    fields:
+    - name: apiVersion
+      type:
+        scalar: string
+    - name: items
+      type:
+        list:
+          elementType:
+            namedType: io.k8s.api.batch.v1.Job
+          elementRelationship: atomic
+    - name: kind
+      type:
+        scalar: string
+    - name: metadata
+      type:
+        namedType: io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta
+- name: io.k8s.api.batch.v1.JobSpec
+  map:
+    fields:
+    - name: activeDeadlineSeconds
+      type:
+        scalar: numeric
+    - name: backoffLimit
+      type:
+        scalar: numeric
+    - name: completions
+      type:
+        scalar: numeric
+    - name: manualSelector
+      type:
+        scalar: boolean
+    - name: parallelism
+      type:
+        scalar: numeric
+    - name: selector
+      type:
+        namedType: io.k8s.apimachinery.pkg.apis.meta.v1.LabelSelector
+    - name: template
+      type:
+        namedType: io.k8s.api.core.v1.PodTemplateSpec
+    - name: ttlSecondsAfterFinished
+      type:
+        scalar: numeric
+- name: io.k8s.api.batch.v1.JobStatus
+  map:
+    fields:
+    - name: active
+      type:
+        scalar: numeric
+    - name: completionTime
+      type:
+        namedType: io.k8s.apimachinery.pkg.apis.meta.v1.Time
+    - name: conditions
+      type:
+        list:
+          elementType:
+            namedType: io.k8s.api.batch.v1.JobCondition
+          elementRelationship: associative
+          keys:
+          - type
+    - name: failed
+      type:
+        scalar: numeric
+    - name: startTime
+      type:
+        namedType: io.k8s.apimachinery.pkg.apis.meta.v1.Time
+    - name: succeeded
+      type:
+        scalar: numeric
+- name: io.k8s.api.batch.v1beta1.CronJob
+  map:
+    fields:
+    - name: apiVersion
+      type:
+        scalar: string
+    - name: kind
+      type:
+        scalar: string
+    - name: metadata
+      type:
+        namedType: io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta
+    - name: spec
+      type:
+        namedType: io.k8s.api.batch.v1beta1.CronJobSpec
+    - name: status
+      type:
+        namedType: io.k8s.api.batch.v1beta1.CronJobStatus
+- name: io.k8s.api.batch.v1beta1.CronJobList
+  map:
+    fields:
+    - name: apiVersion
+      type:
+        scalar: string
+    - name: items
+      type:
+        list:
+          elementType:
+            namedType: io.k8s.api.batch.v1beta1.CronJob
+          elementRelationship: atomic
+    - name: kind
+      type:
+        scalar: string
+    - name: metadata
+      type:
+        namedType: io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta
+        elementRelationship: granular
+- name: io.k8s.api.batch.v1beta1.CronJobSpec
+  map:
+    fields:
+    - name: concurrencyPolicy
+      type:
+        scalar: string
+    - name: failedJobsHistoryLimit
+      type:
+        scalar: numeric
+    - name: jobTemplate
+      type:
+        namedType: io.k8s.api.batch.v1beta1.JobTemplateSpec
+        elementRelationship: granular
+    - name: schedule
+      type:
+        scalar: string
+    - name: startingDeadlineSeconds
+      type:
+        scalar: numeric
+    - name: successfulJobsHistoryLimit
+      type:
+        scalar: numeric
+    - name: suspend
+      type:
+        scalar: boolean
+- name: io.k8s.api.batch.v1beta1.CronJobStatus
+  map:
+    fields:
+    - name: active
+      type:
+        list:
+          elementType:
+            namedType: io.k8s.api.core.v1.ObjectReference
+          elementRelationship: atomic
+    - name: lastScheduleTime
+      type:
+        namedType: io.k8s.apimachinery.pkg.apis.meta.v1.Time
+- name: io.k8s.api.batch.v1beta1.JobTemplateSpec
+  map:
+    fields:
+    - name: metadata
+      type:
+        namedType: io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta
+    - name: spec
+      type:
+        namedType: io.k8s.api.batch.v1.JobSpec
+- name: io.k8s.api.batch.v2alpha1.CronJob
+  map:
+    fields:
+    - name: apiVersion
+      type:
+        scalar: string
+    - name: kind
+      type:
+        scalar: string
+    - name: metadata
+      type:
+        namedType: io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta
+    - name: spec
+      type:
+        namedType: io.k8s.api.batch.v2alpha1.CronJobSpec
+    - name: status
+      type:
+        namedType: io.k8s.api.batch.v2alpha1.CronJobStatus
+- name: io.k8s.api.batch.v2alpha1.CronJobList
+  map:
+    fields:
+    - name: apiVersion
+      type:
+        scalar: string
+    - name: items
+      type:
+        list:
+          elementType:
+            namedType: io.k8s.api.batch.v2alpha1.CronJob
+          elementRelationship: atomic
+    - name: kind
+      type:
+        scalar: string
+    - name: metadata
+      type:
+        namedType: io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta
+- name: io.k8s.api.batch.v2alpha1.CronJobSpec
+  map:
+    fields:
+    - name: concurrencyPolicy
+      type:
+        scalar: string
+    - name: failedJobsHistoryLimit
+      type:
+        scalar: numeric
+    - name: jobTemplate
+      type:
+        namedType: io.k8s.api.batch.v2alpha1.JobTemplateSpec
+    - name: schedule
+      type:
+        scalar: string
+    - name: startingDeadlineSeconds
+      type:
+        scalar: numeric
+    - name: successfulJobsHistoryLimit
+      type:
+        scalar: numeric
+    - name: suspend
+      type:
+        scalar: boolean
+- name: io.k8s.api.batch.v2alpha1.CronJobStatus
+  map:
+    fields:
+    - name: active
+      type:
+        list:
+          elementType:
+            namedType: io.k8s.api.core.v1.ObjectReference
+          elementRelationship: atomic
+    - name: lastScheduleTime
+      type:
+        namedType: io.k8s.apimachinery.pkg.apis.meta.v1.Time
+- name: io.k8s.api.batch.v2alpha1.JobTemplateSpec
+  map:
+    fields:
+    - name: metadata
+      type:
+        namedType: io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta
+    - name: spec
+      type:
+        namedType: io.k8s.api.batch.v1.JobSpec
+- name: io.k8s.api.certificates.v1beta1.CertificateSigningRequest
+  map:
+    fields:
+    - name: apiVersion
+      type:
+        scalar: string
+    - name: kind
+      type:
+        scalar: string
+    - name: metadata
+      type:
+        namedType: io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta
+        elementRelationship: granular
+    - name: spec
+      type:
+        namedType: io.k8s.api.certificates.v1beta1.CertificateSigningRequestSpec
+    - name: status
+      type:
+        namedType: io.k8s.api.certificates.v1beta1.CertificateSigningRequestStatus
+- name: io.k8s.api.certificates.v1beta1.CertificateSigningRequestCondition
+  map:
+    fields:
+    - name: lastUpdateTime
+      type:
+        namedType: io.k8s.apimachinery.pkg.apis.meta.v1.Time
+    - name: message
+      type:
+        scalar: string
+    - name: reason
+      type:
+        scalar: string
+    - name: type
+      type:
+        scalar: string
+- name: io.k8s.api.certificates.v1beta1.CertificateSigningRequestList
+  map:
+    fields:
+    - name: apiVersion
+      type:
+        scalar: string
+    - name: items
+      type:
+        list:
+          elementType:
+            namedType: io.k8s.api.certificates.v1beta1.CertificateSigningRequest
+          elementRelationship: atomic
+    - name: kind
+      type:
+        scalar: string
+    - name: metadata
+      type:
+        namedType: io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta
+- name: io.k8s.api.certificates.v1beta1.CertificateSigningRequestSpec
+  map:
+    fields:
+    - name: extra
+      type:
+        map:
+          elementType:
+            list:
+              elementType:
+                scalar: string
+              elementRelationship: atomic
+    - name: groups
+      type:
+        list:
+          elementType:
+            scalar: string
+          elementRelationship: atomic
+    - name: request
+      type:
+        scalar: string
+    - name: uid
+      type:
+        scalar: string
+    - name: usages
+      type:
+        list:
+          elementType:
+            scalar: string
+          elementRelationship: atomic
+    - name: username
+      type:
+        scalar: string
+- name: io.k8s.api.certificates.v1beta1.CertificateSigningRequestStatus
+  map:
+    fields:
+    - name: certificate
+      type:
+        scalar: string
+    - name: conditions
+      type:
+        list:
+          elementType:
+            namedType: io.k8s.api.certificates.v1beta1.CertificateSigningRequestCondition
+          elementRelationship: atomic
+- name: io.k8s.api.coordination.v1beta1.Lease
+  map:
+    fields:
+    - name: apiVersion
+      type:
+        scalar: string
+    - name: kind
+      type:
+        scalar: string
+    - name: metadata
+      type:
+        namedType: io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta
+    - name: spec
+      type:
+        namedType: io.k8s.api.coordination.v1beta1.LeaseSpec
+- name: io.k8s.api.coordination.v1beta1.LeaseList
+  map:
+    fields:
+    - name: apiVersion
+      type:
+        scalar: string
+    - name: items
+      type:
+        list:
+          elementType:
+            namedType: io.k8s.api.coordination.v1beta1.Lease
+          elementRelationship: atomic
+    - name: kind
+      type:
+        scalar: string
+    - name: metadata
+      type:
+        namedType: io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta
+        elementRelationship: granular
+- name: io.k8s.api.coordination.v1beta1.LeaseSpec
+  map:
+    fields:
+    - name: acquireTime
+      type:
+        namedType: io.k8s.apimachinery.pkg.apis.meta.v1.MicroTime
+    - name: holderIdentity
+      type:
+        scalar: string
+    - name: leaseDurationSeconds
+      type:
+        scalar: numeric
+    - name: leaseTransitions
+      type:
+        scalar: numeric
+    - name: renewTime
+      type:
+        namedType: io.k8s.apimachinery.pkg.apis.meta.v1.MicroTime
+- name: io.k8s.api.core.v1.AWSElasticBlockStoreVolumeSource
+  map:
+    fields:
+    - name: fsType
+      type:
+        scalar: string
+    - name: partition
+      type:
+        scalar: numeric
+    - name: readOnly
+      type:
+        scalar: boolean
+    - name: volumeID
+      type:
+        scalar: string
+- name: io.k8s.api.core.v1.Affinity
+  map:
+    fields:
+    - name: nodeAffinity
+      type:
+        namedType: io.k8s.api.core.v1.NodeAffinity
+    - name: podAffinity
+      type:
+        namedType: io.k8s.api.core.v1.PodAffinity
+    - name: podAntiAffinity
+      type:
+        namedType: io.k8s.api.core.v1.PodAntiAffinity
+- name: io.k8s.api.core.v1.AttachedVolume
+  map:
+    fields:
+    - name: devicePath
+      type:
+        scalar: string
+    - name: name
+      type:
+        scalar: string
+- name: io.k8s.api.core.v1.AzureDiskVolumeSource
+  map:
+    fields:
+    - name: cachingMode
+      type:
+        scalar: string
+    - name: diskName
+      type:
+        scalar: string
+    - name: diskURI
+      type:
+        scalar: string
+    - name: fsType
+      type:
+        scalar: string
+    - name: kind
+      type:
+        scalar: string
+    - name: readOnly
+      type:
+        scalar: boolean
+- name: io.k8s.api.core.v1.AzureFilePersistentVolumeSource
+  map:
+    fields:
+    - name: readOnly
+      type:
+        scalar: boolean
+    - name: secretName
+      type:
+        scalar: string
+    - name: secretNamespace
+      type:
+        scalar: string
+    - name: shareName
+      type:
+        scalar: string
+- name: io.k8s.api.core.v1.AzureFileVolumeSource
+  map:
+    fields:
+    - name: readOnly
+      type:
+        scalar: boolean
+    - name: secretName
+      type:
+        scalar: string
+    - name: shareName
+      type:
+        scalar: string
+- name: io.k8s.api.core.v1.Binding
+  map:
+    fields:
+    - name: apiVersion
+      type:
+        scalar: string
+    - name: kind
+      type:
+        scalar: string
+    - name: metadata
+      type:
+        namedType: io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta
+    - name: target
+      type:
+        namedType: io.k8s.api.core.v1.ObjectReference
+- name: io.k8s.api.core.v1.CSIPersistentVolumeSource
+  map:
+    fields:
+    - name: controllerPublishSecretRef
+      type:
+        namedType: io.k8s.api.core.v1.SecretReference
+    - name: driver
+      type:
+        scalar: string
+    - name: fsType
+      type:
+        scalar: string
+    - name: nodePublishSecretRef
+      type:
+        namedType: io.k8s.api.core.v1.SecretReference
+    - name: nodeStageSecretRef
+      type:
+        namedType: io.k8s.api.core.v1.SecretReference
+    - name: readOnly
+      type:
+        scalar: boolean
+    - name: volumeAttributes
+      type:
+        map:
+          elementType:
+            scalar: string
+    - name: volumeHandle
+      type:
+        scalar: string
+- name: io.k8s.api.core.v1.Capabilities
+  map:
+    fields:
+    - name: add
+      type:
+        list:
+          elementType:
+            scalar: string
+          elementRelationship: atomic
+    - name: drop
+      type:
+        list:
+          elementType:
+            scalar: string
+          elementRelationship: atomic
+- name: io.k8s.api.core.v1.CephFSPersistentVolumeSource
+  map:
+    fields:
+    - name: monitors
+      type:
+        list:
+          elementType:
+            scalar: string
+          elementRelationship: atomic
+    - name: path
+      type:
+        scalar: string
+    - name: readOnly
+      type:
+        scalar: boolean
+    - name: secretFile
+      type:
+        scalar: string
+    - name: secretRef
+      type:
+        namedType: io.k8s.api.core.v1.SecretReference
+    - name: user
+      type:
+        scalar: string
+- name: io.k8s.api.core.v1.CephFSVolumeSource
+  map:
+    fields:
+    - name: monitors
+      type:
+        list:
+          elementType:
+            scalar: string
+          elementRelationship: atomic
+    - name: path
+      type:
+        scalar: string
+    - name: readOnly
+      type:
+        scalar: boolean
+    - name: secretFile
+      type:
+        scalar: string
+    - name: secretRef
+      type:
+        namedType: io.k8s.api.core.v1.LocalObjectReference
+    - name: user
+      type:
+        scalar: string
+- name: io.k8s.api.core.v1.CinderPersistentVolumeSource
+  map:
+    fields:
+    - name: fsType
+      type:
+        scalar: string
+    - name: readOnly
+      type:
+        scalar: boolean
+    - name: secretRef
+      type:
+        namedType: io.k8s.api.core.v1.SecretReference
+        elementRelationship: granular
+    - name: volumeID
+      type:
+        scalar: string
+- name: io.k8s.api.core.v1.CinderVolumeSource
+  map:
+    fields:
+    - name: fsType
+      type:
+        scalar: string
+    - name: readOnly
+      type:
+        scalar: boolean
+    - name: secretRef
+      type:
+        namedType: io.k8s.api.core.v1.LocalObjectReference
+    - name: volumeID
+      type:
+        scalar: string
+- name: io.k8s.api.core.v1.ClientIPConfig
+  map:
+    fields:
+    - name: timeoutSeconds
+      type:
+        scalar: numeric
+- name: io.k8s.api.core.v1.ComponentCondition
+  map:
+    fields:
+    - name: error
+      type:
+        scalar: string
+    - name: message
+      type:
+        scalar: string
+    - name: status
+      type:
+        scalar: string
+    - name: type
+      type:
+        scalar: string
+- name: io.k8s.api.core.v1.ComponentStatus
+  map:
+    fields:
+    - name: apiVersion
+      type:
+        scalar: string
+    - name: conditions
+      type:
+        list:
+          elementType:
+            namedType: io.k8s.api.core.v1.ComponentCondition
+          elementRelationship: associative
+          keys:
+          - type
+    - name: kind
+      type:
+        scalar: string
+    - name: metadata
+      type:
+        namedType: io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta
+- name: io.k8s.api.core.v1.ComponentStatusList
+  map:
+    fields:
+    - name: apiVersion
+      type:
+        scalar: string
+    - name: items
+      type:
+        list:
+          elementType:
+            namedType: io.k8s.api.core.v1.ComponentStatus
+          elementRelationship: atomic
+    - name: kind
+      type:
+        scalar: string
+    - name: metadata
+      type:
+        namedType: io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta
+- name: io.k8s.api.core.v1.ConfigMap
+  map:
+    fields:
+    - name: apiVersion
+      type:
+        scalar: string
+    - name: binaryData
+      type:
+        map:
+          elementType:
+            scalar: string
+    - name: data
+      type:
+        map:
+          elementType:
+            scalar: string
+    - name: kind
+      type:
+        scalar: string
+    - name: metadata
+      type:
+        namedType: io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta
+- name: io.k8s.api.core.v1.ConfigMapEnvSource
+  map:
+    fields:
+    - name: name
+      type:
+        scalar: string
+    - name: optional
+      type:
+        scalar: boolean
+- name: io.k8s.api.core.v1.ConfigMapKeySelector
+  map:
+    fields:
+    - name: key
+      type:
+        scalar: string
+    - name: name
+      type:
+        scalar: string
+    - name: optional
+      type:
+        scalar: boolean
+- name: io.k8s.api.core.v1.ConfigMapList
+  map:
+    fields:
+    - name: apiVersion
+      type:
+        scalar: string
+    - name: items
+      type:
+        list:
+          elementType:
+            namedType: io.k8s.api.core.v1.ConfigMap
+          elementRelationship: atomic
+    - name: kind
+      type:
+        scalar: string
+    - name: metadata
+      type:
+        namedType: io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta
+- name: io.k8s.api.core.v1.ConfigMapNodeConfigSource
+  map:
+    fields:
+    - name: kubeletConfigKey
+      type:
+        scalar: string
+    - name: name
+      type:
+        scalar: string
+    - name: namespace
+      type:
+        scalar: string
+    - name: resourceVersion
+      type:
+        scalar: string
+    - name: uid
+      type:
+        scalar: string
+- name: io.k8s.api.core.v1.ConfigMapProjection
+  map:
+    fields:
+    - name: items
+      type:
+        list:
+          elementType:
+            namedType: io.k8s.api.core.v1.KeyToPath
+          elementRelationship: atomic
+    - name: name
+      type:
+        scalar: string
+    - name: optional
+      type:
+        scalar: boolean
+- name: io.k8s.api.core.v1.ConfigMapVolumeSource
+  map:
+    fields:
+    - name: defaultMode
+      type:
+        scalar: numeric
+    - name: items
+      type:
+        list:
+          elementType:
+            namedType: io.k8s.api.core.v1.KeyToPath
+          elementRelationship: atomic
+    - name: name
+      type:
+        scalar: string
+    - name: optional
+      type:
+        scalar: boolean
+- name: io.k8s.api.core.v1.Container
+  map:
+    fields:
+    - name: args
+      type:
+        list:
+          elementType:
+            scalar: string
+          elementRelationship: atomic
+    - name: command
+      type:
+        list:
+          elementType:
+            scalar: string
+          elementRelationship: atomic
+    - name: env
+      type:
+        list:
+          elementType:
+            namedType: io.k8s.api.core.v1.EnvVar
+          elementRelationship: associative
+          keys:
+          - name
+    - name: envFrom
+      type:
+        list:
+          elementType:
+            namedType: io.k8s.api.core.v1.EnvFromSource
+          elementRelationship: atomic
+    - name: image
+      type:
+        scalar: string
+    - name: imagePullPolicy
+      type:
+        scalar: string
+    - name: lifecycle
+      type:
+        namedType: io.k8s.api.core.v1.Lifecycle
+    - name: livenessProbe
+      type:
+        namedType: io.k8s.api.core.v1.Probe
+    - name: name
+      type:
+        scalar: string
+    - name: ports
+      type:
+        list:
+          elementType:
+            namedType: io.k8s.api.core.v1.ContainerPort
+          elementRelationship: associative
+          keys:
+          - containerPort
+          - protocol
+    - name: readinessProbe
+      type:
+        namedType: io.k8s.api.core.v1.Probe
+    - name: resources
+      type:
+        namedType: io.k8s.api.core.v1.ResourceRequirements
+        elementRelationship: granular
+    - name: securityContext
+      type:
+        namedType: io.k8s.api.core.v1.SecurityContext
+    - name: stdin
+      type:
+        scalar: boolean
+    - name: stdinOnce
+      type:
+        scalar: boolean
+    - name: terminationMessagePath
+      type:
+        scalar: string
+    - name: terminationMessagePolicy
+      type:
+        scalar: string
+    - name: tty
+      type:
+        scalar: boolean
+    - name: volumeDevices
+      type:
+        list:
+          elementType:
+            namedType: io.k8s.api.core.v1.VolumeDevice
+          elementRelationship: associative
+          keys:
+          - devicePath
+    - name: volumeMounts
+      type:
+        list:
+          elementType:
+            namedType: io.k8s.api.core.v1.VolumeMount
+          elementRelationship: associative
+          keys:
+          - mountPath
+    - name: workingDir
+      type:
+        scalar: string
+- name: io.k8s.api.core.v1.ContainerImage
+  map:
+    fields:
+    - name: names
+      type:
+        list:
+          elementType:
+            scalar: string
+          elementRelationship: atomic
+    - name: sizeBytes
+      type:
+        scalar: numeric
+- name: io.k8s.api.core.v1.ContainerPort
+  map:
+    fields:
+    - name: containerPort
+      type:
+        scalar: numeric
+    - name: hostIP
+      type:
+        scalar: string
+    - name: hostPort
+      type:
+        scalar: numeric
+    - name: name
+      type:
+        scalar: string
+    - name: protocol
+      type:
+        scalar: string
+- name: io.k8s.api.core.v1.ContainerState
+  map:
+    fields:
+    - name: running
+      type:
+        namedType: io.k8s.api.core.v1.ContainerStateRunning
+    - name: terminated
+      type:
+        namedType: io.k8s.api.core.v1.ContainerStateTerminated
+    - name: waiting
+      type:
+        namedType: io.k8s.api.core.v1.ContainerStateWaiting
+- name: io.k8s.api.core.v1.ContainerStateRunning
+  map:
+    fields:
+    - name: startedAt
+      type:
+        namedType: io.k8s.apimachinery.pkg.apis.meta.v1.Time
+- name: io.k8s.api.core.v1.ContainerStateTerminated
+  map:
+    fields:
+    - name: containerID
+      type:
+        scalar: string
+    - name: exitCode
+      type:
+        scalar: numeric
+    - name: finishedAt
+      type:
+        namedType: io.k8s.apimachinery.pkg.apis.meta.v1.Time
+    - name: message
+      type:
+        scalar: string
+    - name: reason
+      type:
+        scalar: string
+    - name: signal
+      type:
+        scalar: numeric
+    - name: startedAt
+      type:
+        namedType: io.k8s.apimachinery.pkg.apis.meta.v1.Time
+- name: io.k8s.api.core.v1.ContainerStateWaiting
+  map:
+    fields:
+    - name: message
+      type:
+        scalar: string
+    - name: reason
+      type:
+        scalar: string
+- name: io.k8s.api.core.v1.ContainerStatus
+  map:
+    fields:
+    - name: containerID
+      type:
+        scalar: string
+    - name: image
+      type:
+        scalar: string
+    - name: imageID
+      type:
+        scalar: string
+    - name: lastState
+      type:
+        namedType: io.k8s.api.core.v1.ContainerState
+        elementRelationship: granular
+    - name: name
+      type:
+        scalar: string
+    - name: ready
+      type:
+        scalar: boolean
+    - name: restartCount
+      type:
+        scalar: numeric
+    - name: state
+      type:
+        namedType: io.k8s.api.core.v1.ContainerState
+- name: io.k8s.api.core.v1.DaemonEndpoint
+  map:
+    fields:
+    - name: Port
+      type:
+        scalar: numeric
+- name: io.k8s.api.core.v1.DownwardAPIProjection
+  map:
+    fields:
+    - name: items
+      type:
+        list:
+          elementType:
+            namedType: io.k8s.api.core.v1.DownwardAPIVolumeFile
+          elementRelationship: atomic
+- name: io.k8s.api.core.v1.DownwardAPIVolumeFile
+  map:
+    fields:
+    - name: fieldRef
+      type:
+        namedType: io.k8s.api.core.v1.ObjectFieldSelector
+    - name: mode
+      type:
+        scalar: numeric
+    - name: path
+      type:
+        scalar: string
+    - name: resourceFieldRef
+      type:
+        namedType: io.k8s.api.core.v1.ResourceFieldSelector
+- name: io.k8s.api.core.v1.DownwardAPIVolumeSource
+  map:
+    fields:
+    - name: defaultMode
+      type:
+        scalar: numeric
+    - name: items
+      type:
+        list:
+          elementType:
+            namedType: io.k8s.api.core.v1.DownwardAPIVolumeFile
+          elementRelationship: atomic
+- name: io.k8s.api.core.v1.EmptyDirVolumeSource
+  map:
+    fields:
+    - name: medium
+      type:
+        scalar: string
+    - name: sizeLimit
+      type:
+        namedType: io.k8s.apimachinery.pkg.api.resource.Quantity
+- name: io.k8s.api.core.v1.EndpointAddress
+  map:
+    fields:
+    - name: hostname
+      type:
+        scalar: string
+    - name: ip
+      type:
+        scalar: string
+    - name: nodeName
+      type:
+        scalar: string
+    - name: targetRef
+      type:
+        namedType: io.k8s.api.core.v1.ObjectReference
+- name: io.k8s.api.core.v1.EndpointPort
+  map:
+    fields:
+    - name: name
+      type:
+        scalar: string
+    - name: port
+      type:
+        scalar: numeric
+    - name: protocol
+      type:
+        scalar: string
+- name: io.k8s.api.core.v1.EndpointSubset
+  map:
+    fields:
+    - name: addresses
+      type:
+        list:
+          elementType:
+            namedType: io.k8s.api.core.v1.EndpointAddress
+          elementRelationship: atomic
+    - name: notReadyAddresses
+      type:
+        list:
+          elementType:
+            namedType: io.k8s.api.core.v1.EndpointAddress
+          elementRelationship: atomic
+    - name: ports
+      type:
+        list:
+          elementType:
+            namedType: io.k8s.api.core.v1.EndpointPort
+          elementRelationship: atomic
+- name: io.k8s.api.core.v1.Endpoints
+  map:
+    fields:
+    - name: apiVersion
+      type:
+        scalar: string
+    - name: kind
+      type:
+        scalar: string
+    - name: metadata
+      type:
+        namedType: io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta
+    - name: subsets
+      type:
+        list:
+          elementType:
+            namedType: io.k8s.api.core.v1.EndpointSubset
+          elementRelationship: atomic
+- name: io.k8s.api.core.v1.EndpointsList
+  map:
+    fields:
+    - name: apiVersion
+      type:
+        scalar: string
+    - name: items
+      type:
+        list:
+          elementType:
+            namedType: io.k8s.api.core.v1.Endpoints
+          elementRelationship: atomic
+    - name: kind
+      type:
+        scalar: string
+    - name: metadata
+      type:
+        namedType: io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta
+        elementRelationship: granular
+- name: io.k8s.api.core.v1.EnvFromSource
+  map:
+    fields:
+    - name: configMapRef
+      type:
+        namedType: io.k8s.api.core.v1.ConfigMapEnvSource
+    - name: prefix
+      type:
+        scalar: string
+    - name: secretRef
+      type:
+        namedType: io.k8s.api.core.v1.SecretEnvSource
+- name: io.k8s.api.core.v1.EnvVar
+  map:
+    fields:
+    - name: name
+      type:
+        scalar: string
+    - name: value
+      type:
+        scalar: string
+    - name: valueFrom
+      type:
+        namedType: io.k8s.api.core.v1.EnvVarSource
+- name: io.k8s.api.core.v1.EnvVarSource
+  map:
+    fields:
+    - name: configMapKeyRef
+      type:
+        namedType: io.k8s.api.core.v1.ConfigMapKeySelector
+    - name: fieldRef
+      type:
+        namedType: io.k8s.api.core.v1.ObjectFieldSelector
+    - name: resourceFieldRef
+      type:
+        namedType: io.k8s.api.core.v1.ResourceFieldSelector
+    - name: secretKeyRef
+      type:
+        namedType: io.k8s.api.core.v1.SecretKeySelector
+- name: io.k8s.api.core.v1.Event
+  map:
+    fields:
+    - name: action
+      type:
+        scalar: string
+    - name: apiVersion
+      type:
+        scalar: string
+    - name: count
+      type:
+        scalar: numeric
+    - name: eventTime
+      type:
+        namedType: io.k8s.apimachinery.pkg.apis.meta.v1.MicroTime
+    - name: firstTimestamp
+      type:
+        namedType: io.k8s.apimachinery.pkg.apis.meta.v1.Time
+    - name: involvedObject
+      type:
+        namedType: io.k8s.api.core.v1.ObjectReference
+    - name: kind
+      type:
+        scalar: string
+    - name: lastTimestamp
+      type:
+        namedType: io.k8s.apimachinery.pkg.apis.meta.v1.Time
+    - name: message
+      type:
+        scalar: string
+    - name: metadata
+      type:
+        namedType: io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta
+    - name: reason
+      type:
+        scalar: string
+    - name: related
+      type:
+        namedType: io.k8s.api.core.v1.ObjectReference
+    - name: reportingComponent
+      type:
+        scalar: string
+    - name: reportingInstance
+      type:
+        scalar: string
+    - name: series
+      type:
+        namedType: io.k8s.api.core.v1.EventSeries
+    - name: source
+      type:
+        namedType: io.k8s.api.core.v1.EventSource
+    - name: type
+      type:
+        scalar: string
+- name: io.k8s.api.core.v1.EventList
+  map:
+    fields:
+    - name: apiVersion
+      type:
+        scalar: string
+    - name: items
+      type:
+        list:
+          elementType:
+            namedType: io.k8s.api.core.v1.Event
+          elementRelationship: atomic
+    - name: kind
+      type:
+        scalar: string
+    - name: metadata
+      type:
+        namedType: io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta
+- name: io.k8s.api.core.v1.EventSeries
+  map:
+    fields:
+    - name: count
+      type:
+        scalar: numeric
+    - name: lastObservedTime
+      type:
+        namedType: io.k8s.apimachinery.pkg.apis.meta.v1.MicroTime
+        elementRelationship: granular
+    - name: state
+      type:
+        scalar: string
+- name: io.k8s.api.core.v1.EventSource
+  map:
+    fields:
+    - name: component
+      type:
+        scalar: string
+    - name: host
+      type:
+        scalar: string
+- name: io.k8s.api.core.v1.ExecAction
+  map:
+    fields:
+    - name: command
+      type:
+        list:
+          elementType:
+            scalar: string
+          elementRelationship: atomic
+- name: io.k8s.api.core.v1.FCVolumeSource
+  map:
+    fields:
+    - name: fsType
+      type:
+        scalar: string
+    - name: lun
+      type:
+        scalar: numeric
+    - name: readOnly
+      type:
+        scalar: boolean
+    - name: targetWWNs
+      type:
+        list:
+          elementType:
+            scalar: string
+          elementRelationship: atomic
+    - name: wwids
+      type:
+        list:
+          elementType:
+            scalar: string
+          elementRelationship: atomic
+- name: io.k8s.api.core.v1.FlexPersistentVolumeSource
+  map:
+    fields:
+    - name: driver
+      type:
+        scalar: string
+    - name: fsType
+      type:
+        scalar: string
+    - name: options
+      type:
+        map:
+          elementType:
+            scalar: string
+    - name: readOnly
+      type:
+        scalar: boolean
+    - name: secretRef
+      type:
+        namedType: io.k8s.api.core.v1.SecretReference
+- name: io.k8s.api.core.v1.FlexVolumeSource
+  map:
+    fields:
+    - name: driver
+      type:
+        scalar: string
+    - name: fsType
+      type:
+        scalar: string
+    - name: options
+      type:
+        map:
+          elementType:
+            scalar: string
+    - name: readOnly
+      type:
+        scalar: boolean
+    - name: secretRef
+      type:
+        namedType: io.k8s.api.core.v1.LocalObjectReference
+- name: io.k8s.api.core.v1.FlockerVolumeSource
+  map:
+    fields:
+    - name: datasetName
+      type:
+        scalar: string
+    - name: datasetUUID
+      type:
+        scalar: string
+- name: io.k8s.api.core.v1.GCEPersistentDiskVolumeSource
+  map:
+    fields:
+    - name: fsType
+      type:
+        scalar: string
+    - name: partition
+      type:
+        scalar: numeric
+    - name: pdName
+      type:
+        scalar: string
+    - name: readOnly
+      type:
+        scalar: boolean
+- name: io.k8s.api.core.v1.GitRepoVolumeSource
+  map:
+    fields:
+    - name: directory
+      type:
+        scalar: string
+    - name: repository
+      type:
+        scalar: string
+    - name: revision
+      type:
+        scalar: string
+- name: io.k8s.api.core.v1.GlusterfsVolumeSource
+  map:
+    fields:
+    - name: endpoints
+      type:
+        scalar: string
+    - name: path
+      type:
+        scalar: string
+    - name: readOnly
+      type:
+        scalar: boolean
+- name: io.k8s.api.core.v1.HTTPGetAction
+  map:
+    fields:
+    - name: host
+      type:
+        scalar: string
+    - name: httpHeaders
+      type:
+        list:
+          elementType:
+            namedType: io.k8s.api.core.v1.HTTPHeader
+          elementRelationship: atomic
+    - name: path
+      type:
+        scalar: string
+    - name: port
+      type:
+        namedType: io.k8s.apimachinery.pkg.util.intstr.IntOrString
+    - name: scheme
+      type:
+        scalar: string
+- name: io.k8s.api.core.v1.HTTPHeader
+  map:
+    fields:
+    - name: name
+      type:
+        scalar: string
+    - name: value
+      type:
+        scalar: string
+- name: io.k8s.api.core.v1.Handler
+  map:
+    fields:
+    - name: exec
+      type:
+        namedType: io.k8s.api.core.v1.ExecAction
+        elementRelationship: granular
+    - name: httpGet
+      type:
+        namedType: io.k8s.api.core.v1.HTTPGetAction
+    - name: tcpSocket
+      type:
+        namedType: io.k8s.api.core.v1.TCPSocketAction
+- name: io.k8s.api.core.v1.HostAlias
+  map:
+    fields:
+    - name: hostnames
+      type:
+        list:
+          elementType:
+            scalar: string
+          elementRelationship: atomic
+    - name: ip
+      type:
+        scalar: string
+- name: io.k8s.api.core.v1.HostPathVolumeSource
+  map:
+    fields:
+    - name: path
+      type:
+        scalar: string
+    - name: type
+      type:
+        scalar: string
+- name: io.k8s.api.core.v1.ISCSIPersistentVolumeSource
+  map:
+    fields:
+    - name: chapAuthDiscovery
+      type:
+        scalar: boolean
+    - name: chapAuthSession
+      type:
+        scalar: boolean
+    - name: fsType
+      type:
+        scalar: string
+    - name: initiatorName
+      type:
+        scalar: string
+    - name: iqn
+      type:
+        scalar: string
+    - name: iscsiInterface
+      type:
+        scalar: string
+    - name: lun
+      type:
+        scalar: numeric
+    - name: portals
+      type:
+        list:
+          elementType:
+            scalar: string
+          elementRelationship: atomic
+    - name: readOnly
+      type:
+        scalar: boolean
+    - name: secretRef
+      type:
+        namedType: io.k8s.api.core.v1.SecretReference
+    - name: targetPortal
+      type:
+        scalar: string
+- name: io.k8s.api.core.v1.ISCSIVolumeSource
+  map:
+    fields:
+    - name: chapAuthDiscovery
+      type:
+        scalar: boolean
+    - name: chapAuthSession
+      type:
+        scalar: boolean
+    - name: fsType
+      type:
+        scalar: string
+    - name: initiatorName
+      type:
+        scalar: string
+    - name: iqn
+      type:
+        scalar: string
+    - name: iscsiInterface
+      type:
+        scalar: string
+    - name: lun
+      type:
+        scalar: numeric
+    - name: portals
+      type:
+        list:
+          elementType:
+            scalar: string
+          elementRelationship: atomic
+    - name: readOnly
+      type:
+        scalar: boolean
+    - name: secretRef
+      type:
+        namedType: io.k8s.api.core.v1.LocalObjectReference
+    - name: targetPortal
+      type:
+        scalar: string
+- name: io.k8s.api.core.v1.KeyToPath
+  map:
+    fields:
+    - name: key
+      type:
+        scalar: string
+    - name: mode
+      type:
+        scalar: numeric
+    - name: path
+      type:
+        scalar: string
+- name: io.k8s.api.core.v1.Lifecycle
+  map:
+    fields:
+    - name: postStart
+      type:
+        namedType: io.k8s.api.core.v1.Handler
+    - name: preStop
+      type:
+        namedType: io.k8s.api.core.v1.Handler
+- name: io.k8s.api.core.v1.LimitRange
+  map:
+    fields:
+    - name: apiVersion
+      type:
+        scalar: string
+    - name: kind
+      type:
+        scalar: string
+    - name: metadata
+      type:
+        namedType: io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta
+    - name: spec
+      type:
+        namedType: io.k8s.api.core.v1.LimitRangeSpec
+- name: io.k8s.api.core.v1.LimitRangeItem
+  map:
+    fields:
+    - name: default
+      type:
+        map:
+          elementType:
+            namedType: io.k8s.apimachinery.pkg.api.resource.Quantity
+    - name: defaultRequest
+      type:
+        map:
+          elementType:
+            namedType: io.k8s.apimachinery.pkg.api.resource.Quantity
+    - name: max
+      type:
+        map:
+          elementType:
+            namedType: io.k8s.apimachinery.pkg.api.resource.Quantity
+    - name: maxLimitRequestRatio
+      type:
+        map:
+          elementType:
+            namedType: io.k8s.apimachinery.pkg.api.resource.Quantity
+    - name: min
+      type:
+        map:
+          elementType:
+            namedType: io.k8s.apimachinery.pkg.api.resource.Quantity
+    - name: type
+      type:
+        scalar: string
+- name: io.k8s.api.core.v1.LimitRangeList
+  map:
+    fields:
+    - name: apiVersion
+      type:
+        scalar: string
+    - name: items
+      type:
+        list:
+          elementType:
+            namedType: io.k8s.api.core.v1.LimitRange
+          elementRelationship: atomic
+    - name: kind
+      type:
+        scalar: string
+    - name: metadata
+      type:
+        namedType: io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta
+- name: io.k8s.api.core.v1.LimitRangeSpec
+  map:
+    fields:
+    - name: limits
+      type:
+        list:
+          elementType:
+            namedType: io.k8s.api.core.v1.LimitRangeItem
+          elementRelationship: atomic
+- name: io.k8s.api.core.v1.LoadBalancerIngress
+  map:
+    fields:
+    - name: hostname
+      type:
+        scalar: string
+    - name: ip
+      type:
+        scalar: string
+- name: io.k8s.api.core.v1.LoadBalancerStatus
+  map:
+    fields:
+    - name: ingress
+      type:
+        list:
+          elementType:
+            namedType: io.k8s.api.core.v1.LoadBalancerIngress
+          elementRelationship: atomic
+- name: io.k8s.api.core.v1.LocalObjectReference
+  map:
+    fields:
+    - name: name
+      type:
+        scalar: string
+- name: io.k8s.api.core.v1.LocalVolumeSource
+  map:
+    fields:
+    - name: fsType
+      type:
+        scalar: string
+    - name: path
+      type:
+        scalar: string
+- name: io.k8s.api.core.v1.NFSVolumeSource
+  map:
+    fields:
+    - name: path
+      type:
+        scalar: string
+    - name: readOnly
+      type:
+        scalar: boolean
+    - name: server
+      type:
+        scalar: string
+- name: io.k8s.api.core.v1.Namespace
+  map:
+    fields:
+    - name: apiVersion
+      type:
+        scalar: string
+    - name: kind
+      type:
+        scalar: string
+    - name: metadata
+      type:
+        namedType: io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta
+    - name: spec
+      type:
+        namedType: io.k8s.api.core.v1.NamespaceSpec
+        elementRelationship: granular
+    - name: status
+      type:
+        namedType: io.k8s.api.core.v1.NamespaceStatus
+- name: io.k8s.api.core.v1.NamespaceList
+  map:
+    fields:
+    - name: apiVersion
+      type:
+        scalar: string
+    - name: items
+      type:
+        list:
+          elementType:
+            namedType: io.k8s.api.core.v1.Namespace
+          elementRelationship: atomic
+    - name: kind
+      type:
+        scalar: string
+    - name: metadata
+      type:
+        namedType: io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta
+- name: io.k8s.api.core.v1.NamespaceSpec
+  map:
+    fields:
+    - name: finalizers
+      type:
+        list:
+          elementType:
+            scalar: string
+          elementRelationship: atomic
+- name: io.k8s.api.core.v1.NamespaceStatus
+  map:
+    fields:
+    - name: phase
+      type:
+        scalar: string
+- name: io.k8s.api.core.v1.Node
+  map:
+    fields:
+    - name: apiVersion
+      type:
+        scalar: string
+    - name: kind
+      type:
+        scalar: string
+    - name: metadata
+      type:
+        namedType: io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta
+        elementRelationship: granular
+    - name: spec
+      type:
+        namedType: io.k8s.api.core.v1.NodeSpec
+    - name: status
+      type:
+        namedType: io.k8s.api.core.v1.NodeStatus
+- name: io.k8s.api.core.v1.NodeAddress
+  map:
+    fields:
+    - name: address
+      type:
+        scalar: string
+    - name: type
+      type:
+        scalar: string
+- name: io.k8s.api.core.v1.NodeAffinity
+  map:
+    fields:
+    - name: preferredDuringSchedulingIgnoredDuringExecution
+      type:
+        list:
+          elementType:
+            namedType: io.k8s.api.core.v1.PreferredSchedulingTerm
+          elementRelationship: atomic
+    - name: requiredDuringSchedulingIgnoredDuringExecution
+      type:
+        namedType: io.k8s.api.core.v1.NodeSelector
+- name: io.k8s.api.core.v1.NodeCondition
+  map:
+    fields:
+    - name: lastHeartbeatTime
+      type:
+        namedType: io.k8s.apimachinery.pkg.apis.meta.v1.Time
+    - name: lastTransitionTime
+      type:
+        namedType: io.k8s.apimachinery.pkg.apis.meta.v1.Time
+    - name: message
+      type:
+        scalar: string
+    - name: reason
+      type:
+        scalar: string
+    - name: status
+      type:
+        scalar: string
+    - name: type
+      type:
+        scalar: string
+- name: io.k8s.api.core.v1.NodeConfigSource
+  map:
+    fields:
+    - name: configMap
+      type:
+        namedType: io.k8s.api.core.v1.ConfigMapNodeConfigSource
+- name: io.k8s.api.core.v1.NodeConfigStatus
+  map:
+    fields:
+    - name: active
+      type:
+        namedType: io.k8s.api.core.v1.NodeConfigSource
+        elementRelationship: granular
+    - name: assigned
+      type:
+        namedType: io.k8s.api.core.v1.NodeConfigSource
+    - name: error
+      type:
+        scalar: string
+    - name: lastKnownGood
+      type:
+        namedType: io.k8s.api.core.v1.NodeConfigSource
+- name: io.k8s.api.core.v1.NodeDaemonEndpoints
+  map:
+    fields:
+    - name: kubeletEndpoint
+      type:
+        namedType: io.k8s.api.core.v1.DaemonEndpoint
+- name: io.k8s.api.core.v1.NodeList
+  map:
+    fields:
+    - name: apiVersion
+      type:
+        scalar: string
+    - name: items
+      type:
+        list:
+          elementType:
+            namedType: io.k8s.api.core.v1.Node
+          elementRelationship: atomic
+    - name: kind
+      type:
+        scalar: string
+    - name: metadata
+      type:
+        namedType: io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta
+- name: io.k8s.api.core.v1.NodeSelector
+  map:
+    fields:
+    - name: nodeSelectorTerms
+      type:
+        list:
+          elementType:
+            namedType: io.k8s.api.core.v1.NodeSelectorTerm
+          elementRelationship: atomic
+- name: io.k8s.api.core.v1.NodeSelectorRequirement
+  map:
+    fields:
+    - name: key
+      type:
+        scalar: string
+    - name: operator
+      type:
+        scalar: string
+    - name: values
+      type:
+        list:
+          elementType:
+            scalar: string
+          elementRelationship: atomic
+- name: io.k8s.api.core.v1.NodeSelectorTerm
+  map:
+    fields:
+    - name: matchExpressions
+      type:
+        list:
+          elementType:
+            namedType: io.k8s.api.core.v1.NodeSelectorRequirement
+          elementRelationship: atomic
+    - name: matchFields
+      type:
+        list:
+          elementType:
+            namedType: io.k8s.api.core.v1.NodeSelectorRequirement
+          elementRelationship: atomic
+- name: io.k8s.api.core.v1.NodeSpec
+  map:
+    fields:
+    - name: configSource
+      type:
+        namedType: io.k8s.api.core.v1.NodeConfigSource
+    - name: externalID
+      type:
+        scalar: string
+    - name: podCIDR
+      type:
+        scalar: string
+    - name: providerID
+      type:
+        scalar: string
+    - name: taints
+      type:
+        list:
+          elementType:
+            namedType: io.k8s.api.core.v1.Taint
+          elementRelationship: atomic
+    - name: unschedulable
+      type:
+        scalar: boolean
+- name: io.k8s.api.core.v1.NodeStatus
+  map:
+    fields:
+    - name: addresses
+      type:
+        list:
+          elementType:
+            namedType: io.k8s.api.core.v1.NodeAddress
+          elementRelationship: associative
+          keys:
+          - type
+    - name: allocatable
+      type:
+        map:
+          elementType:
+            namedType: io.k8s.apimachinery.pkg.api.resource.Quantity
+    - name: capacity
+      type:
+        map:
+          elementType:
+            namedType: io.k8s.apimachinery.pkg.api.resource.Quantity
+    - name: conditions
+      type:
+        list:
+          elementType:
+            namedType: io.k8s.api.core.v1.NodeCondition
+          elementRelationship: associative
+          keys:
+          - type
+    - name: config
+      type:
+        namedType: io.k8s.api.core.v1.NodeConfigStatus
+    - name: daemonEndpoints
+      type:
+        namedType: io.k8s.api.core.v1.NodeDaemonEndpoints
+    - name: images
+      type:
+        list:
+          elementType:
+            namedType: io.k8s.api.core.v1.ContainerImage
+          elementRelationship: atomic
+    - name: nodeInfo
+      type:
+        namedType: io.k8s.api.core.v1.NodeSystemInfo
+    - name: phase
+      type:
+        scalar: string
+    - name: volumesAttached
+      type:
+        list:
+          elementType:
+            namedType: io.k8s.api.core.v1.AttachedVolume
+          elementRelationship: atomic
+    - name: volumesInUse
+      type:
+        list:
+          elementType:
+            scalar: string
+          elementRelationship: atomic
+- name: io.k8s.api.core.v1.NodeSystemInfo
+  map:
+    fields:
+    - name: architecture
+      type:
+        scalar: string
+    - name: bootID
+      type:
+        scalar: string
+    - name: containerRuntimeVersion
+      type:
+        scalar: string
+    - name: kernelVersion
+      type:
+        scalar: string
+    - name: kubeProxyVersion
+      type:
+        scalar: string
+    - name: kubeletVersion
+      type:
+        scalar: string
+    - name: machineID
+      type:
+        scalar: string
+    - name: operatingSystem
+      type:
+        scalar: string
+    - name: osImage
+      type:
+        scalar: string
+    - name: systemUUID
+      type:
+        scalar: string
+- name: io.k8s.api.core.v1.ObjectFieldSelector
+  map:
+    fields:
+    - name: apiVersion
+      type:
+        scalar: string
+    - name: fieldPath
+      type:
+        scalar: string
+- name: io.k8s.api.core.v1.ObjectReference
+  map:
+    fields:
+    - name: apiVersion
+      type:
+        scalar: string
+    - name: fieldPath
+      type:
+        scalar: string
+    - name: kind
+      type:
+        scalar: string
+    - name: name
+      type:
+        scalar: string
+    - name: namespace
+      type:
+        scalar: string
+    - name: resourceVersion
+      type:
+        scalar: string
+    - name: uid
+      type:
+        scalar: string
+- name: io.k8s.api.core.v1.PersistentVolume
+  map:
+    fields:
+    - name: apiVersion
+      type:
+        scalar: string
+    - name: kind
+      type:
+        scalar: string
+    - name: metadata
+      type:
+        namedType: io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta
+    - name: spec
+      type:
+        namedType: io.k8s.api.core.v1.PersistentVolumeSpec
+    - name: status
+      type:
+        namedType: io.k8s.api.core.v1.PersistentVolumeStatus
+- name: io.k8s.api.core.v1.PersistentVolumeClaim
+  map:
+    fields:
+    - name: apiVersion
+      type:
+        scalar: string
+    - name: kind
+      type:
+        scalar: string
+    - name: metadata
+      type:
+        namedType: io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta
+    - name: spec
+      type:
+        namedType: io.k8s.api.core.v1.PersistentVolumeClaimSpec
+    - name: status
+      type:
+        namedType: io.k8s.api.core.v1.PersistentVolumeClaimStatus
+- name: io.k8s.api.core.v1.PersistentVolumeClaimCondition
+  map:
+    fields:
+    - name: lastProbeTime
+      type:
+        namedType: io.k8s.apimachinery.pkg.apis.meta.v1.Time
+    - name: lastTransitionTime
+      type:
+        namedType: io.k8s.apimachinery.pkg.apis.meta.v1.Time
+    - name: message
+      type:
+        scalar: string
+    - name: reason
+      type:
+        scalar: string
+    - name: status
+      type:
+        scalar: string
+    - name: type
+      type:
+        scalar: string
+- name: io.k8s.api.core.v1.PersistentVolumeClaimList
+  map:
+    fields:
+    - name: apiVersion
+      type:
+        scalar: string
+    - name: items
+      type:
+        list:
+          elementType:
+            namedType: io.k8s.api.core.v1.PersistentVolumeClaim
+          elementRelationship: atomic
+    - name: kind
+      type:
+        scalar: string
+    - name: metadata
+      type:
+        namedType: io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta
+- name: io.k8s.api.core.v1.PersistentVolumeClaimSpec
+  map:
+    fields:
+    - name: accessModes
+      type:
+        list:
+          elementType:
+            scalar: string
+          elementRelationship: atomic
+    - name: dataSource
+      type:
+        namedType: io.k8s.api.core.v1.TypedLocalObjectReference
+    - name: resources
+      type:
+        namedType: io.k8s.api.core.v1.ResourceRequirements
+    - name: selector
+      type:
+        namedType: io.k8s.apimachinery.pkg.apis.meta.v1.LabelSelector
+    - name: storageClassName
+      type:
+        scalar: string
+    - name: volumeMode
+      type:
+        scalar: string
+    - name: volumeName
+      type:
+        scalar: string
+- name: io.k8s.api.core.v1.PersistentVolumeClaimStatus
+  map:
+    fields:
+    - name: accessModes
+      type:
+        list:
+          elementType:
+            scalar: string
+          elementRelationship: atomic
+    - name: capacity
+      type:
+        map:
+          elementType:
+            namedType: io.k8s.apimachinery.pkg.api.resource.Quantity
+    - name: conditions
+      type:
+        list:
+          elementType:
+            namedType: io.k8s.api.core.v1.PersistentVolumeClaimCondition
+          elementRelationship: associative
+          keys:
+          - type
+    - name: phase
+      type:
+        scalar: string
+- name: io.k8s.api.core.v1.PersistentVolumeClaimVolumeSource
+  map:
+    fields:
+    - name: claimName
+      type:
+        scalar: string
+    - name: readOnly
+      type:
+        scalar: boolean
+- name: io.k8s.api.core.v1.PersistentVolumeList
+  map:
+    fields:
+    - name: apiVersion
+      type:
+        scalar: string
+    - name: items
+      type:
+        list:
+          elementType:
+            namedType: io.k8s.api.core.v1.PersistentVolume
+          elementRelationship: atomic
+    - name: kind
+      type:
+        scalar: string
+    - name: metadata
+      type:
+        namedType: io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta
+- name: io.k8s.api.core.v1.PersistentVolumeSpec
+  map:
+    fields:
+    - name: accessModes
+      type:
+        list:
+          elementType:
+            scalar: string
+          elementRelationship: atomic
+    - name: awsElasticBlockStore
+      type:
+        namedType: io.k8s.api.core.v1.AWSElasticBlockStoreVolumeSource
+    - name: azureDisk
+      type:
+        namedType: io.k8s.api.core.v1.AzureDiskVolumeSource
+    - name: azureFile
+      type:
+        namedType: io.k8s.api.core.v1.AzureFilePersistentVolumeSource
+    - name: capacity
+      type:
+        map:
+          elementType:
+            namedType: io.k8s.apimachinery.pkg.api.resource.Quantity
+    - name: cephfs
+      type:
+        namedType: io.k8s.api.core.v1.CephFSPersistentVolumeSource
+    - name: cinder
+      type:
+        namedType: io.k8s.api.core.v1.CinderPersistentVolumeSource
+    - name: claimRef
+      type:
+        namedType: io.k8s.api.core.v1.ObjectReference
+    - name: csi
+      type:
+        namedType: io.k8s.api.core.v1.CSIPersistentVolumeSource
+    - name: fc
+      type:
+        namedType: io.k8s.api.core.v1.FCVolumeSource
+    - name: flexVolume
+      type:
+        namedType: io.k8s.api.core.v1.FlexPersistentVolumeSource
+        elementRelationship: granular
+    - name: flocker
+      type:
+        namedType: io.k8s.api.core.v1.FlockerVolumeSource
+    - name: gcePersistentDisk
+      type:
+        namedType: io.k8s.api.core.v1.GCEPersistentDiskVolumeSource
+    - name: glusterfs
+      type:
+        namedType: io.k8s.api.core.v1.GlusterfsVolumeSource
+    - name: hostPath
+      type:
+        namedType: io.k8s.api.core.v1.HostPathVolumeSource
+    - name: iscsi
+      type:
+        namedType: io.k8s.api.core.v1.ISCSIPersistentVolumeSource
+    - name: local
+      type:
+        namedType: io.k8s.api.core.v1.LocalVolumeSource
+    - name: mountOptions
+      type:
+        list:
+          elementType:
+            scalar: string
+          elementRelationship: atomic
+    - name: nfs
+      type:
+        namedType: io.k8s.api.core.v1.NFSVolumeSource
+    - name: nodeAffinity
+      type:
+        namedType: io.k8s.api.core.v1.VolumeNodeAffinity
+        elementRelationship: granular
+    - name: persistentVolumeReclaimPolicy
+      type:
+        scalar: string
+    - name: photonPersistentDisk
+      type:
+        namedType: io.k8s.api.core.v1.PhotonPersistentDiskVolumeSource
+    - name: portworxVolume
+      type:
+        namedType: io.k8s.api.core.v1.PortworxVolumeSource
+    - name: quobyte
+      type:
+        namedType: io.k8s.api.core.v1.QuobyteVolumeSource
+    - name: rbd
+      type:
+        namedType: io.k8s.api.core.v1.RBDPersistentVolumeSource
+    - name: scaleIO
+      type:
+        namedType: io.k8s.api.core.v1.ScaleIOPersistentVolumeSource
+    - name: storageClassName
+      type:
+        scalar: string
+    - name: storageos
+      type:
+        namedType: io.k8s.api.core.v1.StorageOSPersistentVolumeSource
+    - name: volumeMode
+      type:
+        scalar: string
+    - name: vsphereVolume
+      type:
+        namedType: io.k8s.api.core.v1.VsphereVirtualDiskVolumeSource
+        elementRelationship: granular
+- name: io.k8s.api.core.v1.PersistentVolumeStatus
+  map:
+    fields:
+    - name: message
+      type:
+        scalar: string
+    - name: phase
+      type:
+        scalar: string
+    - name: reason
+      type:
+        scalar: string
+- name: io.k8s.api.core.v1.PhotonPersistentDiskVolumeSource
+  map:
+    fields:
+    - name: fsType
+      type:
+        scalar: string
+    - name: pdID
+      type:
+        scalar: string
+- name: io.k8s.api.core.v1.Pod
+  map:
+    fields:
+    - name: apiVersion
+      type:
+        scalar: string
+    - name: kind
+      type:
+        scalar: string
+    - name: metadata
+      type:
+        namedType: io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta
+    - name: spec
+      type:
+        namedType: io.k8s.api.core.v1.PodSpec
+    - name: status
+      type:
+        namedType: io.k8s.api.core.v1.PodStatus
+- name: io.k8s.api.core.v1.PodAffinity
+  map:
+    fields:
+    - name: preferredDuringSchedulingIgnoredDuringExecution
+      type:
+        list:
+          elementType:
+            namedType: io.k8s.api.core.v1.WeightedPodAffinityTerm
+          elementRelationship: atomic
+    - name: requiredDuringSchedulingIgnoredDuringExecution
+      type:
+        list:
+          elementType:
+            namedType: io.k8s.api.core.v1.PodAffinityTerm
+          elementRelationship: atomic
+- name: io.k8s.api.core.v1.PodAffinityTerm
+  map:
+    fields:
+    - name: labelSelector
+      type:
+        namedType: io.k8s.apimachinery.pkg.apis.meta.v1.LabelSelector
+    - name: namespaces
+      type:
+        list:
+          elementType:
+            scalar: string
+          elementRelationship: atomic
+    - name: topologyKey
+      type:
+        scalar: string
+- name: io.k8s.api.core.v1.PodAntiAffinity
+  map:
+    fields:
+    - name: preferredDuringSchedulingIgnoredDuringExecution
+      type:
+        list:
+          elementType:
+            namedType: io.k8s.api.core.v1.WeightedPodAffinityTerm
+          elementRelationship: atomic
+    - name: requiredDuringSchedulingIgnoredDuringExecution
+      type:
+        list:
+          elementType:
+            namedType: io.k8s.api.core.v1.PodAffinityTerm
+          elementRelationship: atomic
+- name: io.k8s.api.core.v1.PodCondition
+  map:
+    fields:
+    - name: lastProbeTime
+      type:
+        namedType: io.k8s.apimachinery.pkg.apis.meta.v1.Time
+    - name: lastTransitionTime
+      type:
+        namedType: io.k8s.apimachinery.pkg.apis.meta.v1.Time
+    - name: message
+      type:
+        scalar: string
+    - name: reason
+      type:
+        scalar: string
+    - name: status
+      type:
+        scalar: string
+    - name: type
+      type:
+        scalar: string
+- name: io.k8s.api.core.v1.PodDNSConfig
+  map:
+    fields:
+    - name: nameservers
+      type:
+        list:
+          elementType:
+            scalar: string
+          elementRelationship: atomic
+    - name: options
+      type:
+        list:
+          elementType:
+            namedType: io.k8s.api.core.v1.PodDNSConfigOption
+          elementRelationship: atomic
+    - name: searches
+      type:
+        list:
+          elementType:
+            scalar: string
+          elementRelationship: atomic
+- name: io.k8s.api.core.v1.PodDNSConfigOption
+  map:
+    fields:
+    - name: name
+      type:
+        scalar: string
+    - name: value
+      type:
+        scalar: string
+- name: io.k8s.api.core.v1.PodList
+  map:
+    fields:
+    - name: apiVersion
+      type:
+        scalar: string
+    - name: items
+      type:
+        list:
+          elementType:
+            namedType: io.k8s.api.core.v1.Pod
+          elementRelationship: atomic
+    - name: kind
+      type:
+        scalar: string
+    - name: metadata
+      type:
+        namedType: io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta
+- name: io.k8s.api.core.v1.PodReadinessGate
+  map:
+    fields:
+    - name: conditionType
+      type:
+        scalar: string
+- name: io.k8s.api.core.v1.PodSecurityContext
+  map:
+    fields:
+    - name: fsGroup
+      type:
+        scalar: numeric
+    - name: runAsGroup
+      type:
+        scalar: numeric
+    - name: runAsNonRoot
+      type:
+        scalar: boolean
+    - name: runAsUser
+      type:
+        scalar: numeric
+    - name: seLinuxOptions
+      type:
+        namedType: io.k8s.api.core.v1.SELinuxOptions
+    - name: supplementalGroups
+      type:
+        list:
+          elementType:
+            scalar: numeric
+          elementRelationship: atomic
+    - name: sysctls
+      type:
+        list:
+          elementType:
+            namedType: io.k8s.api.core.v1.Sysctl
+          elementRelationship: atomic
+- name: io.k8s.api.core.v1.PodSpec
+  map:
+    fields:
+    - name: activeDeadlineSeconds
+      type:
+        scalar: numeric
+    - name: affinity
+      type:
+        namedType: io.k8s.api.core.v1.Affinity
+        elementRelationship: granular
+    - name: automountServiceAccountToken
+      type:
+        scalar: boolean
+    - name: containers
+      type:
+        list:
+          elementType:
+            namedType: io.k8s.api.core.v1.Container
+          elementRelationship: associative
+          keys:
+          - name
+    - name: dnsConfig
+      type:
+        namedType: io.k8s.api.core.v1.PodDNSConfig
+    - name: dnsPolicy
+      type:
+        scalar: string
+    - name: enableServiceLinks
+      type:
+        scalar: boolean
+    - name: hostAliases
+      type:
+        list:
+          elementType:
+            namedType: io.k8s.api.core.v1.HostAlias
+          elementRelationship: associative
+          keys:
+          - ip
+    - name: hostIPC
+      type:
+        scalar: boolean
+    - name: hostNetwork
+      type:
+        scalar: boolean
+    - name: hostPID
+      type:
+        scalar: boolean
+    - name: hostname
+      type:
+        scalar: string
+    - name: imagePullSecrets
+      type:
+        list:
+          elementType:
+            namedType: io.k8s.api.core.v1.LocalObjectReference
+          elementRelationship: associative
+          keys:
+          - name
+    - name: initContainers
+      type:
+        list:
+          elementType:
+            namedType: io.k8s.api.core.v1.Container
+          elementRelationship: associative
+          keys:
+          - name
+    - name: nodeName
+      type:
+        scalar: string
+    - name: nodeSelector
+      type:
+        map:
+          elementType:
+            scalar: string
+    - name: priority
+      type:
+        scalar: numeric
+    - name: priorityClassName
+      type:
+        scalar: string
+    - name: readinessGates
+      type:
+        list:
+          elementType:
+            namedType: io.k8s.api.core.v1.PodReadinessGate
+          elementRelationship: atomic
+    - name: restartPolicy
+      type:
+        scalar: string
+    - name: runtimeClassName
+      type:
+        scalar: string
+    - name: schedulerName
+      type:
+        scalar: string
+    - name: securityContext
+      type:
+        namedType: io.k8s.api.core.v1.PodSecurityContext
+    - name: serviceAccount
+      type:
+        scalar: string
+    - name: serviceAccountName
+      type:
+        scalar: string
+    - name: shareProcessNamespace
+      type:
+        scalar: boolean
+    - name: subdomain
+      type:
+        scalar: string
+    - name: terminationGracePeriodSeconds
+      type:
+        scalar: numeric
+    - name: tolerations
+      type:
+        list:
+          elementType:
+            namedType: io.k8s.api.core.v1.Toleration
+          elementRelationship: atomic
+    - name: volumes
+      type:
+        list:
+          elementType:
+            namedType: io.k8s.api.core.v1.Volume
+          elementRelationship: associative
+          keys:
+          - name
+- name: io.k8s.api.core.v1.PodStatus
+  map:
+    fields:
+    - name: conditions
+      type:
+        list:
+          elementType:
+            namedType: io.k8s.api.core.v1.PodCondition
+          elementRelationship: associative
+          keys:
+          - type
+    - name: containerStatuses
+      type:
+        list:
+          elementType:
+            namedType: io.k8s.api.core.v1.ContainerStatus
+          elementRelationship: atomic
+    - name: hostIP
+      type:
+        scalar: string
+    - name: initContainerStatuses
+      type:
+        list:
+          elementType:
+            namedType: io.k8s.api.core.v1.ContainerStatus
+          elementRelationship: atomic
+    - name: message
+      type:
+        scalar: string
+    - name: nominatedNodeName
+      type:
+        scalar: string
+    - name: phase
+      type:
+        scalar: string
+    - name: podIP
+      type:
+        scalar: string
+    - name: qosClass
+      type:
+        scalar: string
+    - name: reason
+      type:
+        scalar: string
+    - name: startTime
+      type:
+        namedType: io.k8s.apimachinery.pkg.apis.meta.v1.Time
+- name: io.k8s.api.core.v1.PodTemplate
+  map:
+    fields:
+    - name: apiVersion
+      type:
+        scalar: string
+    - name: kind
+      type:
+        scalar: string
+    - name: metadata
+      type:
+        namedType: io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta
+    - name: template
+      type:
+        namedType: io.k8s.api.core.v1.PodTemplateSpec
+- name: io.k8s.api.core.v1.PodTemplateList
+  map:
+    fields:
+    - name: apiVersion
+      type:
+        scalar: string
+    - name: items
+      type:
+        list:
+          elementType:
+            namedType: io.k8s.api.core.v1.PodTemplate
+          elementRelationship: atomic
+    - name: kind
+      type:
+        scalar: string
+    - name: metadata
+      type:
+        namedType: io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta
+- name: io.k8s.api.core.v1.PodTemplateSpec
+  map:
+    fields:
+    - name: metadata
+      type:
+        namedType: io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta
+    - name: spec
+      type:
+        namedType: io.k8s.api.core.v1.PodSpec
+- name: io.k8s.api.core.v1.PortworxVolumeSource
+  map:
+    fields:
+    - name: fsType
+      type:
+        scalar: string
+    - name: readOnly
+      type:
+        scalar: boolean
+    - name: volumeID
+      type:
+        scalar: string
+- name: io.k8s.api.core.v1.PreferredSchedulingTerm
+  map:
+    fields:
+    - name: preference
+      type:
+        namedType: io.k8s.api.core.v1.NodeSelectorTerm
+    - name: weight
+      type:
+        scalar: numeric
+- name: io.k8s.api.core.v1.Probe
+  map:
+    fields:
+    - name: exec
+      type:
+        namedType: io.k8s.api.core.v1.ExecAction
+    - name: failureThreshold
+      type:
+        scalar: numeric
+    - name: httpGet
+      type:
+        namedType: io.k8s.api.core.v1.HTTPGetAction
+    - name: initialDelaySeconds
+      type:
+        scalar: numeric
+    - name: periodSeconds
+      type:
+        scalar: numeric
+    - name: successThreshold
+      type:
+        scalar: numeric
+    - name: tcpSocket
+      type:
+        namedType: io.k8s.api.core.v1.TCPSocketAction
+    - name: timeoutSeconds
+      type:
+        scalar: numeric
+- name: io.k8s.api.core.v1.ProjectedVolumeSource
+  map:
+    fields:
+    - name: defaultMode
+      type:
+        scalar: numeric
+    - name: sources
+      type:
+        list:
+          elementType:
+            namedType: io.k8s.api.core.v1.VolumeProjection
+          elementRelationship: atomic
+- name: io.k8s.api.core.v1.QuobyteVolumeSource
+  map:
+    fields:
+    - name: group
+      type:
+        scalar: string
+    - name: readOnly
+      type:
+        scalar: boolean
+    - name: registry
+      type:
+        scalar: string
+    - name: user
+      type:
+        scalar: string
+    - name: volume
+      type:
+        scalar: string
+- name: io.k8s.api.core.v1.RBDPersistentVolumeSource
+  map:
+    fields:
+    - name: fsType
+      type:
+        scalar: string
+    - name: image
+      type:
+        scalar: string
+    - name: keyring
+      type:
+        scalar: string
+    - name: monitors
+      type:
+        list:
+          elementType:
+            scalar: string
+          elementRelationship: atomic
+    - name: pool
+      type:
+        scalar: string
+    - name: readOnly
+      type:
+        scalar: boolean
+    - name: secretRef
+      type:
+        namedType: io.k8s.api.core.v1.SecretReference
+    - name: user
+      type:
+        scalar: string
+- name: io.k8s.api.core.v1.RBDVolumeSource
+  map:
+    fields:
+    - name: fsType
+      type:
+        scalar: string
+    - name: image
+      type:
+        scalar: string
+    - name: keyring
+      type:
+        scalar: string
+    - name: monitors
+      type:
+        list:
+          elementType:
+            scalar: string
+          elementRelationship: atomic
+    - name: pool
+      type:
+        scalar: string
+    - name: readOnly
+      type:
+        scalar: boolean
+    - name: secretRef
+      type:
+        namedType: io.k8s.api.core.v1.LocalObjectReference
+    - name: user
+      type:
+        scalar: string
+- name: io.k8s.api.core.v1.ReplicationController
+  map:
+    fields:
+    - name: apiVersion
+      type:
+        scalar: string
+    - name: kind
+      type:
+        scalar: string
+    - name: metadata
+      type:
+        namedType: io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta
+    - name: spec
+      type:
+        namedType: io.k8s.api.core.v1.ReplicationControllerSpec
+    - name: status
+      type:
+        namedType: io.k8s.api.core.v1.ReplicationControllerStatus
+- name: io.k8s.api.core.v1.ReplicationControllerCondition
+  map:
+    fields:
+    - name: lastTransitionTime
+      type:
+        namedType: io.k8s.apimachinery.pkg.apis.meta.v1.Time
+    - name: message
+      type:
+        scalar: string
+    - name: reason
+      type:
+        scalar: string
+    - name: status
+      type:
+        scalar: string
+    - name: type
+      type:
+        scalar: string
+- name: io.k8s.api.core.v1.ReplicationControllerList
+  map:
+    fields:
+    - name: apiVersion
+      type:
+        scalar: string
+    - name: items
+      type:
+        list:
+          elementType:
+            namedType: io.k8s.api.core.v1.ReplicationController
+          elementRelationship: atomic
+    - name: kind
+      type:
+        scalar: string
+    - name: metadata
+      type:
+        namedType: io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta
+- name: io.k8s.api.core.v1.ReplicationControllerSpec
+  map:
+    fields:
+    - name: minReadySeconds
+      type:
+        scalar: numeric
+    - name: replicas
+      type:
+        scalar: numeric
+    - name: selector
+      type:
+        map:
+          elementType:
+            scalar: string
+    - name: template
+      type:
+        namedType: io.k8s.api.core.v1.PodTemplateSpec
+        elementRelationship: granular
+- name: io.k8s.api.core.v1.ReplicationControllerStatus
+  map:
+    fields:
+    - name: availableReplicas
+      type:
+        scalar: numeric
+    - name: conditions
+      type:
+        list:
+          elementType:
+            namedType: io.k8s.api.core.v1.ReplicationControllerCondition
+          elementRelationship: associative
+          keys:
+          - type
+    - name: fullyLabeledReplicas
+      type:
+        scalar: numeric
+    - name: observedGeneration
+      type:
+        scalar: numeric
+    - name: readyReplicas
+      type:
+        scalar: numeric
+    - name: replicas
+      type:
+        scalar: numeric
+- name: io.k8s.api.core.v1.ResourceFieldSelector
+  map:
+    fields:
+    - name: containerName
+      type:
+        scalar: string
+    - name: divisor
+      type:
+        namedType: io.k8s.apimachinery.pkg.api.resource.Quantity
+    - name: resource
+      type:
+        scalar: string
+- name: io.k8s.api.core.v1.ResourceQuota
+  map:
+    fields:
+    - name: apiVersion
+      type:
+        scalar: string
+    - name: kind
+      type:
+        scalar: string
+    - name: metadata
+      type:
+        namedType: io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta
+    - name: spec
+      type:
+        namedType: io.k8s.api.core.v1.ResourceQuotaSpec
+    - name: status
+      type:
+        namedType: io.k8s.api.core.v1.ResourceQuotaStatus
+- name: io.k8s.api.core.v1.ResourceQuotaList
+  map:
+    fields:
+    - name: apiVersion
+      type:
+        scalar: string
+    - name: items
+      type:
+        list:
+          elementType:
+            namedType: io.k8s.api.core.v1.ResourceQuota
+          elementRelationship: atomic
+    - name: kind
+      type:
+        scalar: string
+    - name: metadata
+      type:
+        namedType: io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta
+- name: io.k8s.api.core.v1.ResourceQuotaSpec
+  map:
+    fields:
+    - name: hard
+      type:
+        map:
+          elementType:
+            namedType: io.k8s.apimachinery.pkg.api.resource.Quantity
+    - name: scopeSelector
+      type:
+        namedType: io.k8s.api.core.v1.ScopeSelector
+    - name: scopes
+      type:
+        list:
+          elementType:
+            scalar: string
+          elementRelationship: atomic
+- name: io.k8s.api.core.v1.ResourceQuotaStatus
+  map:
+    fields:
+    - name: hard
+      type:
+        map:
+          elementType:
+            namedType: io.k8s.apimachinery.pkg.api.resource.Quantity
+    - name: used
+      type:
+        map:
+          elementType:
+            namedType: io.k8s.apimachinery.pkg.api.resource.Quantity
+- name: io.k8s.api.core.v1.ResourceRequirements
+  map:
+    fields:
+    - name: limits
+      type:
+        map:
+          elementType:
+            namedType: io.k8s.apimachinery.pkg.api.resource.Quantity
+    - name: requests
+      type:
+        map:
+          elementType:
+            namedType: io.k8s.apimachinery.pkg.api.resource.Quantity
+- name: io.k8s.api.core.v1.SELinuxOptions
+  map:
+    fields:
+    - name: level
+      type:
+        scalar: string
+    - name: role
+      type:
+        scalar: string
+    - name: type
+      type:
+        scalar: string
+    - name: user
+      type:
+        scalar: string
+- name: io.k8s.api.core.v1.ScaleIOPersistentVolumeSource
+  map:
+    fields:
+    - name: fsType
+      type:
+        scalar: string
+    - name: gateway
+      type:
+        scalar: string
+    - name: protectionDomain
+      type:
+        scalar: string
+    - name: readOnly
+      type:
+        scalar: boolean
+    - name: secretRef
+      type:
+        namedType: io.k8s.api.core.v1.SecretReference
+    - name: sslEnabled
+      type:
+        scalar: boolean
+    - name: storageMode
+      type:
+        scalar: string
+    - name: storagePool
+      type:
+        scalar: string
+    - name: system
+      type:
+        scalar: string
+    - name: volumeName
+      type:
+        scalar: string
+- name: io.k8s.api.core.v1.ScaleIOVolumeSource
+  map:
+    fields:
+    - name: fsType
+      type:
+        scalar: string
+    - name: gateway
+      type:
+        scalar: string
+    - name: protectionDomain
+      type:
+        scalar: string
+    - name: readOnly
+      type:
+        scalar: boolean
+    - name: secretRef
+      type:
+        namedType: io.k8s.api.core.v1.LocalObjectReference
+    - name: sslEnabled
+      type:
+        scalar: boolean
+    - name: storageMode
+      type:
+        scalar: string
+    - name: storagePool
+      type:
+        scalar: string
+    - name: system
+      type:
+        scalar: string
+    - name: volumeName
+      type:
+        scalar: string
+- name: io.k8s.api.core.v1.ScopeSelector
+  map:
+    fields:
+    - name: matchExpressions
+      type:
+        list:
+          elementType:
+            namedType: io.k8s.api.core.v1.ScopedResourceSelectorRequirement
+          elementRelationship: atomic
+- name: io.k8s.api.core.v1.ScopedResourceSelectorRequirement
+  map:
+    fields:
+    - name: operator
+      type:
+        scalar: string
+    - name: scopeName
+      type:
+        scalar: string
+    - name: values
+      type:
+        list:
+          elementType:
+            scalar: string
+          elementRelationship: atomic
+- name: io.k8s.api.core.v1.Secret
+  map:
+    fields:
+    - name: apiVersion
+      type:
+        scalar: string
+    - name: data
+      type:
+        map:
+          elementType:
+            scalar: string
+    - name: kind
+      type:
+        scalar: string
+    - name: metadata
+      type:
+        namedType: io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta
+    - name: stringData
+      type:
+        map:
+          elementType:
+            scalar: string
+    - name: type
+      type:
+        scalar: string
+- name: io.k8s.api.core.v1.SecretEnvSource
+  map:
+    fields:
+    - name: name
+      type:
+        scalar: string
+    - name: optional
+      type:
+        scalar: boolean
+- name: io.k8s.api.core.v1.SecretKeySelector
+  map:
+    fields:
+    - name: key
+      type:
+        scalar: string
+    - name: name
+      type:
+        scalar: string
+    - name: optional
+      type:
+        scalar: boolean
+- name: io.k8s.api.core.v1.SecretList
+  map:
+    fields:
+    - name: apiVersion
+      type:
+        scalar: string
+    - name: items
+      type:
+        list:
+          elementType:
+            namedType: io.k8s.api.core.v1.Secret
+          elementRelationship: atomic
+    - name: kind
+      type:
+        scalar: string
+    - name: metadata
+      type:
+        namedType: io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta
+- name: io.k8s.api.core.v1.SecretProjection
+  map:
+    fields:
+    - name: items
+      type:
+        list:
+          elementType:
+            namedType: io.k8s.api.core.v1.KeyToPath
+          elementRelationship: atomic
+    - name: name
+      type:
+        scalar: string
+    - name: optional
+      type:
+        scalar: boolean
+- name: io.k8s.api.core.v1.SecretReference
+  map:
+    fields:
+    - name: name
+      type:
+        scalar: string
+    - name: namespace
+      type:
+        scalar: string
+- name: io.k8s.api.core.v1.SecretVolumeSource
+  map:
+    fields:
+    - name: defaultMode
+      type:
+        scalar: numeric
+    - name: items
+      type:
+        list:
+          elementType:
+            namedType: io.k8s.api.core.v1.KeyToPath
+          elementRelationship: atomic
+    - name: optional
+      type:
+        scalar: boolean
+    - name: secretName
+      type:
+        scalar: string
+- name: io.k8s.api.core.v1.SecurityContext
+  map:
+    fields:
+    - name: allowPrivilegeEscalation
+      type:
+        scalar: boolean
+    - name: capabilities
+      type:
+        namedType: io.k8s.api.core.v1.Capabilities
+    - name: privileged
+      type:
+        scalar: boolean
+    - name: procMount
+      type:
+        scalar: string
+    - name: readOnlyRootFilesystem
+      type:
+        scalar: boolean
+    - name: runAsGroup
+      type:
+        scalar: numeric
+    - name: runAsNonRoot
+      type:
+        scalar: boolean
+    - name: runAsUser
+      type:
+        scalar: numeric
+    - name: seLinuxOptions
+      type:
+        namedType: io.k8s.api.core.v1.SELinuxOptions
+- name: io.k8s.api.core.v1.Service
+  map:
+    fields:
+    - name: apiVersion
+      type:
+        scalar: string
+    - name: kind
+      type:
+        scalar: string
+    - name: metadata
+      type:
+        namedType: io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta
+        elementRelationship: granular
+    - name: spec
+      type:
+        namedType: io.k8s.api.core.v1.ServiceSpec
+    - name: status
+      type:
+        namedType: io.k8s.api.core.v1.ServiceStatus
+- name: io.k8s.api.core.v1.ServiceAccount
+  map:
+    fields:
+    - name: apiVersion
+      type:
+        scalar: string
+    - name: automountServiceAccountToken
+      type:
+        scalar: boolean
+    - name: imagePullSecrets
+      type:
+        list:
+          elementType:
+            namedType: io.k8s.api.core.v1.LocalObjectReference
+          elementRelationship: atomic
+    - name: kind
+      type:
+        scalar: string
+    - name: metadata
+      type:
+        namedType: io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta
+    - name: secrets
+      type:
+        list:
+          elementType:
+            namedType: io.k8s.api.core.v1.ObjectReference
+          elementRelationship: associative
+          keys:
+          - name
+- name: io.k8s.api.core.v1.ServiceAccountList
+  map:
+    fields:
+    - name: apiVersion
+      type:
+        scalar: string
+    - name: items
+      type:
+        list:
+          elementType:
+            namedType: io.k8s.api.core.v1.ServiceAccount
+          elementRelationship: atomic
+    - name: kind
+      type:
+        scalar: string
+    - name: metadata
+      type:
+        namedType: io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta
+- name: io.k8s.api.core.v1.ServiceAccountTokenProjection
+  map:
+    fields:
+    - name: audience
+      type:
+        scalar: string
+    - name: expirationSeconds
+      type:
+        scalar: numeric
+    - name: path
+      type:
+        scalar: string
+- name: io.k8s.api.core.v1.ServiceList
+  map:
+    fields:
+    - name: apiVersion
+      type:
+        scalar: string
+    - name: items
+      type:
+        list:
+          elementType:
+            namedType: io.k8s.api.core.v1.Service
+          elementRelationship: atomic
+    - name: kind
+      type:
+        scalar: string
+    - name: metadata
+      type:
+        namedType: io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta
+- name: io.k8s.api.core.v1.ServicePort
+  map:
+    fields:
+    - name: name
+      type:
+        scalar: string
+    - name: nodePort
+      type:
+        scalar: numeric
+    - name: port
+      type:
+        scalar: numeric
+    - name: protocol
+      type:
+        scalar: string
+    - name: targetPort
+      type:
+        namedType: io.k8s.apimachinery.pkg.util.intstr.IntOrString
+- name: io.k8s.api.core.v1.ServiceSpec
+  map:
+    fields:
+    - name: clusterIP
+      type:
+        scalar: string
+    - name: externalIPs
+      type:
+        list:
+          elementType:
+            scalar: string
+          elementRelationship: atomic
+    - name: externalName
+      type:
+        scalar: string
+    - name: externalTrafficPolicy
+      type:
+        scalar: string
+    - name: healthCheckNodePort
+      type:
+        scalar: numeric
+    - name: loadBalancerIP
+      type:
+        scalar: string
+    - name: loadBalancerSourceRanges
+      type:
+        list:
+          elementType:
+            scalar: string
+          elementRelationship: atomic
+    - name: ports
+      type:
+        list:
+          elementType:
+            namedType: io.k8s.api.core.v1.ServicePort
+          elementRelationship: associative
+          keys:
+          - port
+    - name: publishNotReadyAddresses
+      type:
+        scalar: boolean
+    - name: selector
+      type:
+        map:
+          elementType:
+            scalar: string
+    - name: sessionAffinity
+      type:
+        scalar: string
+    - name: sessionAffinityConfig
+      type:
+        namedType: io.k8s.api.core.v1.SessionAffinityConfig
+        elementRelationship: granular
+    - name: type
+      type:
+        scalar: string
+- name: io.k8s.api.core.v1.ServiceStatus
+  map:
+    fields:
+    - name: loadBalancer
+      type:
+        namedType: io.k8s.api.core.v1.LoadBalancerStatus
+- name: io.k8s.api.core.v1.SessionAffinityConfig
+  map:
+    fields:
+    - name: clientIP
+      type:
+        namedType: io.k8s.api.core.v1.ClientIPConfig
+- name: io.k8s.api.core.v1.StorageOSPersistentVolumeSource
+  map:
+    fields:
+    - name: fsType
+      type:
+        scalar: string
+    - name: readOnly
+      type:
+        scalar: boolean
+    - name: secretRef
+      type:
+        namedType: io.k8s.api.core.v1.ObjectReference
+    - name: volumeName
+      type:
+        scalar: string
+    - name: volumeNamespace
+      type:
+        scalar: string
+- name: io.k8s.api.core.v1.StorageOSVolumeSource
+  map:
+    fields:
+    - name: fsType
+      type:
+        scalar: string
+    - name: readOnly
+      type:
+        scalar: boolean
+    - name: secretRef
+      type:
+        namedType: io.k8s.api.core.v1.LocalObjectReference
+    - name: volumeName
+      type:
+        scalar: string
+    - name: volumeNamespace
+      type:
+        scalar: string
+- name: io.k8s.api.core.v1.Sysctl
+  map:
+    fields:
+    - name: name
+      type:
+        scalar: string
+    - name: value
+      type:
+        scalar: string
+- name: io.k8s.api.core.v1.TCPSocketAction
+  map:
+    fields:
+    - name: host
+      type:
+        scalar: string
+    - name: port
+      type:
+        namedType: io.k8s.apimachinery.pkg.util.intstr.IntOrString
+        elementRelationship: granular
+- name: io.k8s.api.core.v1.Taint
+  map:
+    fields:
+    - name: effect
+      type:
+        scalar: string
+    - name: key
+      type:
+        scalar: string
+    - name: timeAdded
+      type:
+        namedType: io.k8s.apimachinery.pkg.apis.meta.v1.Time
+    - name: value
+      type:
+        scalar: string
+- name: io.k8s.api.core.v1.Toleration
+  map:
+    fields:
+    - name: effect
+      type:
+        scalar: string
+    - name: key
+      type:
+        scalar: string
+    - name: operator
+      type:
+        scalar: string
+    - name: tolerationSeconds
+      type:
+        scalar: numeric
+    - name: value
+      type:
+        scalar: string
+- name: io.k8s.api.core.v1.TopologySelectorLabelRequirement
+  map:
+    fields:
+    - name: key
+      type:
+        scalar: string
+    - name: values
+      type:
+        list:
+          elementType:
+            scalar: string
+          elementRelationship: atomic
+- name: io.k8s.api.core.v1.TopologySelectorTerm
+  map:
+    fields:
+    - name: matchLabelExpressions
+      type:
+        list:
+          elementType:
+            namedType: io.k8s.api.core.v1.TopologySelectorLabelRequirement
+          elementRelationship: atomic
+- name: io.k8s.api.core.v1.TypedLocalObjectReference
+  map:
+    fields:
+    - name: apiGroup
+      type:
+        scalar: string
+    - name: kind
+      type:
+        scalar: string
+    - name: name
+      type:
+        scalar: string
+- name: io.k8s.api.core.v1.Volume
+  map:
+    fields:
+    - name: awsElasticBlockStore
+      type:
+        namedType: io.k8s.api.core.v1.AWSElasticBlockStoreVolumeSource
+    - name: azureDisk
+      type:
+        namedType: io.k8s.api.core.v1.AzureDiskVolumeSource
+    - name: azureFile
+      type:
+        namedType: io.k8s.api.core.v1.AzureFileVolumeSource
+    - name: cephfs
+      type:
+        namedType: io.k8s.api.core.v1.CephFSVolumeSource
+    - name: cinder
+      type:
+        namedType: io.k8s.api.core.v1.CinderVolumeSource
+    - name: configMap
+      type:
+        namedType: io.k8s.api.core.v1.ConfigMapVolumeSource
+    - name: downwardAPI
+      type:
+        namedType: io.k8s.api.core.v1.DownwardAPIVolumeSource
+    - name: emptyDir
+      type:
+        namedType: io.k8s.api.core.v1.EmptyDirVolumeSource
+    - name: fc
+      type:
+        namedType: io.k8s.api.core.v1.FCVolumeSource
+    - name: flexVolume
+      type:
+        namedType: io.k8s.api.core.v1.FlexVolumeSource
+    - name: flocker
+      type:
+        namedType: io.k8s.api.core.v1.FlockerVolumeSource
+    - name: gcePersistentDisk
+      type:
+        namedType: io.k8s.api.core.v1.GCEPersistentDiskVolumeSource
+        elementRelationship: granular
+    - name: gitRepo
+      type:
+        namedType: io.k8s.api.core.v1.GitRepoVolumeSource
+    - name: glusterfs
+      type:
+        namedType: io.k8s.api.core.v1.GlusterfsVolumeSource
+    - name: hostPath
+      type:
+        namedType: io.k8s.api.core.v1.HostPathVolumeSource
+    - name: iscsi
+      type:
+        namedType: io.k8s.api.core.v1.ISCSIVolumeSource
+    - name: name
+      type:
+        scalar: string
+    - name: nfs
+      type:
+        namedType: io.k8s.api.core.v1.NFSVolumeSource
+    - name: persistentVolumeClaim
+      type:
+        namedType: io.k8s.api.core.v1.PersistentVolumeClaimVolumeSource
+    - name: photonPersistentDisk
+      type:
+        namedType: io.k8s.api.core.v1.PhotonPersistentDiskVolumeSource
+    - name: portworxVolume
+      type:
+        namedType: io.k8s.api.core.v1.PortworxVolumeSource
+    - name: projected
+      type:
+        namedType: io.k8s.api.core.v1.ProjectedVolumeSource
+        elementRelationship: granular
+    - name: quobyte
+      type:
+        namedType: io.k8s.api.core.v1.QuobyteVolumeSource
+    - name: rbd
+      type:
+        namedType: io.k8s.api.core.v1.RBDVolumeSource
+    - name: scaleIO
+      type:
+        namedType: io.k8s.api.core.v1.ScaleIOVolumeSource
+    - name: secret
+      type:
+        namedType: io.k8s.api.core.v1.SecretVolumeSource
+    - name: storageos
+      type:
+        namedType: io.k8s.api.core.v1.StorageOSVolumeSource
+        elementRelationship: granular
+    - name: vsphereVolume
+      type:
+        namedType: io.k8s.api.core.v1.VsphereVirtualDiskVolumeSource
+    unions:
+    - fields:
+      - fieldName: awsElasticBlockStore
+        discriminatorValue: AWSElasticBlockStore
+      - fieldName: azureDisk
+        discriminatorValue: AzureDisk
+      - fieldName: azureFile
+        discriminatorValue: AzureFile
+      - fieldName: cephfs
+        discriminatorValue: CephFS
+      - fieldName: cinder
+        discriminatorValue: Cinder
+      - fieldName: configMap
+        discriminatorValue: ConfigMap
+      - fieldName: downwardAPI
+        discriminatorValue: DownwardAPI
+      - fieldName: emptyDir
+        discriminatorValue: EmptyDir
+      - fieldName: fc
+        discriminatorValue: FC
+      - fieldName: flexVolume
+        discriminatorValue: FlexVolume
+      - fieldName: flocker
+        discriminatorValue: Flocker
+      - fieldName: gcePersistentDisk
+        discriminatorValue: GCEPersistentDisk
+      - fieldName: gitRepo
+        discriminatorValue: GitRepo
+      - fieldName: glusterfs
+        discriminatorValue: Glusterfs
+      - fieldName: hostPath
+        discriminatorValue: HostPath
+      - fieldName: iscsi
+        discriminatorValue: ISCSI
+      - fieldName: nfs
+        discriminatorValue: NFS
+      - fieldName: persistentVolumeClaim
+        discriminatorValue: PersistentVolumeClaim
+      - fieldName: photonPersistentDisk
+        discriminatorValue: PhotonPersistentDisk
+      - fieldName: portworxVolume
+        discriminatorValue: PortworxVolume
+      - fieldName: projected
+        discriminatorValue: Projected
+      - fieldName: quobyte
+        discriminatorValue: Quobyte
+      - fieldName: rbd
+        discriminatorValue: RBD
+      - fieldName: scaleIO
+        discriminatorValue: ScaleIO
+      - fieldName: secret
+        discriminatorValue: Secret
+      - fieldName: storageos
+        discriminatorValue: StorageOS
+      - fieldName: vsphereVolume
+        discriminatorValue: VsphereVolume
+- name: io.k8s.api.core.v1.VolumeDevice
+  map:
+    fields:
+    - name: devicePath
+      type:
+        scalar: string
+    - name: name
+      type:
+        scalar: string
+- name: io.k8s.api.core.v1.VolumeMount
+  map:
+    fields:
+    - name: mountPath
+      type:
+        scalar: string
+    - name: mountPropagation
+      type:
+        scalar: string
+    - name: name
+      type:
+        scalar: string
+    - name: readOnly
+      type:
+        scalar: boolean
+    - name: subPath
+      type:
+        scalar: string
+- name: io.k8s.api.core.v1.VolumeNodeAffinity
+  map:
+    fields:
+    - name: required
+      type:
+        namedType: io.k8s.api.core.v1.NodeSelector
+- name: io.k8s.api.core.v1.VolumeProjection
+  map:
+    fields:
+    - name: configMap
+      type:
+        namedType: io.k8s.api.core.v1.ConfigMapProjection
+    - name: downwardAPI
+      type:
+        namedType: io.k8s.api.core.v1.DownwardAPIProjection
+    - name: secret
+      type:
+        namedType: io.k8s.api.core.v1.SecretProjection
+    - name: serviceAccountToken
+      type:
+        namedType: io.k8s.api.core.v1.ServiceAccountTokenProjection
+- name: io.k8s.api.core.v1.VsphereVirtualDiskVolumeSource
+  map:
+    fields:
+    - name: fsType
+      type:
+        scalar: string
+    - name: storagePolicyID
+      type:
+        scalar: string
+    - name: storagePolicyName
+      type:
+        scalar: string
+    - name: volumePath
+      type:
+        scalar: string
+- name: io.k8s.api.core.v1.WeightedPodAffinityTerm
+  map:
+    fields:
+    - name: podAffinityTerm
+      type:
+        namedType: io.k8s.api.core.v1.PodAffinityTerm
+    - name: weight
+      type:
+        scalar: numeric
+- name: io.k8s.api.events.v1beta1.Event
+  map:
+    fields:
+    - name: action
+      type:
+        scalar: string
+    - name: apiVersion
+      type:
+        scalar: string
+    - name: deprecatedCount
+      type:
+        scalar: numeric
+    - name: deprecatedFirstTimestamp
+      type:
+        namedType: io.k8s.apimachinery.pkg.apis.meta.v1.Time
+    - name: deprecatedLastTimestamp
+      type:
+        namedType: io.k8s.apimachinery.pkg.apis.meta.v1.Time
+    - name: deprecatedSource
+      type:
+        namedType: io.k8s.api.core.v1.EventSource
+    - name: eventTime
+      type:
+        namedType: io.k8s.apimachinery.pkg.apis.meta.v1.MicroTime
+    - name: kind
+      type:
+        scalar: string
+    - name: metadata
+      type:
+        namedType: io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta
+    - name: note
+      type:
+        scalar: string
+    - name: reason
+      type:
+        scalar: string
+    - name: regarding
+      type:
+        namedType: io.k8s.api.core.v1.ObjectReference
+    - name: related
+      type:
+        namedType: io.k8s.api.core.v1.ObjectReference
+    - name: reportingController
+      type:
+        scalar: string
+    - name: reportingInstance
+      type:
+        scalar: string
+    - name: series
+      type:
+        namedType: io.k8s.api.events.v1beta1.EventSeries
+    - name: type
+      type:
+        scalar: string
+- name: io.k8s.api.events.v1beta1.EventList
+  map:
+    fields:
+    - name: apiVersion
+      type:
+        scalar: string
+    - name: items
+      type:
+        list:
+          elementType:
+            namedType: io.k8s.api.events.v1beta1.Event
+          elementRelationship: atomic
+    - name: kind
+      type:
+        scalar: string
+    - name: metadata
+      type:
+        namedType: io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta
+- name: io.k8s.api.events.v1beta1.EventSeries
+  map:
+    fields:
+    - name: count
+      type:
+        scalar: numeric
+    - name: lastObservedTime
+      type:
+        namedType: io.k8s.apimachinery.pkg.apis.meta.v1.MicroTime
+    - name: state
+      type:
+        scalar: string
+- name: io.k8s.api.extensions.v1beta1.AllowedFlexVolume
+  map:
+    fields:
+    - name: driver
+      type:
+        scalar: string
+- name: io.k8s.api.extensions.v1beta1.AllowedHostPath
+  map:
+    fields:
+    - name: pathPrefix
+      type:
+        scalar: string
+    - name: readOnly
+      type:
+        scalar: boolean
+- name: io.k8s.api.extensions.v1beta1.DaemonSet
+  map:
+    fields:
+    - name: apiVersion
+      type:
+        scalar: string
+    - name: kind
+      type:
+        scalar: string
+    - name: metadata
+      type:
+        namedType: io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta
+    - name: spec
+      type:
+        namedType: io.k8s.api.extensions.v1beta1.DaemonSetSpec
+    - name: status
+      type:
+        namedType: io.k8s.api.extensions.v1beta1.DaemonSetStatus
+- name: io.k8s.api.extensions.v1beta1.DaemonSetCondition
+  map:
+    fields:
+    - name: lastTransitionTime
+      type:
+        namedType: io.k8s.apimachinery.pkg.apis.meta.v1.Time
+    - name: message
+      type:
+        scalar: string
+    - name: reason
+      type:
+        scalar: string
+    - name: status
+      type:
+        scalar: string
+    - name: type
+      type:
+        scalar: string
+- name: io.k8s.api.extensions.v1beta1.DaemonSetList
+  map:
+    fields:
+    - name: apiVersion
+      type:
+        scalar: string
+    - name: items
+      type:
+        list:
+          elementType:
+            namedType: io.k8s.api.extensions.v1beta1.DaemonSet
+          elementRelationship: atomic
+    - name: kind
+      type:
+        scalar: string
+    - name: metadata
+      type:
+        namedType: io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta
+- name: io.k8s.api.extensions.v1beta1.DaemonSetSpec
+  map:
+    fields:
+    - name: minReadySeconds
+      type:
+        scalar: numeric
+    - name: revisionHistoryLimit
+      type:
+        scalar: numeric
+    - name: selector
+      type:
+        namedType: io.k8s.apimachinery.pkg.apis.meta.v1.LabelSelector
+    - name: template
+      type:
+        namedType: io.k8s.api.core.v1.PodTemplateSpec
+    - name: templateGeneration
+      type:
+        scalar: numeric
+    - name: updateStrategy
+      type:
+        namedType: io.k8s.api.extensions.v1beta1.DaemonSetUpdateStrategy
+- name: io.k8s.api.extensions.v1beta1.DaemonSetStatus
+  map:
+    fields:
+    - name: collisionCount
+      type:
+        scalar: numeric
+    - name: conditions
+      type:
+        list:
+          elementType:
+            namedType: io.k8s.api.extensions.v1beta1.DaemonSetCondition
+          elementRelationship: associative
+          keys:
+          - type
+    - name: currentNumberScheduled
+      type:
+        scalar: numeric
+    - name: desiredNumberScheduled
+      type:
+        scalar: numeric
+    - name: numberAvailable
+      type:
+        scalar: numeric
+    - name: numberMisscheduled
+      type:
+        scalar: numeric
+    - name: numberReady
+      type:
+        scalar: numeric
+    - name: numberUnavailable
+      type:
+        scalar: numeric
+    - name: observedGeneration
+      type:
+        scalar: numeric
+    - name: updatedNumberScheduled
+      type:
+        scalar: numeric
+- name: io.k8s.api.extensions.v1beta1.DaemonSetUpdateStrategy
+  map:
+    fields:
+    - name: rollingUpdate
+      type:
+        namedType: io.k8s.api.extensions.v1beta1.RollingUpdateDaemonSet
+    - name: type
+      type:
+        scalar: string
+- name: io.k8s.api.extensions.v1beta1.Deployment
+  map:
+    fields:
+    - name: apiVersion
+      type:
+        scalar: string
+    - name: kind
+      type:
+        scalar: string
+    - name: metadata
+      type:
+        namedType: io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta
+    - name: spec
+      type:
+        namedType: io.k8s.api.extensions.v1beta1.DeploymentSpec
+    - name: status
+      type:
+        namedType: io.k8s.api.extensions.v1beta1.DeploymentStatus
+- name: io.k8s.api.extensions.v1beta1.DeploymentCondition
+  map:
+    fields:
+    - name: lastTransitionTime
+      type:
+        namedType: io.k8s.apimachinery.pkg.apis.meta.v1.Time
+    - name: lastUpdateTime
+      type:
+        namedType: io.k8s.apimachinery.pkg.apis.meta.v1.Time
+    - name: message
+      type:
+        scalar: string
+    - name: reason
+      type:
+        scalar: string
+    - name: status
+      type:
+        scalar: string
+    - name: type
+      type:
+        scalar: string
+- name: io.k8s.api.extensions.v1beta1.DeploymentList
+  map:
+    fields:
+    - name: apiVersion
+      type:
+        scalar: string
+    - name: items
+      type:
+        list:
+          elementType:
+            namedType: io.k8s.api.extensions.v1beta1.Deployment
+          elementRelationship: atomic
+    - name: kind
+      type:
+        scalar: string
+    - name: metadata
+      type:
+        namedType: io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta
+- name: io.k8s.api.extensions.v1beta1.DeploymentRollback
+  map:
+    fields:
+    - name: apiVersion
+      type:
+        scalar: string
+    - name: kind
+      type:
+        scalar: string
+    - name: name
+      type:
+        scalar: string
+    - name: rollbackTo
+      type:
+        namedType: io.k8s.api.extensions.v1beta1.RollbackConfig
+        elementRelationship: granular
+    - name: updatedAnnotations
+      type:
+        map:
+          elementType:
+            scalar: string
+- name: io.k8s.api.extensions.v1beta1.DeploymentSpec
+  map:
+    fields:
+    - name: minReadySeconds
+      type:
+        scalar: numeric
+    - name: paused
+      type:
+        scalar: boolean
+    - name: progressDeadlineSeconds
+      type:
+        scalar: numeric
+    - name: replicas
+      type:
+        scalar: numeric
+    - name: revisionHistoryLimit
+      type:
+        scalar: numeric
+    - name: rollbackTo
+      type:
+        namedType: io.k8s.api.extensions.v1beta1.RollbackConfig
+    - name: selector
+      type:
+        namedType: io.k8s.apimachinery.pkg.apis.meta.v1.LabelSelector
+    - name: strategy
+      type:
+        namedType: io.k8s.api.extensions.v1beta1.DeploymentStrategy
+    - name: template
+      type:
+        namedType: io.k8s.api.core.v1.PodTemplateSpec
+- name: io.k8s.api.extensions.v1beta1.DeploymentStatus
+  map:
+    fields:
+    - name: availableReplicas
+      type:
+        scalar: numeric
+    - name: collisionCount
+      type:
+        scalar: numeric
+    - name: conditions
+      type:
+        list:
+          elementType:
+            namedType: io.k8s.api.extensions.v1beta1.DeploymentCondition
+          elementRelationship: associative
+          keys:
+          - type
+    - name: observedGeneration
+      type:
+        scalar: numeric
+    - name: readyReplicas
+      type:
+        scalar: numeric
+    - name: replicas
+      type:
+        scalar: numeric
+    - name: unavailableReplicas
+      type:
+        scalar: numeric
+    - name: updatedReplicas
+      type:
+        scalar: numeric
+- name: io.k8s.api.extensions.v1beta1.DeploymentStrategy
+  map:
+    fields:
+    - name: rollingUpdate
+      type:
+        namedType: io.k8s.api.extensions.v1beta1.RollingUpdateDeployment
+    - name: type
+      type:
+        scalar: string
+- name: io.k8s.api.extensions.v1beta1.FSGroupStrategyOptions
+  map:
+    fields:
+    - name: ranges
+      type:
+        list:
+          elementType:
+            namedType: io.k8s.api.extensions.v1beta1.IDRange
+          elementRelationship: atomic
+    - name: rule
+      type:
+        scalar: string
+- name: io.k8s.api.extensions.v1beta1.HTTPIngressPath
+  map:
+    fields:
+    - name: backend
+      type:
+        namedType: io.k8s.api.extensions.v1beta1.IngressBackend
+    - name: path
+      type:
+        scalar: string
+- name: io.k8s.api.extensions.v1beta1.HTTPIngressRuleValue
+  map:
+    fields:
+    - name: paths
+      type:
+        list:
+          elementType:
+            namedType: io.k8s.api.extensions.v1beta1.HTTPIngressPath
+          elementRelationship: atomic
+- name: io.k8s.api.extensions.v1beta1.HostPortRange
+  map:
+    fields:
+    - name: max
+      type:
+        scalar: numeric
+    - name: min
+      type:
+        scalar: numeric
+- name: io.k8s.api.extensions.v1beta1.IDRange
+  map:
+    fields:
+    - name: max
+      type:
+        scalar: numeric
+    - name: min
+      type:
+        scalar: numeric
+- name: io.k8s.api.extensions.v1beta1.IPBlock
+  map:
+    fields:
+    - name: cidr
+      type:
+        scalar: string
+    - name: except
+      type:
+        list:
+          elementType:
+            scalar: string
+          elementRelationship: atomic
+- name: io.k8s.api.extensions.v1beta1.Ingress
+  map:
+    fields:
+    - name: apiVersion
+      type:
+        scalar: string
+    - name: kind
+      type:
+        scalar: string
+    - name: metadata
+      type:
+        namedType: io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta
+    - name: spec
+      type:
+        namedType: io.k8s.api.extensions.v1beta1.IngressSpec
+    - name: status
+      type:
+        namedType: io.k8s.api.extensions.v1beta1.IngressStatus
+- name: io.k8s.api.extensions.v1beta1.IngressBackend
+  map:
+    fields:
+    - name: serviceName
+      type:
+        scalar: string
+    - name: servicePort
+      type:
+        namedType: io.k8s.apimachinery.pkg.util.intstr.IntOrString
+- name: io.k8s.api.extensions.v1beta1.IngressList
+  map:
+    fields:
+    - name: apiVersion
+      type:
+        scalar: string
+    - name: items
+      type:
+        list:
+          elementType:
+            namedType: io.k8s.api.extensions.v1beta1.Ingress
+          elementRelationship: atomic
+    - name: kind
+      type:
+        scalar: string
+    - name: metadata
+      type:
+        namedType: io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta
+- name: io.k8s.api.extensions.v1beta1.IngressRule
+  map:
+    fields:
+    - name: host
+      type:
+        scalar: string
+    - name: http
+      type:
+        namedType: io.k8s.api.extensions.v1beta1.HTTPIngressRuleValue
+- name: io.k8s.api.extensions.v1beta1.IngressSpec
+  map:
+    fields:
+    - name: backend
+      type:
+        namedType: io.k8s.api.extensions.v1beta1.IngressBackend
+        elementRelationship: granular
+    - name: rules
+      type:
+        list:
+          elementType:
+            namedType: io.k8s.api.extensions.v1beta1.IngressRule
+          elementRelationship: atomic
+    - name: tls
+      type:
+        list:
+          elementType:
+            namedType: io.k8s.api.extensions.v1beta1.IngressTLS
+          elementRelationship: atomic
+- name: io.k8s.api.extensions.v1beta1.IngressStatus
+  map:
+    fields:
+    - name: loadBalancer
+      type:
+        namedType: io.k8s.api.core.v1.LoadBalancerStatus
+- name: io.k8s.api.extensions.v1beta1.IngressTLS
+  map:
+    fields:
+    - name: hosts
+      type:
+        list:
+          elementType:
+            scalar: string
+          elementRelationship: atomic
+    - name: secretName
+      type:
+        scalar: string
+- name: io.k8s.api.extensions.v1beta1.NetworkPolicy
+  map:
+    fields:
+    - name: apiVersion
+      type:
+        scalar: string
+    - name: kind
+      type:
+        scalar: string
+    - name: metadata
+      type:
+        namedType: io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta
+    - name: spec
+      type:
+        namedType: io.k8s.api.extensions.v1beta1.NetworkPolicySpec
+- name: io.k8s.api.extensions.v1beta1.NetworkPolicyEgressRule
+  map:
+    fields:
+    - name: ports
+      type:
+        list:
+          elementType:
+            namedType: io.k8s.api.extensions.v1beta1.NetworkPolicyPort
+          elementRelationship: atomic
+    - name: to
+      type:
+        list:
+          elementType:
+            namedType: io.k8s.api.extensions.v1beta1.NetworkPolicyPeer
+          elementRelationship: atomic
+- name: io.k8s.api.extensions.v1beta1.NetworkPolicyIngressRule
+  map:
+    fields:
+    - name: from
+      type:
+        list:
+          elementType:
+            namedType: io.k8s.api.extensions.v1beta1.NetworkPolicyPeer
+          elementRelationship: atomic
+    - name: ports
+      type:
+        list:
+          elementType:
+            namedType: io.k8s.api.extensions.v1beta1.NetworkPolicyPort
+          elementRelationship: atomic
+- name: io.k8s.api.extensions.v1beta1.NetworkPolicyList
+  map:
+    fields:
+    - name: apiVersion
+      type:
+        scalar: string
+    - name: items
+      type:
+        list:
+          elementType:
+            namedType: io.k8s.api.extensions.v1beta1.NetworkPolicy
+          elementRelationship: atomic
+    - name: kind
+      type:
+        scalar: string
+    - name: metadata
+      type:
+        namedType: io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta
+- name: io.k8s.api.extensions.v1beta1.NetworkPolicyPeer
+  map:
+    fields:
+    - name: ipBlock
+      type:
+        namedType: io.k8s.api.extensions.v1beta1.IPBlock
+    - name: namespaceSelector
+      type:
+        namedType: io.k8s.apimachinery.pkg.apis.meta.v1.LabelSelector
+    - name: podSelector
+      type:
+        namedType: io.k8s.apimachinery.pkg.apis.meta.v1.LabelSelector
+- name: io.k8s.api.extensions.v1beta1.NetworkPolicyPort
+  map:
+    fields:
+    - name: port
+      type:
+        namedType: io.k8s.apimachinery.pkg.util.intstr.IntOrString
+        elementRelationship: granular
+    - name: protocol
+      type:
+        scalar: string
+- name: io.k8s.api.extensions.v1beta1.NetworkPolicySpec
+  map:
+    fields:
+    - name: egress
+      type:
+        list:
+          elementType:
+            namedType: io.k8s.api.extensions.v1beta1.NetworkPolicyEgressRule
+          elementRelationship: atomic
+    - name: ingress
+      type:
+        list:
+          elementType:
+            namedType: io.k8s.api.extensions.v1beta1.NetworkPolicyIngressRule
+          elementRelationship: atomic
+    - name: podSelector
+      type:
+        namedType: io.k8s.apimachinery.pkg.apis.meta.v1.LabelSelector
+    - name: policyTypes
+      type:
+        list:
+          elementType:
+            scalar: string
+          elementRelationship: atomic
+- name: io.k8s.api.extensions.v1beta1.PodSecurityPolicy
+  map:
+    fields:
+    - name: apiVersion
+      type:
+        scalar: string
+    - name: kind
+      type:
+        scalar: string
+    - name: metadata
+      type:
+        namedType: io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta
+    - name: spec
+      type:
+        namedType: io.k8s.api.extensions.v1beta1.PodSecurityPolicySpec
+- name: io.k8s.api.extensions.v1beta1.PodSecurityPolicyList
+  map:
+    fields:
+    - name: apiVersion
+      type:
+        scalar: string
+    - name: items
+      type:
+        list:
+          elementType:
+            namedType: io.k8s.api.extensions.v1beta1.PodSecurityPolicy
+          elementRelationship: atomic
+    - name: kind
+      type:
+        scalar: string
+    - name: metadata
+      type:
+        namedType: io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta
+- name: io.k8s.api.extensions.v1beta1.PodSecurityPolicySpec
+  map:
+    fields:
+    - name: allowPrivilegeEscalation
+      type:
+        scalar: boolean
+    - name: allowedCapabilities
+      type:
+        list:
+          elementType:
+            scalar: string
+          elementRelationship: atomic
+    - name: allowedFlexVolumes
+      type:
+        list:
+          elementType:
+            namedType: io.k8s.api.extensions.v1beta1.AllowedFlexVolume
+          elementRelationship: atomic
+    - name: allowedHostPaths
+      type:
+        list:
+          elementType:
+            namedType: io.k8s.api.extensions.v1beta1.AllowedHostPath
+          elementRelationship: atomic
+    - name: allowedProcMountTypes
+      type:
+        list:
+          elementType:
+            scalar: string
+          elementRelationship: atomic
+    - name: allowedUnsafeSysctls
+      type:
+        list:
+          elementType:
+            scalar: string
+          elementRelationship: atomic
+    - name: defaultAddCapabilities
+      type:
+        list:
+          elementType:
+            scalar: string
+          elementRelationship: atomic
+    - name: defaultAllowPrivilegeEscalation
+      type:
+        scalar: boolean
+    - name: forbiddenSysctls
+      type:
+        list:
+          elementType:
+            scalar: string
+          elementRelationship: atomic
+    - name: fsGroup
+      type:
+        namedType: io.k8s.api.extensions.v1beta1.FSGroupStrategyOptions
+    - name: hostIPC
+      type:
+        scalar: boolean
+    - name: hostNetwork
+      type:
+        scalar: boolean
+    - name: hostPID
+      type:
+        scalar: boolean
+    - name: hostPorts
+      type:
+        list:
+          elementType:
+            namedType: io.k8s.api.extensions.v1beta1.HostPortRange
+          elementRelationship: atomic
+    - name: privileged
+      type:
+        scalar: boolean
+    - name: readOnlyRootFilesystem
+      type:
+        scalar: boolean
+    - name: requiredDropCapabilities
+      type:
+        list:
+          elementType:
+            scalar: string
+          elementRelationship: atomic
+    - name: runAsGroup
+      type:
+        namedType: io.k8s.api.extensions.v1beta1.RunAsGroupStrategyOptions
+    - name: runAsUser
+      type:
+        namedType: io.k8s.api.extensions.v1beta1.RunAsUserStrategyOptions
+    - name: seLinux
+      type:
+        namedType: io.k8s.api.extensions.v1beta1.SELinuxStrategyOptions
+    - name: supplementalGroups
+      type:
+        namedType: io.k8s.api.extensions.v1beta1.SupplementalGroupsStrategyOptions
+    - name: volumes
+      type:
+        list:
+          elementType:
+            scalar: string
+          elementRelationship: atomic
+- name: io.k8s.api.extensions.v1beta1.ReplicaSet
+  map:
+    fields:
+    - name: apiVersion
+      type:
+        scalar: string
+    - name: kind
+      type:
+        scalar: string
+    - name: metadata
+      type:
+        namedType: io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta
+        elementRelationship: granular
+    - name: spec
+      type:
+        namedType: io.k8s.api.extensions.v1beta1.ReplicaSetSpec
+    - name: status
+      type:
+        namedType: io.k8s.api.extensions.v1beta1.ReplicaSetStatus
+- name: io.k8s.api.extensions.v1beta1.ReplicaSetCondition
+  map:
+    fields:
+    - name: lastTransitionTime
+      type:
+        namedType: io.k8s.apimachinery.pkg.apis.meta.v1.Time
+    - name: message
+      type:
+        scalar: string
+    - name: reason
+      type:
+        scalar: string
+    - name: status
+      type:
+        scalar: string
+    - name: type
+      type:
+        scalar: string
+- name: io.k8s.api.extensions.v1beta1.ReplicaSetList
+  map:
+    fields:
+    - name: apiVersion
+      type:
+        scalar: string
+    - name: items
+      type:
+        list:
+          elementType:
+            namedType: io.k8s.api.extensions.v1beta1.ReplicaSet
+          elementRelationship: atomic
+    - name: kind
+      type:
+        scalar: string
+    - name: metadata
+      type:
+        namedType: io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta
+- name: io.k8s.api.extensions.v1beta1.ReplicaSetSpec
+  map:
+    fields:
+    - name: minReadySeconds
+      type:
+        scalar: numeric
+    - name: replicas
+      type:
+        scalar: numeric
+    - name: selector
+      type:
+        namedType: io.k8s.apimachinery.pkg.apis.meta.v1.LabelSelector
+    - name: template
+      type:
+        namedType: io.k8s.api.core.v1.PodTemplateSpec
+- name: io.k8s.api.extensions.v1beta1.ReplicaSetStatus
+  map:
+    fields:
+    - name: availableReplicas
+      type:
+        scalar: numeric
+    - name: conditions
+      type:
+        list:
+          elementType:
+            namedType: io.k8s.api.extensions.v1beta1.ReplicaSetCondition
+          elementRelationship: associative
+          keys:
+          - type
+    - name: fullyLabeledReplicas
+      type:
+        scalar: numeric
+    - name: observedGeneration
+      type:
+        scalar: numeric
+    - name: readyReplicas
+      type:
+        scalar: numeric
+    - name: replicas
+      type:
+        scalar: numeric
+- name: io.k8s.api.extensions.v1beta1.RollbackConfig
+  map:
+    fields:
+    - name: revision
+      type:
+        scalar: numeric
+- name: io.k8s.api.extensions.v1beta1.RollingUpdateDaemonSet
+  map:
+    fields:
+    - name: maxUnavailable
+      type:
+        namedType: io.k8s.apimachinery.pkg.util.intstr.IntOrString
+- name: io.k8s.api.extensions.v1beta1.RollingUpdateDeployment
+  map:
+    fields:
+    - name: maxSurge
+      type:
+        namedType: io.k8s.apimachinery.pkg.util.intstr.IntOrString
+    - name: maxUnavailable
+      type:
+        namedType: io.k8s.apimachinery.pkg.util.intstr.IntOrString
+- name: io.k8s.api.extensions.v1beta1.RunAsGroupStrategyOptions
+  map:
+    fields:
+    - name: ranges
+      type:
+        list:
+          elementType:
+            namedType: io.k8s.api.extensions.v1beta1.IDRange
+          elementRelationship: atomic
+    - name: rule
+      type:
+        scalar: string
+- name: io.k8s.api.extensions.v1beta1.RunAsUserStrategyOptions
+  map:
+    fields:
+    - name: ranges
+      type:
+        list:
+          elementType:
+            namedType: io.k8s.api.extensions.v1beta1.IDRange
+          elementRelationship: atomic
+    - name: rule
+      type:
+        scalar: string
+- name: io.k8s.api.extensions.v1beta1.SELinuxStrategyOptions
+  map:
+    fields:
+    - name: rule
+      type:
+        scalar: string
+    - name: seLinuxOptions
+      type:
+        namedType: io.k8s.api.core.v1.SELinuxOptions
+- name: io.k8s.api.extensions.v1beta1.Scale
+  map:
+    fields:
+    - name: apiVersion
+      type:
+        scalar: string
+    - name: kind
+      type:
+        scalar: string
+    - name: metadata
+      type:
+        namedType: io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta
+    - name: spec
+      type:
+        namedType: io.k8s.api.extensions.v1beta1.ScaleSpec
+        elementRelationship: granular
+    - name: status
+      type:
+        namedType: io.k8s.api.extensions.v1beta1.ScaleStatus
+- name: io.k8s.api.extensions.v1beta1.ScaleSpec
+  map:
+    fields:
+    - name: replicas
+      type:
+        scalar: numeric
+- name: io.k8s.api.extensions.v1beta1.ScaleStatus
+  map:
+    fields:
+    - name: replicas
+      type:
+        scalar: numeric
+    - name: selector
+      type:
+        map:
+          elementType:
+            scalar: string
+    - name: targetSelector
+      type:
+        scalar: string
+- name: io.k8s.api.extensions.v1beta1.SupplementalGroupsStrategyOptions
+  map:
+    fields:
+    - name: ranges
+      type:
+        list:
+          elementType:
+            namedType: io.k8s.api.extensions.v1beta1.IDRange
+          elementRelationship: atomic
+    - name: rule
+      type:
+        scalar: string
+- name: io.k8s.api.networking.v1.IPBlock
+  map:
+    fields:
+    - name: cidr
+      type:
+        scalar: string
+    - name: except
+      type:
+        list:
+          elementType:
+            scalar: string
+          elementRelationship: atomic
+- name: io.k8s.api.networking.v1.NetworkPolicy
+  map:
+    fields:
+    - name: apiVersion
+      type:
+        scalar: string
+    - name: kind
+      type:
+        scalar: string
+    - name: metadata
+      type:
+        namedType: io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta
+    - name: spec
+      type:
+        namedType: io.k8s.api.networking.v1.NetworkPolicySpec
+- name: io.k8s.api.networking.v1.NetworkPolicyEgressRule
+  map:
+    fields:
+    - name: ports
+      type:
+        list:
+          elementType:
+            namedType: io.k8s.api.networking.v1.NetworkPolicyPort
+          elementRelationship: atomic
+    - name: to
+      type:
+        list:
+          elementType:
+            namedType: io.k8s.api.networking.v1.NetworkPolicyPeer
+          elementRelationship: atomic
+- name: io.k8s.api.networking.v1.NetworkPolicyIngressRule
+  map:
+    fields:
+    - name: from
+      type:
+        list:
+          elementType:
+            namedType: io.k8s.api.networking.v1.NetworkPolicyPeer
+          elementRelationship: atomic
+    - name: ports
+      type:
+        list:
+          elementType:
+            namedType: io.k8s.api.networking.v1.NetworkPolicyPort
+          elementRelationship: atomic
+- name: io.k8s.api.networking.v1.NetworkPolicyList
+  map:
+    fields:
+    - name: apiVersion
+      type:
+        scalar: string
+    - name: items
+      type:
+        list:
+          elementType:
+            namedType: io.k8s.api.networking.v1.NetworkPolicy
+          elementRelationship: atomic
+    - name: kind
+      type:
+        scalar: string
+    - name: metadata
+      type:
+        namedType: io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta
+- name: io.k8s.api.networking.v1.NetworkPolicyPeer
+  map:
+    fields:
+    - name: ipBlock
+      type:
+        namedType: io.k8s.api.networking.v1.IPBlock
+    - name: namespaceSelector
+      type:
+        namedType: io.k8s.apimachinery.pkg.apis.meta.v1.LabelSelector
+    - name: podSelector
+      type:
+        namedType: io.k8s.apimachinery.pkg.apis.meta.v1.LabelSelector
+- name: io.k8s.api.networking.v1.NetworkPolicyPort
+  map:
+    fields:
+    - name: port
+      type:
+        namedType: io.k8s.apimachinery.pkg.util.intstr.IntOrString
+    - name: protocol
+      type:
+        scalar: string
+- name: io.k8s.api.networking.v1.NetworkPolicySpec
+  map:
+    fields:
+    - name: egress
+      type:
+        list:
+          elementType:
+            namedType: io.k8s.api.networking.v1.NetworkPolicyEgressRule
+          elementRelationship: atomic
+    - name: ingress
+      type:
+        list:
+          elementType:
+            namedType: io.k8s.api.networking.v1.NetworkPolicyIngressRule
+          elementRelationship: atomic
+    - name: podSelector
+      type:
+        namedType: io.k8s.apimachinery.pkg.apis.meta.v1.LabelSelector
+    - name: policyTypes
+      type:
+        list:
+          elementType:
+            scalar: string
+          elementRelationship: atomic
+- name: io.k8s.api.policy.v1beta1.AllowedFlexVolume
+  map:
+    fields:
+    - name: driver
+      type:
+        scalar: string
+- name: io.k8s.api.policy.v1beta1.AllowedHostPath
+  map:
+    fields:
+    - name: pathPrefix
+      type:
+        scalar: string
+    - name: readOnly
+      type:
+        scalar: boolean
+- name: io.k8s.api.policy.v1beta1.Eviction
+  map:
+    fields:
+    - name: apiVersion
+      type:
+        scalar: string
+    - name: deleteOptions
+      type:
+        namedType: io.k8s.apimachinery.pkg.apis.meta.v1.DeleteOptions
+    - name: kind
+      type:
+        scalar: string
+    - name: metadata
+      type:
+        namedType: io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta
+- name: io.k8s.api.policy.v1beta1.FSGroupStrategyOptions
+  map:
+    fields:
+    - name: ranges
+      type:
+        list:
+          elementType:
+            namedType: io.k8s.api.policy.v1beta1.IDRange
+          elementRelationship: atomic
+    - name: rule
+      type:
+        scalar: string
+- name: io.k8s.api.policy.v1beta1.HostPortRange
+  map:
+    fields:
+    - name: max
+      type:
+        scalar: numeric
+    - name: min
+      type:
+        scalar: numeric
+- name: io.k8s.api.policy.v1beta1.IDRange
+  map:
+    fields:
+    - name: max
+      type:
+        scalar: numeric
+    - name: min
+      type:
+        scalar: numeric
+- name: io.k8s.api.policy.v1beta1.PodDisruptionBudget
+  map:
+    fields:
+    - name: apiVersion
+      type:
+        scalar: string
+    - name: kind
+      type:
+        scalar: string
+    - name: metadata
+      type:
+        namedType: io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta
+    - name: spec
+      type:
+        namedType: io.k8s.api.policy.v1beta1.PodDisruptionBudgetSpec
+    - name: status
+      type:
+        namedType: io.k8s.api.policy.v1beta1.PodDisruptionBudgetStatus
+        elementRelationship: granular
+- name: io.k8s.api.policy.v1beta1.PodDisruptionBudgetList
+  map:
+    fields:
+    - name: apiVersion
+      type:
+        scalar: string
+    - name: items
+      type:
+        list:
+          elementType:
+            namedType: io.k8s.api.policy.v1beta1.PodDisruptionBudget
+          elementRelationship: atomic
+    - name: kind
+      type:
+        scalar: string
+    - name: metadata
+      type:
+        namedType: io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta
+- name: io.k8s.api.policy.v1beta1.PodDisruptionBudgetSpec
+  map:
+    fields:
+    - name: maxUnavailable
+      type:
+        namedType: io.k8s.apimachinery.pkg.util.intstr.IntOrString
+    - name: minAvailable
+      type:
+        namedType: io.k8s.apimachinery.pkg.util.intstr.IntOrString
+    - name: selector
+      type:
+        namedType: io.k8s.apimachinery.pkg.apis.meta.v1.LabelSelector
+- name: io.k8s.api.policy.v1beta1.PodDisruptionBudgetStatus
+  map:
+    fields:
+    - name: currentHealthy
+      type:
+        scalar: numeric
+    - name: desiredHealthy
+      type:
+        scalar: numeric
+    - name: disruptedPods
+      type:
+        map:
+          elementType:
+            namedType: io.k8s.apimachinery.pkg.apis.meta.v1.Time
+    - name: disruptionsAllowed
+      type:
+        scalar: numeric
+    - name: expectedPods
+      type:
+        scalar: numeric
+    - name: observedGeneration
+      type:
+        scalar: numeric
+- name: io.k8s.api.policy.v1beta1.PodSecurityPolicy
+  map:
+    fields:
+    - name: apiVersion
+      type:
+        scalar: string
+    - name: kind
+      type:
+        scalar: string
+    - name: metadata
+      type:
+        namedType: io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta
+    - name: spec
+      type:
+        namedType: io.k8s.api.policy.v1beta1.PodSecurityPolicySpec
+- name: io.k8s.api.policy.v1beta1.PodSecurityPolicyList
+  map:
+    fields:
+    - name: apiVersion
+      type:
+        scalar: string
+    - name: items
+      type:
+        list:
+          elementType:
+            namedType: io.k8s.api.policy.v1beta1.PodSecurityPolicy
+          elementRelationship: atomic
+    - name: kind
+      type:
+        scalar: string
+    - name: metadata
+      type:
+        namedType: io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta
+- name: io.k8s.api.policy.v1beta1.PodSecurityPolicySpec
+  map:
+    fields:
+    - name: allowPrivilegeEscalation
+      type:
+        scalar: boolean
+    - name: allowedCapabilities
+      type:
+        list:
+          elementType:
+            scalar: string
+          elementRelationship: atomic
+    - name: allowedFlexVolumes
+      type:
+        list:
+          elementType:
+            namedType: io.k8s.api.policy.v1beta1.AllowedFlexVolume
+          elementRelationship: atomic
+    - name: allowedHostPaths
+      type:
+        list:
+          elementType:
+            namedType: io.k8s.api.policy.v1beta1.AllowedHostPath
+          elementRelationship: atomic
+    - name: allowedProcMountTypes
+      type:
+        list:
+          elementType:
+            scalar: string
+          elementRelationship: atomic
+    - name: allowedUnsafeSysctls
+      type:
+        list:
+          elementType:
+            scalar: string
+          elementRelationship: atomic
+    - name: defaultAddCapabilities
+      type:
+        list:
+          elementType:
+            scalar: string
+          elementRelationship: atomic
+    - name: defaultAllowPrivilegeEscalation
+      type:
+        scalar: boolean
+    - name: forbiddenSysctls
+      type:
+        list:
+          elementType:
+            scalar: string
+          elementRelationship: atomic
+    - name: fsGroup
+      type:
+        namedType: io.k8s.api.policy.v1beta1.FSGroupStrategyOptions
+    - name: hostIPC
+      type:
+        scalar: boolean
+    - name: hostNetwork
+      type:
+        scalar: boolean
+    - name: hostPID
+      type:
+        scalar: boolean
+    - name: hostPorts
+      type:
+        list:
+          elementType:
+            namedType: io.k8s.api.policy.v1beta1.HostPortRange
+          elementRelationship: atomic
+    - name: privileged
+      type:
+        scalar: boolean
+    - name: readOnlyRootFilesystem
+      type:
+        scalar: boolean
+    - name: requiredDropCapabilities
+      type:
+        list:
+          elementType:
+            scalar: string
+          elementRelationship: atomic
+    - name: runAsGroup
+      type:
+        namedType: io.k8s.api.policy.v1beta1.RunAsGroupStrategyOptions
+    - name: runAsUser
+      type:
+        namedType: io.k8s.api.policy.v1beta1.RunAsUserStrategyOptions
+    - name: seLinux
+      type:
+        namedType: io.k8s.api.policy.v1beta1.SELinuxStrategyOptions
+    - name: supplementalGroups
+      type:
+        namedType: io.k8s.api.policy.v1beta1.SupplementalGroupsStrategyOptions
+    - name: volumes
+      type:
+        list:
+          elementType:
+            scalar: string
+          elementRelationship: atomic
+- name: io.k8s.api.policy.v1beta1.RunAsGroupStrategyOptions
+  map:
+    fields:
+    - name: ranges
+      type:
+        list:
+          elementType:
+            namedType: io.k8s.api.policy.v1beta1.IDRange
+          elementRelationship: atomic
+    - name: rule
+      type:
+        scalar: string
+- name: io.k8s.api.policy.v1beta1.RunAsUserStrategyOptions
+  map:
+    fields:
+    - name: ranges
+      type:
+        list:
+          elementType:
+            namedType: io.k8s.api.policy.v1beta1.IDRange
+          elementRelationship: atomic
+    - name: rule
+      type:
+        scalar: string
+- name: io.k8s.api.policy.v1beta1.SELinuxStrategyOptions
+  map:
+    fields:
+    - name: rule
+      type:
+        scalar: string
+    - name: seLinuxOptions
+      type:
+        namedType: io.k8s.api.core.v1.SELinuxOptions
+        elementRelationship: granular
+- name: io.k8s.api.policy.v1beta1.SupplementalGroupsStrategyOptions
+  map:
+    fields:
+    - name: ranges
+      type:
+        list:
+          elementType:
+            namedType: io.k8s.api.policy.v1beta1.IDRange
+          elementRelationship: atomic
+    - name: rule
+      type:
+        scalar: string
+- name: io.k8s.api.rbac.v1.AggregationRule
+  map:
+    fields:
+    - name: clusterRoleSelectors
+      type:
+        list:
+          elementType:
+            namedType: io.k8s.apimachinery.pkg.apis.meta.v1.LabelSelector
+          elementRelationship: atomic
+- name: io.k8s.api.rbac.v1.ClusterRole
+  map:
+    fields:
+    - name: aggregationRule
+      type:
+        namedType: io.k8s.api.rbac.v1.AggregationRule
+    - name: apiVersion
+      type:
+        scalar: string
+    - name: kind
+      type:
+        scalar: string
+    - name: metadata
+      type:
+        namedType: io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta
+    - name: rules
+      type:
+        list:
+          elementType:
+            namedType: io.k8s.api.rbac.v1.PolicyRule
+          elementRelationship: atomic
+- name: io.k8s.api.rbac.v1.ClusterRoleBinding
+  map:
+    fields:
+    - name: apiVersion
+      type:
+        scalar: string
+    - name: kind
+      type:
+        scalar: string
+    - name: metadata
+      type:
+        namedType: io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta
+    - name: roleRef
+      type:
+        namedType: io.k8s.api.rbac.v1.RoleRef
+    - name: subjects
+      type:
+        list:
+          elementType:
+            namedType: io.k8s.api.rbac.v1.Subject
+          elementRelationship: atomic
+- name: io.k8s.api.rbac.v1.ClusterRoleBindingList
+  map:
+    fields:
+    - name: apiVersion
+      type:
+        scalar: string
+    - name: items
+      type:
+        list:
+          elementType:
+            namedType: io.k8s.api.rbac.v1.ClusterRoleBinding
+          elementRelationship: atomic
+    - name: kind
+      type:
+        scalar: string
+    - name: metadata
+      type:
+        namedType: io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta
+- name: io.k8s.api.rbac.v1.ClusterRoleList
+  map:
+    fields:
+    - name: apiVersion
+      type:
+        scalar: string
+    - name: items
+      type:
+        list:
+          elementType:
+            namedType: io.k8s.api.rbac.v1.ClusterRole
+          elementRelationship: atomic
+    - name: kind
+      type:
+        scalar: string
+    - name: metadata
+      type:
+        namedType: io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta
+- name: io.k8s.api.rbac.v1.PolicyRule
+  map:
+    fields:
+    - name: apiGroups
+      type:
+        list:
+          elementType:
+            scalar: string
+          elementRelationship: atomic
+    - name: nonResourceURLs
+      type:
+        list:
+          elementType:
+            scalar: string
+          elementRelationship: atomic
+    - name: resourceNames
+      type:
+        list:
+          elementType:
+            scalar: string
+          elementRelationship: atomic
+    - name: resources
+      type:
+        list:
+          elementType:
+            scalar: string
+          elementRelationship: atomic
+    - name: verbs
+      type:
+        list:
+          elementType:
+            scalar: string
+          elementRelationship: atomic
+- name: io.k8s.api.rbac.v1.Role
+  map:
+    fields:
+    - name: apiVersion
+      type:
+        scalar: string
+    - name: kind
+      type:
+        scalar: string
+    - name: metadata
+      type:
+        namedType: io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta
+    - name: rules
+      type:
+        list:
+          elementType:
+            namedType: io.k8s.api.rbac.v1.PolicyRule
+          elementRelationship: atomic
+- name: io.k8s.api.rbac.v1.RoleBinding
+  map:
+    fields:
+    - name: apiVersion
+      type:
+        scalar: string
+    - name: kind
+      type:
+        scalar: string
+    - name: metadata
+      type:
+        namedType: io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta
+        elementRelationship: granular
+    - name: roleRef
+      type:
+        namedType: io.k8s.api.rbac.v1.RoleRef
+    - name: subjects
+      type:
+        list:
+          elementType:
+            namedType: io.k8s.api.rbac.v1.Subject
+          elementRelationship: atomic
+- name: io.k8s.api.rbac.v1.RoleBindingList
+  map:
+    fields:
+    - name: apiVersion
+      type:
+        scalar: string
+    - name: items
+      type:
+        list:
+          elementType:
+            namedType: io.k8s.api.rbac.v1.RoleBinding
+          elementRelationship: atomic
+    - name: kind
+      type:
+        scalar: string
+    - name: metadata
+      type:
+        namedType: io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta
+- name: io.k8s.api.rbac.v1.RoleList
+  map:
+    fields:
+    - name: apiVersion
+      type:
+        scalar: string
+    - name: items
+      type:
+        list:
+          elementType:
+            namedType: io.k8s.api.rbac.v1.Role
+          elementRelationship: atomic
+    - name: kind
+      type:
+        scalar: string
+    - name: metadata
+      type:
+        namedType: io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta
+- name: io.k8s.api.rbac.v1.RoleRef
+  map:
+    fields:
+    - name: apiGroup
+      type:
+        scalar: string
+    - name: kind
+      type:
+        scalar: string
+    - name: name
+      type:
+        scalar: string
+- name: io.k8s.api.rbac.v1.Subject
+  map:
+    fields:
+    - name: apiGroup
+      type:
+        scalar: string
+    - name: kind
+      type:
+        scalar: string
+    - name: name
+      type:
+        scalar: string
+    - name: namespace
+      type:
+        scalar: string
+- name: io.k8s.api.rbac.v1alpha1.AggregationRule
+  map:
+    fields:
+    - name: clusterRoleSelectors
+      type:
+        list:
+          elementType:
+            namedType: io.k8s.apimachinery.pkg.apis.meta.v1.LabelSelector
+          elementRelationship: atomic
+- name: io.k8s.api.rbac.v1alpha1.ClusterRole
+  map:
+    fields:
+    - name: aggregationRule
+      type:
+        namedType: io.k8s.api.rbac.v1alpha1.AggregationRule
+    - name: apiVersion
+      type:
+        scalar: string
+    - name: kind
+      type:
+        scalar: string
+    - name: metadata
+      type:
+        namedType: io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta
+    - name: rules
+      type:
+        list:
+          elementType:
+            namedType: io.k8s.api.rbac.v1alpha1.PolicyRule
+          elementRelationship: atomic
+- name: io.k8s.api.rbac.v1alpha1.ClusterRoleBinding
+  map:
+    fields:
+    - name: apiVersion
+      type:
+        scalar: string
+    - name: kind
+      type:
+        scalar: string
+    - name: metadata
+      type:
+        namedType: io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta
+    - name: roleRef
+      type:
+        namedType: io.k8s.api.rbac.v1alpha1.RoleRef
+    - name: subjects
+      type:
+        list:
+          elementType:
+            namedType: io.k8s.api.rbac.v1alpha1.Subject
+          elementRelationship: atomic
+- name: io.k8s.api.rbac.v1alpha1.ClusterRoleBindingList
+  map:
+    fields:
+    - name: apiVersion
+      type:
+        scalar: string
+    - name: items
+      type:
+        list:
+          elementType:
+            namedType: io.k8s.api.rbac.v1alpha1.ClusterRoleBinding
+          elementRelationship: atomic
+    - name: kind
+      type:
+        scalar: string
+    - name: metadata
+      type:
+        namedType: io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta
+        elementRelationship: granular
+- name: io.k8s.api.rbac.v1alpha1.ClusterRoleList
+  map:
+    fields:
+    - name: apiVersion
+      type:
+        scalar: string
+    - name: items
+      type:
+        list:
+          elementType:
+            namedType: io.k8s.api.rbac.v1alpha1.ClusterRole
+          elementRelationship: atomic
+    - name: kind
+      type:
+        scalar: string
+    - name: metadata
+      type:
+        namedType: io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta
+- name: io.k8s.api.rbac.v1alpha1.PolicyRule
+  map:
+    fields:
+    - name: apiGroups
+      type:
+        list:
+          elementType:
+            scalar: string
+          elementRelationship: atomic
+    - name: nonResourceURLs
+      type:
+        list:
+          elementType:
+            scalar: string
+          elementRelationship: atomic
+    - name: resourceNames
+      type:
+        list:
+          elementType:
+            scalar: string
+          elementRelationship: atomic
+    - name: resources
+      type:
+        list:
+          elementType:
+            scalar: string
+          elementRelationship: atomic
+    - name: verbs
+      type:
+        list:
+          elementType:
+            scalar: string
+          elementRelationship: atomic
+- name: io.k8s.api.rbac.v1alpha1.Role
+  map:
+    fields:
+    - name: apiVersion
+      type:
+        scalar: string
+    - name: kind
+      type:
+        scalar: string
+    - name: metadata
+      type:
+        namedType: io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta
+    - name: rules
+      type:
+        list:
+          elementType:
+            namedType: io.k8s.api.rbac.v1alpha1.PolicyRule
+          elementRelationship: atomic
+- name: io.k8s.api.rbac.v1alpha1.RoleBinding
+  map:
+    fields:
+    - name: apiVersion
+      type:
+        scalar: string
+    - name: kind
+      type:
+        scalar: string
+    - name: metadata
+      type:
+        namedType: io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta
+    - name: roleRef
+      type:
+        namedType: io.k8s.api.rbac.v1alpha1.RoleRef
+    - name: subjects
+      type:
+        list:
+          elementType:
+            namedType: io.k8s.api.rbac.v1alpha1.Subject
+          elementRelationship: atomic
+- name: io.k8s.api.rbac.v1alpha1.RoleBindingList
+  map:
+    fields:
+    - name: apiVersion
+      type:
+        scalar: string
+    - name: items
+      type:
+        list:
+          elementType:
+            namedType: io.k8s.api.rbac.v1alpha1.RoleBinding
+          elementRelationship: atomic
+    - name: kind
+      type:
+        scalar: string
+    - name: metadata
+      type:
+        namedType: io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta
+- name: io.k8s.api.rbac.v1alpha1.RoleList
+  map:
+    fields:
+    - name: apiVersion
+      type:
+        scalar: string
+    - name: items
+      type:
+        list:
+          elementType:
+            namedType: io.k8s.api.rbac.v1alpha1.Role
+          elementRelationship: atomic
+    - name: kind
+      type:
+        scalar: string
+    - name: metadata
+      type:
+        namedType: io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta
+- name: io.k8s.api.rbac.v1alpha1.RoleRef
+  map:
+    fields:
+    - name: apiGroup
+      type:
+        scalar: string
+    - name: kind
+      type:
+        scalar: string
+    - name: name
+      type:
+        scalar: string
+- name: io.k8s.api.rbac.v1alpha1.Subject
+  map:
+    fields:
+    - name: apiVersion
+      type:
+        scalar: string
+    - name: kind
+      type:
+        scalar: string
+    - name: name
+      type:
+        scalar: string
+    - name: namespace
+      type:
+        scalar: string
+- name: io.k8s.api.rbac.v1beta1.AggregationRule
+  map:
+    fields:
+    - name: clusterRoleSelectors
+      type:
+        list:
+          elementType:
+            namedType: io.k8s.apimachinery.pkg.apis.meta.v1.LabelSelector
+          elementRelationship: atomic
+- name: io.k8s.api.rbac.v1beta1.ClusterRole
+  map:
+    fields:
+    - name: aggregationRule
+      type:
+        namedType: io.k8s.api.rbac.v1beta1.AggregationRule
+    - name: apiVersion
+      type:
+        scalar: string
+    - name: kind
+      type:
+        scalar: string
+    - name: metadata
+      type:
+        namedType: io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta
+    - name: rules
+      type:
+        list:
+          elementType:
+            namedType: io.k8s.api.rbac.v1beta1.PolicyRule
+          elementRelationship: atomic
+- name: io.k8s.api.rbac.v1beta1.ClusterRoleBinding
+  map:
+    fields:
+    - name: apiVersion
+      type:
+        scalar: string
+    - name: kind
+      type:
+        scalar: string
+    - name: metadata
+      type:
+        namedType: io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta
+        elementRelationship: granular
+    - name: roleRef
+      type:
+        namedType: io.k8s.api.rbac.v1beta1.RoleRef
+    - name: subjects
+      type:
+        list:
+          elementType:
+            namedType: io.k8s.api.rbac.v1beta1.Subject
+          elementRelationship: atomic
+- name: io.k8s.api.rbac.v1beta1.ClusterRoleBindingList
+  map:
+    fields:
+    - name: apiVersion
+      type:
+        scalar: string
+    - name: items
+      type:
+        list:
+          elementType:
+            namedType: io.k8s.api.rbac.v1beta1.ClusterRoleBinding
+          elementRelationship: atomic
+    - name: kind
+      type:
+        scalar: string
+    - name: metadata
+      type:
+        namedType: io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta
+- name: io.k8s.api.rbac.v1beta1.ClusterRoleList
+  map:
+    fields:
+    - name: apiVersion
+      type:
+        scalar: string
+    - name: items
+      type:
+        list:
+          elementType:
+            namedType: io.k8s.api.rbac.v1beta1.ClusterRole
+          elementRelationship: atomic
+    - name: kind
+      type:
+        scalar: string
+    - name: metadata
+      type:
+        namedType: io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta
+- name: io.k8s.api.rbac.v1beta1.PolicyRule
+  map:
+    fields:
+    - name: apiGroups
+      type:
+        list:
+          elementType:
+            scalar: string
+          elementRelationship: atomic
+    - name: nonResourceURLs
+      type:
+        list:
+          elementType:
+            scalar: string
+          elementRelationship: atomic
+    - name: resourceNames
+      type:
+        list:
+          elementType:
+            scalar: string
+          elementRelationship: atomic
+    - name: resources
+      type:
+        list:
+          elementType:
+            scalar: string
+          elementRelationship: atomic
+    - name: verbs
+      type:
+        list:
+          elementType:
+            scalar: string
+          elementRelationship: atomic
+- name: io.k8s.api.rbac.v1beta1.Role
+  map:
+    fields:
+    - name: apiVersion
+      type:
+        scalar: string
+    - name: kind
+      type:
+        scalar: string
+    - name: metadata
+      type:
+        namedType: io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta
+    - name: rules
+      type:
+        list:
+          elementType:
+            namedType: io.k8s.api.rbac.v1beta1.PolicyRule
+          elementRelationship: atomic
+- name: io.k8s.api.rbac.v1beta1.RoleBinding
+  map:
+    fields:
+    - name: apiVersion
+      type:
+        scalar: string
+    - name: kind
+      type:
+        scalar: string
+    - name: metadata
+      type:
+        namedType: io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta
+        elementRelationship: granular
+    - name: roleRef
+      type:
+        namedType: io.k8s.api.rbac.v1beta1.RoleRef
+    - name: subjects
+      type:
+        list:
+          elementType:
+            namedType: io.k8s.api.rbac.v1beta1.Subject
+          elementRelationship: atomic
+- name: io.k8s.api.rbac.v1beta1.RoleBindingList
+  map:
+    fields:
+    - name: apiVersion
+      type:
+        scalar: string
+    - name: items
+      type:
+        list:
+          elementType:
+            namedType: io.k8s.api.rbac.v1beta1.RoleBinding
+          elementRelationship: atomic
+    - name: kind
+      type:
+        scalar: string
+    - name: metadata
+      type:
+        namedType: io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta
+- name: io.k8s.api.rbac.v1beta1.RoleList
+  map:
+    fields:
+    - name: apiVersion
+      type:
+        scalar: string
+    - name: items
+      type:
+        list:
+          elementType:
+            namedType: io.k8s.api.rbac.v1beta1.Role
+          elementRelationship: atomic
+    - name: kind
+      type:
+        scalar: string
+    - name: metadata
+      type:
+        namedType: io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta
+- name: io.k8s.api.rbac.v1beta1.RoleRef
+  map:
+    fields:
+    - name: apiGroup
+      type:
+        scalar: string
+    - name: kind
+      type:
+        scalar: string
+    - name: name
+      type:
+        scalar: string
+- name: io.k8s.api.rbac.v1beta1.Subject
+  map:
+    fields:
+    - name: apiGroup
+      type:
+        scalar: string
+    - name: kind
+      type:
+        scalar: string
+    - name: name
+      type:
+        scalar: string
+    - name: namespace
+      type:
+        scalar: string
+- name: io.k8s.api.scheduling.v1alpha1.PriorityClass
+  map:
+    fields:
+    - name: apiVersion
+      type:
+        scalar: string
+    - name: description
+      type:
+        scalar: string
+    - name: globalDefault
+      type:
+        scalar: boolean
+    - name: kind
+      type:
+        scalar: string
+    - name: metadata
+      type:
+        namedType: io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta
+    - name: value
+      type:
+        scalar: numeric
+- name: io.k8s.api.scheduling.v1alpha1.PriorityClassList
+  map:
+    fields:
+    - name: apiVersion
+      type:
+        scalar: string
+    - name: items
+      type:
+        list:
+          elementType:
+            namedType: io.k8s.api.scheduling.v1alpha1.PriorityClass
+          elementRelationship: atomic
+    - name: kind
+      type:
+        scalar: string
+    - name: metadata
+      type:
+        namedType: io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta
+- name: io.k8s.api.scheduling.v1beta1.PriorityClass
+  map:
+    fields:
+    - name: apiVersion
+      type:
+        scalar: string
+    - name: description
+      type:
+        scalar: string
+    - name: globalDefault
+      type:
+        scalar: boolean
+    - name: kind
+      type:
+        scalar: string
+    - name: metadata
+      type:
+        namedType: io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta
+    - name: value
+      type:
+        scalar: numeric
+- name: io.k8s.api.scheduling.v1beta1.PriorityClassList
+  map:
+    fields:
+    - name: apiVersion
+      type:
+        scalar: string
+    - name: items
+      type:
+        list:
+          elementType:
+            namedType: io.k8s.api.scheduling.v1beta1.PriorityClass
+          elementRelationship: atomic
+    - name: kind
+      type:
+        scalar: string
+    - name: metadata
+      type:
+        namedType: io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta
+- name: io.k8s.api.settings.v1alpha1.PodPreset
+  map:
+    fields:
+    - name: apiVersion
+      type:
+        scalar: string
+    - name: kind
+      type:
+        scalar: string
+    - name: metadata
+      type:
+        namedType: io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta
+    - name: spec
+      type:
+        namedType: io.k8s.api.settings.v1alpha1.PodPresetSpec
+- name: io.k8s.api.settings.v1alpha1.PodPresetList
+  map:
+    fields:
+    - name: apiVersion
+      type:
+        scalar: string
+    - name: items
+      type:
+        list:
+          elementType:
+            namedType: io.k8s.api.settings.v1alpha1.PodPreset
+          elementRelationship: atomic
+    - name: kind
+      type:
+        scalar: string
+    - name: metadata
+      type:
+        namedType: io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta
+- name: io.k8s.api.settings.v1alpha1.PodPresetSpec
+  map:
+    fields:
+    - name: env
+      type:
+        list:
+          elementType:
+            namedType: io.k8s.api.core.v1.EnvVar
+          elementRelationship: atomic
+    - name: envFrom
+      type:
+        list:
+          elementType:
+            namedType: io.k8s.api.core.v1.EnvFromSource
+          elementRelationship: atomic
+    - name: selector
+      type:
+        namedType: io.k8s.apimachinery.pkg.apis.meta.v1.LabelSelector
+    - name: volumeMounts
+      type:
+        list:
+          elementType:
+            namedType: io.k8s.api.core.v1.VolumeMount
+          elementRelationship: atomic
+    - name: volumes
+      type:
+        list:
+          elementType:
+            namedType: io.k8s.api.core.v1.Volume
+          elementRelationship: atomic
+- name: io.k8s.api.storage.v1.StorageClass
+  map:
+    fields:
+    - name: allowVolumeExpansion
+      type:
+        scalar: boolean
+    - name: allowedTopologies
+      type:
+        list:
+          elementType:
+            namedType: io.k8s.api.core.v1.TopologySelectorTerm
+          elementRelationship: atomic
+    - name: apiVersion
+      type:
+        scalar: string
+    - name: kind
+      type:
+        scalar: string
+    - name: metadata
+      type:
+        namedType: io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta
+    - name: mountOptions
+      type:
+        list:
+          elementType:
+            scalar: string
+          elementRelationship: atomic
+    - name: parameters
+      type:
+        map:
+          elementType:
+            scalar: string
+    - name: provisioner
+      type:
+        scalar: string
+    - name: reclaimPolicy
+      type:
+        scalar: string
+    - name: volumeBindingMode
+      type:
+        scalar: string
+- name: io.k8s.api.storage.v1.StorageClassList
+  map:
+    fields:
+    - name: apiVersion
+      type:
+        scalar: string
+    - name: items
+      type:
+        list:
+          elementType:
+            namedType: io.k8s.api.storage.v1.StorageClass
+          elementRelationship: atomic
+    - name: kind
+      type:
+        scalar: string
+    - name: metadata
+      type:
+        namedType: io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta
+- name: io.k8s.api.storage.v1alpha1.VolumeAttachment
+  map:
+    fields:
+    - name: apiVersion
+      type:
+        scalar: string
+    - name: kind
+      type:
+        scalar: string
+    - name: metadata
+      type:
+        namedType: io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta
+    - name: spec
+      type:
+        namedType: io.k8s.api.storage.v1alpha1.VolumeAttachmentSpec
+    - name: status
+      type:
+        namedType: io.k8s.api.storage.v1alpha1.VolumeAttachmentStatus
+- name: io.k8s.api.storage.v1alpha1.VolumeAttachmentList
+  map:
+    fields:
+    - name: apiVersion
+      type:
+        scalar: string
+    - name: items
+      type:
+        list:
+          elementType:
+            namedType: io.k8s.api.storage.v1alpha1.VolumeAttachment
+          elementRelationship: atomic
+    - name: kind
+      type:
+        scalar: string
+    - name: metadata
+      type:
+        namedType: io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta
+        elementRelationship: granular
+- name: io.k8s.api.storage.v1alpha1.VolumeAttachmentSource
+  map:
+    fields:
+    - name: persistentVolumeName
+      type:
+        scalar: string
+- name: io.k8s.api.storage.v1alpha1.VolumeAttachmentSpec
+  map:
+    fields:
+    - name: attacher
+      type:
+        scalar: string
+    - name: nodeName
+      type:
+        scalar: string
+    - name: source
+      type:
+        namedType: io.k8s.api.storage.v1alpha1.VolumeAttachmentSource
+- name: io.k8s.api.storage.v1alpha1.VolumeAttachmentStatus
+  map:
+    fields:
+    - name: attachError
+      type:
+        namedType: io.k8s.api.storage.v1alpha1.VolumeError
+    - name: attached
+      type:
+        scalar: boolean
+    - name: attachmentMetadata
+      type:
+        map:
+          elementType:
+            scalar: string
+    - name: detachError
+      type:
+        namedType: io.k8s.api.storage.v1alpha1.VolumeError
+- name: io.k8s.api.storage.v1alpha1.VolumeError
+  map:
+    fields:
+    - name: message
+      type:
+        scalar: string
+    - name: time
+      type:
+        namedType: io.k8s.apimachinery.pkg.apis.meta.v1.Time
+- name: io.k8s.api.storage.v1beta1.StorageClass
+  map:
+    fields:
+    - name: allowVolumeExpansion
+      type:
+        scalar: boolean
+    - name: allowedTopologies
+      type:
+        list:
+          elementType:
+            namedType: io.k8s.api.core.v1.TopologySelectorTerm
+          elementRelationship: atomic
+    - name: apiVersion
+      type:
+        scalar: string
+    - name: kind
+      type:
+        scalar: string
+    - name: metadata
+      type:
+        namedType: io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta
+    - name: mountOptions
+      type:
+        list:
+          elementType:
+            scalar: string
+          elementRelationship: atomic
+    - name: parameters
+      type:
+        map:
+          elementType:
+            scalar: string
+    - name: provisioner
+      type:
+        scalar: string
+    - name: reclaimPolicy
+      type:
+        scalar: string
+    - name: volumeBindingMode
+      type:
+        scalar: string
+- name: io.k8s.api.storage.v1beta1.StorageClassList
+  map:
+    fields:
+    - name: apiVersion
+      type:
+        scalar: string
+    - name: items
+      type:
+        list:
+          elementType:
+            namedType: io.k8s.api.storage.v1beta1.StorageClass
+          elementRelationship: atomic
+    - name: kind
+      type:
+        scalar: string
+    - name: metadata
+      type:
+        namedType: io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta
+- name: io.k8s.api.storage.v1beta1.VolumeAttachment
+  map:
+    fields:
+    - name: apiVersion
+      type:
+        scalar: string
+    - name: kind
+      type:
+        scalar: string
+    - name: metadata
+      type:
+        namedType: io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta
+    - name: spec
+      type:
+        namedType: io.k8s.api.storage.v1beta1.VolumeAttachmentSpec
+    - name: status
+      type:
+        namedType: io.k8s.api.storage.v1beta1.VolumeAttachmentStatus
+- name: io.k8s.api.storage.v1beta1.VolumeAttachmentList
+  map:
+    fields:
+    - name: apiVersion
+      type:
+        scalar: string
+    - name: items
+      type:
+        list:
+          elementType:
+            namedType: io.k8s.api.storage.v1beta1.VolumeAttachment
+          elementRelationship: atomic
+    - name: kind
+      type:
+        scalar: string
+    - name: metadata
+      type:
+        namedType: io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta
+- name: io.k8s.api.storage.v1beta1.VolumeAttachmentSource
+  map:
+    fields:
+    - name: persistentVolumeName
+      type:
+        scalar: string
+- name: io.k8s.api.storage.v1beta1.VolumeAttachmentSpec
+  map:
+    fields:
+    - name: attacher
+      type:
+        scalar: string
+    - name: nodeName
+      type:
+        scalar: string
+    - name: source
+      type:
+        namedType: io.k8s.api.storage.v1beta1.VolumeAttachmentSource
+- name: io.k8s.api.storage.v1beta1.VolumeAttachmentStatus
+  map:
+    fields:
+    - name: attachError
+      type:
+        namedType: io.k8s.api.storage.v1beta1.VolumeError
+    - name: attached
+      type:
+        scalar: boolean
+    - name: attachmentMetadata
+      type:
+        map:
+          elementType:
+            scalar: string
+    - name: detachError
+      type:
+        namedType: io.k8s.api.storage.v1beta1.VolumeError
+- name: io.k8s.api.storage.v1beta1.VolumeError
+  map:
+    fields:
+    - name: message
+      type:
+        scalar: string
+    - name: time
+      type:
+        namedType: io.k8s.apimachinery.pkg.apis.meta.v1.Time
+- name: io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1beta1.CustomResourceColumnDefinition
+  map:
+    fields:
+    - name: JSONPath
+      type:
+        scalar: string
+    - name: description
+      type:
+        scalar: string
+    - name: format
+      type:
+        scalar: string
+    - name: name
+      type:
+        scalar: string
+    - name: priority
+      type:
+        scalar: numeric
+    - name: type
+      type:
+        scalar: string
+- name: io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1beta1.CustomResourceDefinition
+  map:
+    fields:
+    - name: apiVersion
+      type:
+        scalar: string
+    - name: kind
+      type:
+        scalar: string
+    - name: metadata
+      type:
+        namedType: io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta
+    - name: spec
+      type:
+        namedType: io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1beta1.CustomResourceDefinitionSpec
+    - name: status
+      type:
+        namedType: io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1beta1.CustomResourceDefinitionStatus
+- name: io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1beta1.CustomResourceDefinitionCondition
+  map:
+    fields:
+    - name: lastTransitionTime
+      type:
+        namedType: io.k8s.apimachinery.pkg.apis.meta.v1.Time
+    - name: message
+      type:
+        scalar: string
+    - name: reason
+      type:
+        scalar: string
+    - name: status
+      type:
+        scalar: string
+    - name: type
+      type:
+        scalar: string
+- name: io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1beta1.CustomResourceDefinitionList
+  map:
+    fields:
+    - name: apiVersion
+      type:
+        scalar: string
+    - name: items
+      type:
+        list:
+          elementType:
+            namedType: io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1beta1.CustomResourceDefinition
+          elementRelationship: atomic
+    - name: kind
+      type:
+        scalar: string
+    - name: metadata
+      type:
+        namedType: io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta
+- name: io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1beta1.CustomResourceDefinitionNames
+  map:
+    fields:
+    - name: categories
+      type:
+        list:
+          elementType:
+            scalar: string
+          elementRelationship: atomic
+    - name: kind
+      type:
+        scalar: string
+    - name: listKind
+      type:
+        scalar: string
+    - name: plural
+      type:
+        scalar: string
+    - name: shortNames
+      type:
+        list:
+          elementType:
+            scalar: string
+          elementRelationship: atomic
+    - name: singular
+      type:
+        scalar: string
+- name: io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1beta1.CustomResourceDefinitionSpec
+  map:
+    fields:
+    - name: additionalPrinterColumns
+      type:
+        list:
+          elementType:
+            namedType: io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1beta1.CustomResourceColumnDefinition
+          elementRelationship: atomic
+    - name: group
+      type:
+        scalar: string
+    - name: names
+      type:
+        namedType: io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1beta1.CustomResourceDefinitionNames
+    - name: scope
+      type:
+        scalar: string
+    - name: subresources
+      type:
+        namedType: io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1beta1.CustomResourceSubresources
+    - name: validation
+      type:
+        namedType: io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1beta1.CustomResourceValidation
+        elementRelationship: granular
+    - name: version
+      type:
+        scalar: string
+    - name: versions
+      type:
+        list:
+          elementType:
+            namedType: io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1beta1.CustomResourceDefinitionVersion
+          elementRelationship: atomic
+- name: io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1beta1.CustomResourceDefinitionStatus
+  map:
+    fields:
+    - name: acceptedNames
+      type:
+        namedType: io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1beta1.CustomResourceDefinitionNames
+    - name: conditions
+      type:
+        list:
+          elementType:
+            namedType: io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1beta1.CustomResourceDefinitionCondition
+          elementRelationship: atomic
+    - name: storedVersions
+      type:
+        list:
+          elementType:
+            scalar: string
+          elementRelationship: atomic
+- name: io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1beta1.CustomResourceDefinitionVersion
+  map:
+    fields:
+    - name: name
+      type:
+        scalar: string
+    - name: served
+      type:
+        scalar: boolean
+    - name: storage
+      type:
+        scalar: boolean
+- name: io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1beta1.CustomResourceSubresourceScale
+  map:
+    fields:
+    - name: labelSelectorPath
+      type:
+        scalar: string
+    - name: specReplicasPath
+      type:
+        scalar: string
+    - name: statusReplicasPath
+      type:
+        scalar: string
+- name: io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1beta1.CustomResourceSubresourceStatus
+  scalar: untyped
+  list:
+    elementType:
+      namedType: __untyped_atomic_
+    elementRelationship: atomic
+  map:
+    elementType:
+      namedType: __untyped_atomic_
+    elementRelationship: atomic
+- name: io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1beta1.CustomResourceSubresources
+  map:
+    fields:
+    - name: scale
+      type:
+        namedType: io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1beta1.CustomResourceSubresourceScale
+    - name: status
+      type:
+        namedType: io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1beta1.CustomResourceSubresourceStatus
+- name: io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1beta1.CustomResourceValidation
+  map:
+    fields:
+    - name: openAPIV3Schema
+      type:
+        namedType: io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1beta1.JSONSchemaProps
+- name: io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1beta1.ExternalDocumentation
+  map:
+    fields:
+    - name: description
+      type:
+        scalar: string
+    - name: url
+      type:
+        scalar: string
+- name: io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1beta1.JSON
+  scalar: untyped
+  list:
+    elementType:
+      namedType: __untyped_atomic_
+    elementRelationship: atomic
+  map:
+    elementType:
+      namedType: __untyped_atomic_
+    elementRelationship: atomic
+- name: io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1beta1.JSONSchemaProps
+  map:
+    fields:
+    - name: $ref
+      type:
+        scalar: string
+    - name: $schema
+      type:
+        scalar: string
+    - name: additionalItems
+      type:
+        namedType: io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1beta1.JSONSchemaPropsOrBool
+    - name: additionalProperties
+      type:
+        namedType: io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1beta1.JSONSchemaPropsOrBool
+    - name: allOf
+      type:
+        list:
+          elementType:
+            namedType: io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1beta1.JSONSchemaProps
+          elementRelationship: atomic
+    - name: anyOf
+      type:
+        list:
+          elementType:
+            namedType: io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1beta1.JSONSchemaProps
+          elementRelationship: atomic
+    - name: default
+      type:
+        namedType: io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1beta1.JSON
+    - name: definitions
+      type:
+        map:
+          elementType:
+            namedType: io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1beta1.JSONSchemaProps
+    - name: dependencies
+      type:
+        map:
+          elementType:
+            namedType: io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1beta1.JSONSchemaPropsOrStringArray
+    - name: description
+      type:
+        scalar: string
+    - name: enum
+      type:
+        list:
+          elementType:
+            namedType: io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1beta1.JSON
+          elementRelationship: atomic
+    - name: example
+      type:
+        namedType: io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1beta1.JSON
+    - name: exclusiveMaximum
+      type:
+        scalar: boolean
+    - name: exclusiveMinimum
+      type:
+        scalar: boolean
+    - name: externalDocs
+      type:
+        namedType: io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1beta1.ExternalDocumentation
+    - name: format
+      type:
+        scalar: string
+    - name: id
+      type:
+        scalar: string
+    - name: items
+      type:
+        namedType: io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1beta1.JSONSchemaPropsOrArray
+    - name: maxItems
+      type:
+        scalar: numeric
+    - name: maxLength
+      type:
+        scalar: numeric
+    - name: maxProperties
+      type:
+        scalar: numeric
+    - name: maximum
+      type:
+        scalar: numeric
+    - name: minItems
+      type:
+        scalar: numeric
+    - name: minLength
+      type:
+        scalar: numeric
+    - name: minProperties
+      type:
+        scalar: numeric
+    - name: minimum
+      type:
+        scalar: numeric
+    - name: multipleOf
+      type:
+        scalar: numeric
+    - name: not
+      type:
+        namedType: io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1beta1.JSONSchemaProps
+    - name: oneOf
+      type:
+        list:
+          elementType:
+            namedType: io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1beta1.JSONSchemaProps
+          elementRelationship: atomic
+    - name: pattern
+      type:
+        scalar: string
+    - name: patternProperties
+      type:
+        map:
+          elementType:
+            namedType: io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1beta1.JSONSchemaProps
+    - name: properties
+      type:
+        map:
+          elementType:
+            namedType: io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1beta1.JSONSchemaProps
+    - name: required
+      type:
+        list:
+          elementType:
+            scalar: string
+          elementRelationship: atomic
+    - name: title
+      type:
+        scalar: string
+    - name: type
+      type:
+        scalar: string
+    - name: uniqueItems
+      type:
+        scalar: boolean
+- name: io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1beta1.JSONSchemaPropsOrArray
+  scalar: untyped
+  list:
+    elementType:
+      namedType: __untyped_atomic_
+    elementRelationship: atomic
+  map:
+    elementType:
+      namedType: __untyped_atomic_
+    elementRelationship: atomic
+- name: io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1beta1.JSONSchemaPropsOrBool
+  scalar: untyped
+  list:
+    elementType:
+      namedType: __untyped_atomic_
+    elementRelationship: atomic
+  map:
+    elementType:
+      namedType: __untyped_atomic_
+    elementRelationship: atomic
+- name: io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1beta1.JSONSchemaPropsOrStringArray
+  scalar: untyped
+  list:
+    elementType:
+      namedType: __untyped_atomic_
+    elementRelationship: atomic
+  map:
+    elementType:
+      namedType: __untyped_atomic_
+    elementRelationship: atomic
+- name: io.k8s.apimachinery.pkg.api.resource.Quantity
+  scalar: string
+- name: io.k8s.apimachinery.pkg.apis.meta.v1.APIGroup
+  map:
+    fields:
+    - name: apiVersion
+      type:
+        scalar: string
+    - name: kind
+      type:
+        scalar: string
+    - name: name
+      type:
+        scalar: string
+    - name: preferredVersion
+      type:
+        namedType: io.k8s.apimachinery.pkg.apis.meta.v1.GroupVersionForDiscovery
+    - name: serverAddressByClientCIDRs
+      type:
+        list:
+          elementType:
+            namedType: io.k8s.apimachinery.pkg.apis.meta.v1.ServerAddressByClientCIDR
+          elementRelationship: atomic
+    - name: versions
+      type:
+        list:
+          elementType:
+            namedType: io.k8s.apimachinery.pkg.apis.meta.v1.GroupVersionForDiscovery
+          elementRelationship: atomic
+- name: io.k8s.apimachinery.pkg.apis.meta.v1.APIGroupList
+  map:
+    fields:
+    - name: apiVersion
+      type:
+        scalar: string
+    - name: groups
+      type:
+        list:
+          elementType:
+            namedType: io.k8s.apimachinery.pkg.apis.meta.v1.APIGroup
+          elementRelationship: atomic
+    - name: kind
+      type:
+        scalar: string
+- name: io.k8s.apimachinery.pkg.apis.meta.v1.APIResource
+  map:
+    fields:
+    - name: categories
+      type:
+        list:
+          elementType:
+            scalar: string
+          elementRelationship: atomic
+    - name: group
+      type:
+        scalar: string
+    - name: kind
+      type:
+        scalar: string
+    - name: name
+      type:
+        scalar: string
+    - name: namespaced
+      type:
+        scalar: boolean
+    - name: shortNames
+      type:
+        list:
+          elementType:
+            scalar: string
+          elementRelationship: atomic
+    - name: singularName
+      type:
+        scalar: string
+    - name: verbs
+      type:
+        list:
+          elementType:
+            scalar: string
+          elementRelationship: atomic
+    - name: version
+      type:
+        scalar: string
+- name: io.k8s.apimachinery.pkg.apis.meta.v1.APIResourceList
+  map:
+    fields:
+    - name: apiVersion
+      type:
+        scalar: string
+    - name: groupVersion
+      type:
+        scalar: string
+    - name: kind
+      type:
+        scalar: string
+    - name: resources
+      type:
+        list:
+          elementType:
+            namedType: io.k8s.apimachinery.pkg.apis.meta.v1.APIResource
+          elementRelationship: atomic
+- name: io.k8s.apimachinery.pkg.apis.meta.v1.APIVersions
+  map:
+    fields:
+    - name: apiVersion
+      type:
+        scalar: string
+    - name: kind
+      type:
+        scalar: string
+    - name: serverAddressByClientCIDRs
+      type:
+        list:
+          elementType:
+            namedType: io.k8s.apimachinery.pkg.apis.meta.v1.ServerAddressByClientCIDR
+          elementRelationship: atomic
+    - name: versions
+      type:
+        list:
+          elementType:
+            scalar: string
+          elementRelationship: atomic
+- name: io.k8s.apimachinery.pkg.apis.meta.v1.DeleteOptions
+  map:
+    fields:
+    - name: apiVersion
+      type:
+        scalar: string
+    - name: dryRun
+      type:
+        list:
+          elementType:
+            scalar: string
+          elementRelationship: atomic
+    - name: gracePeriodSeconds
+      type:
+        scalar: numeric
+    - name: kind
+      type:
+        scalar: string
+    - name: orphanDependents
+      type:
+        scalar: boolean
+    - name: preconditions
+      type:
+        namedType: io.k8s.apimachinery.pkg.apis.meta.v1.Preconditions
+    - name: propagationPolicy
+      type:
+        scalar: string
+- name: io.k8s.apimachinery.pkg.apis.meta.v1.GroupVersionForDiscovery
+  map:
+    fields:
+    - name: groupVersion
+      type:
+        scalar: string
+    - name: version
+      type:
+        scalar: string
+- name: io.k8s.apimachinery.pkg.apis.meta.v1.Initializer
+  map:
+    fields:
+    - name: name
+      type:
+        scalar: string
+- name: io.k8s.apimachinery.pkg.apis.meta.v1.Initializers
+  map:
+    fields:
+    - name: pending
+      type:
+        list:
+          elementType:
+            namedType: io.k8s.apimachinery.pkg.apis.meta.v1.Initializer
+          elementRelationship: associative
+          keys:
+          - name
+    - name: result
+      type:
+        namedType: io.k8s.apimachinery.pkg.apis.meta.v1.Status
+- name: io.k8s.apimachinery.pkg.apis.meta.v1.LabelSelector
+  map:
+    fields:
+    - name: matchExpressions
+      type:
+        list:
+          elementType:
+            namedType: io.k8s.apimachinery.pkg.apis.meta.v1.LabelSelectorRequirement
+          elementRelationship: atomic
+    - name: matchLabels
+      type:
+        map:
+          elementType:
+            scalar: string
+- name: io.k8s.apimachinery.pkg.apis.meta.v1.LabelSelectorRequirement
+  map:
+    fields:
+    - name: key
+      type:
+        scalar: string
+    - name: operator
+      type:
+        scalar: string
+    - name: values
+      type:
+        list:
+          elementType:
+            scalar: string
+          elementRelationship: atomic
+- name: io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta
+  map:
+    fields:
+    - name: continue
+      type:
+        scalar: string
+    - name: resourceVersion
+      type:
+        scalar: string
+    - name: selfLink
+      type:
+        scalar: string
+- name: io.k8s.apimachinery.pkg.apis.meta.v1.MicroTime
+  scalar: untyped
+- name: io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta
+  map:
+    fields:
+    - name: annotations
+      type:
+        map:
+          elementType:
+            scalar: string
+    - name: clusterName
+      type:
+        scalar: string
+    - name: creationTimestamp
+      type:
+        namedType: io.k8s.apimachinery.pkg.apis.meta.v1.Time
+    - name: deletionGracePeriodSeconds
+      type:
+        scalar: numeric
+    - name: deletionTimestamp
+      type:
+        namedType: io.k8s.apimachinery.pkg.apis.meta.v1.Time
+    - name: finalizers
+      type:
+        list:
+          elementType:
+            scalar: string
+          elementRelationship: associative
+    - name: generateName
+      type:
+        scalar: string
+    - name: generation
+      type:
+        scalar: numeric
+    - name: initializers
+      type:
+        namedType: io.k8s.apimachinery.pkg.apis.meta.v1.Initializers
+    - name: labels
+      type:
+        map:
+          elementType:
+            scalar: string
+    - name: name
+      type:
+        scalar: string
+    - name: namespace
+      type:
+        scalar: string
+    - name: ownerReferences
+      type:
+        list:
+          elementType:
+            namedType: io.k8s.apimachinery.pkg.apis.meta.v1.OwnerReference
+          elementRelationship: associative
+          keys:
+          - uid
+    - name: resourceVersion
+      type:
+        scalar: string
+    - name: selfLink
+      type:
+        scalar: string
+    - name: uid
+      type:
+        scalar: string
+- name: io.k8s.apimachinery.pkg.apis.meta.v1.OwnerReference
+  map:
+    fields:
+    - name: apiVersion
+      type:
+        scalar: string
+    - name: blockOwnerDeletion
+      type:
+        scalar: boolean
+    - name: controller
+      type:
+        scalar: boolean
+    - name: kind
+      type:
+        scalar: string
+    - name: name
+      type:
+        scalar: string
+    - name: uid
+      type:
+        scalar: string
+- name: io.k8s.apimachinery.pkg.apis.meta.v1.Patch
+  scalar: untyped
+  list:
+    elementType:
+      namedType: __untyped_atomic_
+    elementRelationship: atomic
+  map:
+    elementType:
+      namedType: __untyped_atomic_
+    elementRelationship: atomic
+- name: io.k8s.apimachinery.pkg.apis.meta.v1.Preconditions
+  map:
+    fields:
+    - name: uid
+      type:
+        scalar: string
+- name: io.k8s.apimachinery.pkg.apis.meta.v1.ServerAddressByClientCIDR
+  map:
+    fields:
+    - name: clientCIDR
+      type:
+        scalar: string
+    - name: serverAddress
+      type:
+        scalar: string
+- name: io.k8s.apimachinery.pkg.apis.meta.v1.Status
+  map:
+    fields:
+    - name: apiVersion
+      type:
+        scalar: string
+    - name: code
+      type:
+        scalar: numeric
+    - name: details
+      type:
+        namedType: io.k8s.apimachinery.pkg.apis.meta.v1.StatusDetails
+    - name: kind
+      type:
+        scalar: string
+    - name: message
+      type:
+        scalar: string
+    - name: metadata
+      type:
+        namedType: io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta
+    - name: reason
+      type:
+        scalar: string
+    - name: status
+      type:
+        scalar: string
+- name: io.k8s.apimachinery.pkg.apis.meta.v1.StatusCause
+  map:
+    fields:
+    - name: field
+      type:
+        scalar: string
+    - name: message
+      type:
+        scalar: string
+    - name: reason
+      type:
+        scalar: string
+- name: io.k8s.apimachinery.pkg.apis.meta.v1.StatusDetails
+  map:
+    fields:
+    - name: causes
+      type:
+        list:
+          elementType:
+            namedType: io.k8s.apimachinery.pkg.apis.meta.v1.StatusCause
+          elementRelationship: atomic
+    - name: group
+      type:
+        scalar: string
+    - name: kind
+      type:
+        scalar: string
+    - name: name
+      type:
+        scalar: string
+    - name: retryAfterSeconds
+      type:
+        scalar: numeric
+    - name: uid
+      type:
+        scalar: string
+- name: io.k8s.apimachinery.pkg.apis.meta.v1.Time
+  scalar: untyped
+- name: io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent
+  map:
+    fields:
+    - name: object
+      type:
+        namedType: __untyped_atomic_
+    - name: type
+      type:
+        scalar: string
+- name: io.k8s.apimachinery.pkg.runtime.RawExtension
+  map:
+    fields:
+    - name: Raw
+      type:
+        scalar: string
+- name: io.k8s.apimachinery.pkg.util.intstr.IntOrString
+  scalar: untyped
+- name: io.k8s.apimachinery.pkg.version.Info
+  map:
+    fields:
+    - name: buildDate
+      type:
+        scalar: string
+    - name: compiler
+      type:
+        scalar: string
+    - name: gitCommit
+      type:
+        scalar: string
+    - name: gitTreeState
+      type:
+        scalar: string
+    - name: gitVersion
+      type:
+        scalar: string
+    - name: goVersion
+      type:
+        scalar: string
+    - name: major
+      type:
+        scalar: string
+    - name: minor
+      type:
+        scalar: string
+    - name: platform
+      type:
+        scalar: string
+- name: io.k8s.kube-aggregator.pkg.apis.apiregistration.v1.APIService
+  map:
+    fields:
+    - name: apiVersion
+      type:
+        scalar: string
+    - name: kind
+      type:
+        scalar: string
+    - name: metadata
+      type:
+        namedType: io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta
+        elementRelationship: granular
+    - name: spec
+      type:
+        namedType: io.k8s.kube-aggregator.pkg.apis.apiregistration.v1.APIServiceSpec
+    - name: status
+      type:
+        namedType: io.k8s.kube-aggregator.pkg.apis.apiregistration.v1.APIServiceStatus
+- name: io.k8s.kube-aggregator.pkg.apis.apiregistration.v1.APIServiceCondition
+  map:
+    fields:
+    - name: lastTransitionTime
+      type:
+        namedType: io.k8s.apimachinery.pkg.apis.meta.v1.Time
+    - name: message
+      type:
+        scalar: string
+    - name: reason
+      type:
+        scalar: string
+    - name: status
+      type:
+        scalar: string
+    - name: type
+      type:
+        scalar: string
+- name: io.k8s.kube-aggregator.pkg.apis.apiregistration.v1.APIServiceList
+  map:
+    fields:
+    - name: apiVersion
+      type:
+        scalar: string
+    - name: items
+      type:
+        list:
+          elementType:
+            namedType: io.k8s.kube-aggregator.pkg.apis.apiregistration.v1.APIService
+          elementRelationship: atomic
+    - name: kind
+      type:
+        scalar: string
+    - name: metadata
+      type:
+        namedType: io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta
+        elementRelationship: granular
+- name: io.k8s.kube-aggregator.pkg.apis.apiregistration.v1.APIServiceSpec
+  map:
+    fields:
+    - name: caBundle
+      type:
+        scalar: string
+    - name: group
+      type:
+        scalar: string
+    - name: groupPriorityMinimum
+      type:
+        scalar: numeric
+    - name: insecureSkipTLSVerify
+      type:
+        scalar: boolean
+    - name: service
+      type:
+        namedType: io.k8s.kube-aggregator.pkg.apis.apiregistration.v1.ServiceReference
+    - name: version
+      type:
+        scalar: string
+    - name: versionPriority
+      type:
+        scalar: numeric
+- name: io.k8s.kube-aggregator.pkg.apis.apiregistration.v1.APIServiceStatus
+  map:
+    fields:
+    - name: conditions
+      type:
+        list:
+          elementType:
+            namedType: io.k8s.kube-aggregator.pkg.apis.apiregistration.v1.APIServiceCondition
+          elementRelationship: associative
+          keys:
+          - type
+- name: io.k8s.kube-aggregator.pkg.apis.apiregistration.v1.ServiceReference
+  map:
+    fields:
+    - name: name
+      type:
+        scalar: string
+    - name: namespace
+      type:
+        scalar: string
+- name: io.k8s.kube-aggregator.pkg.apis.apiregistration.v1beta1.APIService
+  map:
+    fields:
+    - name: apiVersion
+      type:
+        scalar: string
+    - name: kind
+      type:
+        scalar: string
+    - name: metadata
+      type:
+        namedType: io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta
+    - name: spec
+      type:
+        namedType: io.k8s.kube-aggregator.pkg.apis.apiregistration.v1beta1.APIServiceSpec
+        elementRelationship: granular
+    - name: status
+      type:
+        namedType: io.k8s.kube-aggregator.pkg.apis.apiregistration.v1beta1.APIServiceStatus
+- name: io.k8s.kube-aggregator.pkg.apis.apiregistration.v1beta1.APIServiceCondition
+  map:
+    fields:
+    - name: lastTransitionTime
+      type:
+        namedType: io.k8s.apimachinery.pkg.apis.meta.v1.Time
+    - name: message
+      type:
+        scalar: string
+    - name: reason
+      type:
+        scalar: string
+    - name: status
+      type:
+        scalar: string
+    - name: type
+      type:
+        scalar: string
+- name: io.k8s.kube-aggregator.pkg.apis.apiregistration.v1beta1.APIServiceList
+  map:
+    fields:
+    - name: apiVersion
+      type:
+        scalar: string
+    - name: items
+      type:
+        list:
+          elementType:
+            namedType: io.k8s.kube-aggregator.pkg.apis.apiregistration.v1beta1.APIService
+          elementRelationship: atomic
+    - name: kind
+      type:
+        scalar: string
+    - name: metadata
+      type:
+        namedType: io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta
+- name: io.k8s.kube-aggregator.pkg.apis.apiregistration.v1beta1.APIServiceSpec
+  map:
+    fields:
+    - name: caBundle
+      type:
+        scalar: string
+    - name: group
+      type:
+        scalar: string
+    - name: groupPriorityMinimum
+      type:
+        scalar: numeric
+    - name: insecureSkipTLSVerify
+      type:
+        scalar: boolean
+    - name: service
+      type:
+        namedType: io.k8s.kube-aggregator.pkg.apis.apiregistration.v1beta1.ServiceReference
+    - name: version
+      type:
+        scalar: string
+    - name: versionPriority
+      type:
+        scalar: numeric
+- name: io.k8s.kube-aggregator.pkg.apis.apiregistration.v1beta1.APIServiceStatus
+  map:
+    fields:
+    - name: conditions
+      type:
+        list:
+          elementType:
+            namedType: io.k8s.kube-aggregator.pkg.apis.apiregistration.v1beta1.APIServiceCondition
+          elementRelationship: associative
+          keys:
+          - type
+- name: io.k8s.kube-aggregator.pkg.apis.apiregistration.v1beta1.ServiceReference
+  map:
+    fields:
+    - name: name
+      type:
+        scalar: string
+    - name: namespace
+      type:
+        scalar: string
+- name: __untyped_atomic_
+  scalar: untyped
+  list:
+    elementType:
+      namedType: __untyped_atomic_
+    elementRelationship: atomic
+  map:
+    elementType:
+      namedType: __untyped_atomic_
+    elementRelationship: atomic

--- a/merge/field_level_overrides_test.go
+++ b/merge/field_level_overrides_test.go
@@ -1,0 +1,262 @@
+package merge_test
+
+import (
+	"testing"
+
+	"sigs.k8s.io/structured-merge-diff/v4/fieldpath"
+	"sigs.k8s.io/structured-merge-diff/v4/internal/fixture"
+	"sigs.k8s.io/structured-merge-diff/v4/merge"
+	"sigs.k8s.io/structured-merge-diff/v4/typed"
+)
+
+func TestFieldLevelOverrides(t *testing.T) {
+	var overrideStructTypeParser = func() fixture.Parser {
+		parser, err := typed.NewParser(`
+        types:
+        - name: type
+          map:
+            fields:
+              - name: associativeListReference
+                type:
+                  namedType: associativeList
+                  elementRelationship: atomic
+              - name: separableInlineList
+                type:
+                  list:
+                    elementType:
+                      scalar: numeric
+                    elementRelationship: atomic
+                  elementRelationship: associative
+              - name: separableMapReference
+                type:
+                  namedType: atomicMap
+                  elementRelationship: separable
+              - name: atomicMapReference
+                type:
+                  namedType: unspecifiedMap
+                  elementRelationship: atomic
+
+        - name: associativeList
+          list:
+            elementType:
+              namedType: unspecifiedMap
+              elementRelationship: atomic
+            elementRelationship: associative
+            keys:
+            - name
+        - name: unspecifiedMap
+          map:
+            fields:
+            - name: name
+              type:
+                scalar: string
+            - name: value
+              type:
+                scalar: numeric
+        - name: atomicMap
+          map:
+            elementRelationship: atomic
+            fields:
+            - name: name
+              type:
+                scalar: string
+            - name: value
+              type:
+                scalar: numeric
+    `)
+		if err != nil {
+			panic(err)
+		}
+		return fixture.SameVersionParser{T: parser.Type("type")}
+	}()
+
+	tests := map[string]fixture.TestCase{
+		"test_override_atomic_map_with_separable": {
+			// Test that a reference with an separable override to an atomic type
+			// is treated as separable
+			Ops: []fixture.Operation{
+				fixture.Apply{
+					Manager: "apply_one",
+					Object: `
+                        separableMapReference:
+                          name: a
+                    `,
+					APIVersion: "v1",
+				},
+				fixture.Apply{
+					Manager: "apply_two",
+					Object: `
+                        separableMapReference:
+                          value: 2
+                    `,
+					APIVersion: "v1",
+				},
+			},
+			Object: `
+                separableMapReference:
+                  name: a
+                  value: 2
+            `,
+			APIVersion: "v1",
+			Managed: fieldpath.ManagedFields{
+				"apply_one": fieldpath.NewVersionedSet(
+					_NS(
+						_P("separableMapReference", "name"),
+					),
+					"v1",
+					false,
+				),
+				"apply_two": fieldpath.NewVersionedSet(
+					_NS(
+						_P("separableMapReference", "value"),
+					),
+					"v1",
+					false,
+				),
+			},
+		},
+		"test_override_unspecified_map_with_atomic": {
+			// Test that a map which has its element relaetionship left as defualt
+			// (granular) can be overriden to be atomic
+			Ops: []fixture.Operation{
+				fixture.Apply{
+					Manager: "apply_one",
+					Object: `
+                        atomicMapReference:
+                          name: a
+                    `,
+					APIVersion: "v1",
+				},
+				fixture.Apply{
+					Manager: "apply_two",
+					Object: `
+                        atomicMapReference:
+                          value: 2
+                    `,
+					APIVersion: "v1",
+					Conflicts: merge.Conflicts{
+						merge.Conflict{Manager: "apply_one", Path: _P("atomicMapReference")},
+					},
+				},
+				fixture.Apply{
+					Manager: "apply_one",
+					Object: `
+                        atomicMapReference:
+                          name: b
+                          value: 2
+                    `,
+					APIVersion: "v1",
+				},
+			},
+			Object: `
+                atomicMapReference:
+                  name: b
+                  value: 2
+            `,
+			APIVersion: "v1",
+			Managed: fieldpath.ManagedFields{
+				"apply_one": fieldpath.NewVersionedSet(
+					_NS(
+						_P("atomicMapReference"),
+					),
+					"v1",
+					false,
+				),
+			},
+		},
+		"test_override_associative_list_with_atomic": {
+			// Test that if a list type is listed associative but referred to as atomic
+			// that attempting to add to the list fauks
+			Ops: []fixture.Operation{
+				fixture.Apply{
+					Manager: "apply_one",
+					Object: `
+                        associativeListReference:
+                          - name: a
+                            value: 1
+                    `,
+					APIVersion: "v1",
+				},
+				fixture.Apply{
+					Manager: "apply_two",
+					Object: `
+                        associativeListReference:
+                        - name: b
+                          value: 2
+                    `,
+					APIVersion: "v1",
+					Conflicts: merge.Conflicts{
+						merge.Conflict{Manager: "apply_one", Path: _P("associativeListReference")},
+					},
+				},
+			},
+			Object: `
+                associativeListReference:
+                  - name: a
+                    value: 1
+            `,
+			APIVersion: "v1",
+			Managed: fieldpath.ManagedFields{
+				"apply_one": fieldpath.NewVersionedSet(
+					_NS(
+						_P("associativeListReference"),
+					),
+					"v1",
+					false,
+				),
+			},
+		},
+		"test_override_inline_atomic_list_with_associative": {
+			// Tests that an inline atomic list can have its type overridden to be
+			// associative
+			Ops: []fixture.Operation{
+				fixture.Apply{
+					Manager: "apply_one",
+					Object: `
+                        separableInlineList:
+                        - 1
+                    `,
+					APIVersion: "v1",
+				},
+				fixture.Apply{
+					Manager: "apply_two",
+					Object: `
+                        separableInlineList:
+                        - 2
+                    `,
+					APIVersion: "v1",
+				},
+			},
+			Object: `
+                separableInlineList:
+                - 1
+                - 2
+            `,
+			APIVersion: "v1",
+			Managed: fieldpath.ManagedFields{
+				"apply_one": fieldpath.NewVersionedSet(
+					_NS(
+						_P("separableInlineList", _V(1)),
+					),
+					"v1",
+					true,
+				),
+				"apply_two": fieldpath.NewVersionedSet(
+					_NS(
+						_P("separableInlineList", _V(2)),
+					),
+					"v1",
+					true,
+				),
+			},
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			if err := test.Test(overrideStructTypeParser); err != nil {
+				t.Fatal(err)
+			}
+		})
+	}
+}

--- a/schema/elements.go
+++ b/schema/elements.go
@@ -30,11 +30,7 @@ type Schema struct {
 	once sync.Once
 	m    map[string]TypeDef
 
-	// Once used to protect the initialization of `lock` field.
-	lockOnce sync.Once
-	// Lock which protects writes to resolvedTypes. Used as pointer so that
-	// schema may be used as a value type
-	lock *sync.Mutex
+	lock sync.Mutex
 	// Cached results of resolving type references to atoms. Only stores
 	// type references which require fields of Atom to be overriden.
 	resolvedTypes map[TypeRef]Atom
@@ -43,7 +39,7 @@ type Schema struct {
 // A TypeSpecifier references a particular type in a schema.
 type TypeSpecifier struct {
 	Type   TypeRef `yaml:"type,omitempty"`
-	Schema Schema  `yaml:"schema,omitempty"`
+	Schema *Schema `yaml:"schema,omitempty"`
 }
 
 // TypeDef represents a named type in a schema.
@@ -290,13 +286,9 @@ func (s *Schema) Resolve(tr TypeRef) (Atom, bool) {
 	}
 
 	// Check to see if we have a cached version of this type
-	s.lockOnce.Do(func() {
-		s.lock = &sync.Mutex{}
-		s.resolvedTypes = make(map[TypeRef]Atom)
-	})
-
 	s.lock.Lock()
 	defer s.lock.Unlock()
+	s.resolvedTypes = make(map[TypeRef]Atom)
 
 	var result Atom
 	var exists bool
@@ -335,7 +327,7 @@ func (s *Schema) Resolve(tr TypeRef) (Atom, bool) {
 // If other is nil this method does nothing.
 // If other is already initialized, overwrites it with this instance
 // Warning: Not thread safe
-func (s Schema) CopyInto(dst *Schema) {
+func (s *Schema) CopyInto(dst *Schema) {
 	if dst == nil {
 		return
 	}

--- a/schema/elements.go
+++ b/schema/elements.go
@@ -16,7 +16,9 @@ limitations under the License.
 
 package schema
 
-import "sync"
+import (
+	"sync"
+)
 
 // Schema is a list of named types.
 //
@@ -27,6 +29,15 @@ type Schema struct {
 
 	once sync.Once
 	m    map[string]TypeDef
+
+	// Once used to protect the initialization of `lock` field.
+	lockOnce sync.Once
+	// Lock which protects writes to resolvedTypes. Used as pointer so that
+	// schema may be used as a value type
+	lock *sync.Mutex
+	// Cached results of resolving type references to atoms. Only stores
+	// type references which require fields of Atom to be overriden.
+	resolvedTypes map[TypeRef]Atom
 }
 
 // A TypeSpecifier references a particular type in a schema.
@@ -48,6 +59,12 @@ type TypeRef struct {
 	// Either the name or one member of Atom should be set.
 	NamedType *string `yaml:"namedType,omitempty"`
 	Inlined   Atom    `yaml:",inline,omitempty"`
+
+	// If this reference refers to a map-type or list-type, this field overrides
+	// the `ElementRelationship` of the referred type when resolved.
+	// If this field is nil, then it has no effect.
+	// See `Map` and `List` for more information about `ElementRelationship`
+	ElementRelationship *ElementRelationship `yaml:"elementRelationship,omitempty"`
 }
 
 // Atom represents the smallest possible pieces of the type system.
@@ -244,20 +261,74 @@ func (s *Schema) FindNamedType(name string) (TypeDef, bool) {
 	return t, ok
 }
 
+func (s *Schema) resolveNoOverrides(tr TypeRef) (Atom, bool) {
+	result := Atom{}
+
+	if tr.NamedType != nil {
+		t, ok := s.FindNamedType(*tr.NamedType)
+		if !ok {
+			return Atom{}, false
+		}
+
+		result = t.Atom
+	} else {
+		result = tr.Inlined
+	}
+
+	return result, true
+}
+
 // Resolve is a convenience function which returns the atom referenced, whether
 // it is inline or named. Returns (Atom{}, false) if the type can't be resolved.
 //
 // This allows callers to not care about the difference between a (possibly
 // inlined) reference and a definition.
 func (s *Schema) Resolve(tr TypeRef) (Atom, bool) {
-	if tr.NamedType != nil {
-		t, ok := s.FindNamedType(*tr.NamedType)
-		if !ok {
+	// If this is a plain reference with no overrides, just return the type
+	if tr.ElementRelationship == nil {
+		return s.resolveNoOverrides(tr)
+	}
+
+	// Check to see if we have a cached version of this type
+	s.lockOnce.Do(func() {
+		s.lock = &sync.Mutex{}
+		s.resolvedTypes = make(map[TypeRef]Atom)
+	})
+
+	s.lock.Lock()
+	defer s.lock.Unlock()
+
+	var result Atom
+	var exists bool
+
+	// Return cached result if available
+	// If not, calculate result and cache it
+	if result, exists = s.resolvedTypes[tr]; !exists {
+		if result, exists = s.resolveNoOverrides(tr); exists {
+			// Allow field-level electives to override the referred type's modifiers
+			switch {
+			case result.Map != nil:
+				mapCopy := *result.Map
+				mapCopy.ElementRelationship = *tr.ElementRelationship
+				result.Map = &mapCopy
+			case result.List != nil:
+				listCopy := *result.List
+				listCopy.ElementRelationship = *tr.ElementRelationship
+				result.List = &listCopy
+			case result.Scalar != nil:
+				return Atom{}, false
+			default:
+				return Atom{}, false
+			}
+		} else {
 			return Atom{}, false
 		}
-		return t.Atom, true
+
+		// Save result. If it is nil, that is also recorded as not existing.
+		s.resolvedTypes[tr] = result
 	}
-	return tr.Inlined, true
+
+	return result, true
 }
 
 // Clones this instance of Schema into the other

--- a/schema/elements.go
+++ b/schema/elements.go
@@ -101,11 +101,11 @@ const (
 
 // Map is a key-value pair. Its default semantics are the same as an
 // associative list, but:
-// * It is serialized differently:
+//   - It is serialized differently:
 //     map:  {"k": {"value": "v"}}
 //     list: [{"key": "k", "value": "v"}]
-// * Keys must be string typed.
-// * Keys can't have multiple components.
+//   - Keys must be string typed.
+//   - Keys can't have multiple components.
 //
 // Optionally, maps may be atomic (for example, imagine representing an RGB
 // color value--it doesn't make sense to have different actors own the R and G

--- a/schema/elements_test.go
+++ b/schema/elements_test.go
@@ -90,7 +90,18 @@ func TestFindField(t *testing.T) {
 func TestResolve(t *testing.T) {
 	existing := "existing"
 	notExisting := "not-existing"
+	numeric := Numeric
+	granular := Separable
+	atomic := Atomic
+
 	a := Atom{List: &List{}}
+	b := Atom{Scalar: &numeric}
+
+	emptyMap := Map{}
+	atomicMap := Map{ElementRelationship: Atomic}
+
+	emptyList := List{}
+	atomicList := List{ElementRelationship: Atomic}
 
 	tests := []struct {
 		testName       string
@@ -102,6 +113,10 @@ func TestResolve(t *testing.T) {
 		{"noNamedType", nil, TypeRef{Inlined: a}, a, true},
 		{"notExistingNamedType", nil, TypeRef{NamedType: &notExisting}, Atom{}, false},
 		{"existingNamedType", []TypeDef{{Name: existing, Atom: a}}, TypeRef{NamedType: &existing}, a, true},
+		{"invalidRelationshipOnScalarType", []TypeDef{{Name: existing, Atom: b}}, TypeRef{NamedType: &existing, ElementRelationship: &granular}, Atom{}, false},
+		{"mapElementRelationshipNamed", []TypeDef{{Name: existing, Atom: Atom{Map: &emptyMap}}}, TypeRef{NamedType: &existing, ElementRelationship: &atomic}, Atom{Map: &atomicMap}, true},
+		{"mapElementRelationshipInlined", nil, TypeRef{Inlined: Atom{Map: &emptyMap}, ElementRelationship: &atomic}, Atom{Map: &atomicMap}, true},
+		{"listElementRelationshipInlined", nil, TypeRef{Inlined: Atom{List: &emptyList}, ElementRelationship: &atomic}, Atom{List: &atomicList}, true},
 	}
 	for _, tt := range tests {
 		tt := tt

--- a/schema/elements_test.go
+++ b/schema/elements_test.go
@@ -161,7 +161,7 @@ func TestCopyInto(t *testing.T) {
 			theCopy := Schema{}
 			s.CopyInto(&theCopy)
 
-			if !reflect.DeepEqual(s, theCopy) {
+			if !reflect.DeepEqual(&s, &theCopy) {
 				t.Fatal("")
 			}
 
@@ -170,7 +170,7 @@ func TestCopyInto(t *testing.T) {
 			theCopy = Schema{}
 			s.CopyInto(&theCopy)
 
-			if !reflect.DeepEqual(s, theCopy) {
+			if !reflect.DeepEqual(&s, &theCopy) {
 				t.Fatal("")
 			}
 		})

--- a/schema/equals.go
+++ b/schema/equals.go
@@ -52,6 +52,9 @@ func (a *TypeRef) Equals(b *TypeRef) bool {
 		}
 		//return true
 	}
+	if a.ElementRelationship != b.ElementRelationship {
+		return false
+	}
 	return a.Inlined.Equals(&b.Inlined)
 }
 

--- a/schema/equals_test.go
+++ b/schema/equals_test.go
@@ -31,10 +31,10 @@ func fuzzInterface(i *interface{}, c fuzz.Continue) {
 	*i = &m
 }
 
-func (Schema) Generate(rand *rand.Rand, size int) reflect.Value {
-	s := Schema{}
+func (*Schema) Generate(rand *rand.Rand, size int) reflect.Value {
+	s := &Schema{}
 	f := fuzz.New().RandSource(rand).MaxDepth(4)
-	f.Fuzz(&s)
+	f.Fuzz(s)
 	return reflect.ValueOf(s)
 }
 
@@ -73,13 +73,13 @@ func TestEquals(t *testing.T) {
 	// The "copy known fields" section of these function is to break if folks
 	// add new fields without fixing the Equals function and this test.
 	funcs := []interface{}{
-		func(x Schema) bool {
-			if !x.Equals(&x) {
+		func(x *Schema) bool {
+			if !x.Equals(x) {
 				return false
 			}
 			var y Schema
 			y.Types = x.Types
-			return x.Equals(&y) == reflect.DeepEqual(&x, &y)
+			return x.Equals(&y) == reflect.DeepEqual(x, &y)
 		},
 		func(x TypeDef) bool {
 			if !x.Equals(&x) {

--- a/schema/schemaschema.go
+++ b/schema/schemaschema.go
@@ -66,6 +66,9 @@ var SchemaSchemaYAML = `types:
     - name: untyped
       type:
         namedType: untyped
+    - name: elementRelationship
+      type:
+        scalar: string
 - name: scalar
   scalar: string
 - name: map

--- a/typed/helpers.go
+++ b/typed/helpers.go
@@ -105,7 +105,11 @@ type atomHandler interface {
 func resolveSchema(s *schema.Schema, tr schema.TypeRef, v value.Value, ah atomHandler) ValidationErrors {
 	a, ok := s.Resolve(tr)
 	if !ok {
-		return errorf("schema error: no type found matching: %v", *tr.NamedType)
+		typeName := "inlined type"
+		if tr.NamedType != nil {
+			typeName = *tr.NamedType
+		}
+		return errorf("schema error: no type found matching: %v", typeName)
 	}
 
 	a = deduceAtom(a, v)

--- a/typed/helpers_test.go
+++ b/typed/helpers_test.go
@@ -1,0 +1,47 @@
+package typed_test
+
+import (
+	"strings"
+	"testing"
+
+	"sigs.k8s.io/structured-merge-diff/v4/internal/fixture"
+	"sigs.k8s.io/structured-merge-diff/v4/typed"
+)
+
+func TestInvalidOverride(t *testing.T) {
+	// Exercises code path for invalidly specifying a scalar type is atomic
+	parser, err := typed.NewParser(`
+    types:
+    - name: type
+      map:
+        fields:
+          - name: field
+            type:
+              scalar: numeric
+              elementRelationship: atomic
+      `)
+
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	sameVersionParser := fixture.SameVersionParser{T: parser.Type("type")}
+
+	test := fixture.TestCase{
+		Ops: []fixture.Operation{
+			fixture.Apply{
+				Manager: "apply_one",
+				Object: `
+                        field: 1
+                    `,
+				APIVersion: "v1",
+			},
+		},
+		APIVersion: "v1",
+	}
+
+	if err := test.Test(sameVersionParser); err == nil ||
+		!strings.Contains(err.Error(), "no type found matching: inlined type") {
+		t.Fatal(err)
+	}
+}

--- a/typed/parser.go
+++ b/typed/parser.go
@@ -29,12 +29,14 @@ type YAMLObject string
 
 // Parser implements YAMLParser and allows introspecting the schema.
 type Parser struct {
-	Schema schema.Schema
+	Schema *schema.Schema
 }
 
 // create builds an unvalidated parser.
 func create(s YAMLObject) (*Parser, error) {
-	p := Parser{}
+	p := Parser{
+		Schema: &schema.Schema{},
+	}
 	err := yaml.Unmarshal([]byte(s), &p.Schema)
 	return &p, err
 }
@@ -74,7 +76,7 @@ func (p *Parser) TypeNames() (names []string) {
 // errors are deferred until a further function is called.
 func (p *Parser) Type(name string) ParseableType {
 	return ParseableType{
-		Schema:  &p.Schema,
+		Schema:  p.Schema,
 		TypeRef: schema.TypeRef{NamedType: &name},
 	}
 }

--- a/typed/reconcile_schema.go
+++ b/typed/reconcile_schema.go
@@ -110,7 +110,7 @@ func (v *reconcileWithSchemaWalker) finishDescent(v2 *reconcileWithSchemaWalker)
 }
 
 // ReconcileFieldSetWithSchema reconciles the a field set with any changes to the
-//// object's schema since the field set was written. Returns the reconciled field set, or nil of
+// // object's schema since the field set was written. Returns the reconciled field set, or nil of
 // no changes were made to the field set.
 //
 // Supports:

--- a/typed/reconcile_schema.go
+++ b/typed/reconcile_schema.go
@@ -110,7 +110,7 @@ func (v *reconcileWithSchemaWalker) finishDescent(v2 *reconcileWithSchemaWalker)
 }
 
 // ReconcileFieldSetWithSchema reconciles the a field set with any changes to the
-// // object's schema since the field set was written. Returns the reconciled field set, or nil of
+// object's schema since the field set was written. Returns the reconciled field set, or nil of
 // no changes were made to the field set.
 //
 // Supports:

--- a/typed/typed.go
+++ b/typed/typed.go
@@ -99,12 +99,13 @@ func (tv TypedValue) ToFieldSet() (*fieldpath.Set, error) {
 
 // Merge returns the result of merging tv and pso ("partially specified
 // object") together. Of note:
-//  * No fields can be removed by this operation.
-//  * If both tv and pso specify a given leaf field, the result will keep pso's
-//    value.
-//  * Container typed elements will have their items ordered:
-//    * like tv, if pso doesn't change anything in the container
-//    * like pso, if pso does change something in the container.
+//   - No fields can be removed by this operation.
+//   - If both tv and pso specify a given leaf field, the result will keep pso's
+//     value.
+//   - Container typed elements will have their items ordered:
+//   - like tv, if pso doesn't change anything in the container
+//   - like pso, if pso does change something in the container.
+//
 // tv and pso must both be of the same type (their Schema and TypeRef must
 // match), or an error will be returned. Validation errors will be returned if
 // the objects don't conform to the schema.

--- a/typed/typed.go
+++ b/typed/typed.go
@@ -103,8 +103,8 @@ func (tv TypedValue) ToFieldSet() (*fieldpath.Set, error) {
 //   - If both tv and pso specify a given leaf field, the result will keep pso's
 //     value.
 //   - Container typed elements will have their items ordered:
-//   - like tv, if pso doesn't change anything in the container
-//   - like pso, if pso does change something in the container.
+//     1. like tv, if pso doesn't change anything in the container
+//     2. like pso, if pso does change something in the container.
 //
 // tv and pso must both be of the same type (their Schema and TypeRef must
 // match), or an error will be returned. Validation errors will be returned if


### PR DESCRIPTION
Part of our solution for https://github.com/kubernetes/kubernetes/pull/110495

Adds necessary functionality to support field-level annotations which may override the annotation of the referred type.