### PR TITLE
Revert backwards incompatible changes

### DIFF
--- a/fieldpath/element.go
+++ b/fieldpath/element.go
@@ -21,7 +21,7 @@ import (
 	"sort"
 	"strings"
 
-	"sigs.k8s.io/structured-merge-diff/v5/value"
+	"sigs.k8s.io/structured-merge-diff/v4/value"
 )
 
 // PathElement describes how to select a child field given a containing object.

--- a/fieldpath/element_test.go
+++ b/fieldpath/element_test.go
@@ -19,7 +19,7 @@ package fieldpath
 import (
 	"testing"
 
-	"sigs.k8s.io/structured-merge-diff/v5/value"
+	"sigs.k8s.io/structured-merge-diff/v4/value"
 )
 
 func TestPathElementSet(t *testing.T) {

--- a/fieldpath/fromvalue.go
+++ b/fieldpath/fromvalue.go
@@ -17,7 +17,7 @@ limitations under the License.
 package fieldpath
 
 import (
-	"sigs.k8s.io/structured-merge-diff/v5/value"
+	"sigs.k8s.io/structured-merge-diff/v4/value"
 )
 
 // SetFromValue creates a set containing every leaf field mentioned in v.

--- a/fieldpath/fromvalue_test.go
+++ b/fieldpath/fromvalue_test.go
@@ -20,7 +20,7 @@ import (
 	"testing"
 
 	"gopkg.in/yaml.v2"
-	"sigs.k8s.io/structured-merge-diff/v5/value"
+	"sigs.k8s.io/structured-merge-diff/v4/value"
 )
 
 func TestFromValue(t *testing.T) {

--- a/fieldpath/managers_test.go
+++ b/fieldpath/managers_test.go
@@ -21,7 +21,7 @@ import (
 	"reflect"
 	"testing"
 
-	"sigs.k8s.io/structured-merge-diff/v5/fieldpath"
+	"sigs.k8s.io/structured-merge-diff/v4/fieldpath"
 )
 
 var (

--- a/fieldpath/path.go
+++ b/fieldpath/path.go
@@ -20,7 +20,7 @@ import (
 	"fmt"
 	"strings"
 
-	"sigs.k8s.io/structured-merge-diff/v5/value"
+	"sigs.k8s.io/structured-merge-diff/v4/value"
 )
 
 // Path describes how to select a potentially deeply-nested child field given a

--- a/fieldpath/path_test.go
+++ b/fieldpath/path_test.go
@@ -19,7 +19,7 @@ package fieldpath
 import (
 	"testing"
 
-	"sigs.k8s.io/structured-merge-diff/v5/value"
+	"sigs.k8s.io/structured-merge-diff/v4/value"
 )
 
 var (

--- a/fieldpath/pathelementmap.go
+++ b/fieldpath/pathelementmap.go
@@ -19,7 +19,7 @@ package fieldpath
 import (
 	"sort"
 
-	"sigs.k8s.io/structured-merge-diff/v5/value"
+	"sigs.k8s.io/structured-merge-diff/v4/value"
 )
 
 // PathElementValueMap is a map from PathElement to value.Value.

--- a/fieldpath/pathelementmap_test.go
+++ b/fieldpath/pathelementmap_test.go
@@ -19,7 +19,7 @@ package fieldpath
 import (
 	"testing"
 
-	"sigs.k8s.io/structured-merge-diff/v5/value"
+	"sigs.k8s.io/structured-merge-diff/v4/value"
 )
 
 func TestPathElementValueMap(t *testing.T) {

--- a/fieldpath/serialize-pe.go
+++ b/fieldpath/serialize-pe.go
@@ -24,7 +24,7 @@ import (
 	"strings"
 
 	jsoniter "github.com/json-iterator/go"
-	"sigs.k8s.io/structured-merge-diff/v5/value"
+	"sigs.k8s.io/structured-merge-diff/v4/value"
 )
 
 var ErrUnknownPathElementType = errors.New("unknown path element type")

--- a/fieldpath/set.go
+++ b/fieldpath/set.go
@@ -20,7 +20,7 @@ import (
 	"sort"
 	"strings"
 
-	"sigs.k8s.io/structured-merge-diff/v5/schema"
+	"sigs.k8s.io/structured-merge-diff/v4/schema"
 )
 
 // Set identifies a set of fields.

--- a/fieldpath/set_test.go
+++ b/fieldpath/set_test.go
@@ -23,7 +23,7 @@ import (
 	"testing"
 
 	"gopkg.in/yaml.v2"
-	"sigs.k8s.io/structured-merge-diff/v5/schema"
+	"sigs.k8s.io/structured-merge-diff/v4/schema"
 )
 
 type randomPathAlphabet []PathElement

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module sigs.k8s.io/structured-merge-diff/v5
+module sigs.k8s.io/structured-merge-diff/v4
 
 require gopkg.in/yaml.v2 v2.2.8
 

--- a/internal/cli/operation.go
+++ b/internal/cli/operation.go
@@ -21,8 +21,8 @@ import (
 	"io"
 	"io/ioutil"
 
-	"sigs.k8s.io/structured-merge-diff/v5/typed"
-	"sigs.k8s.io/structured-merge-diff/v5/value"
+	"sigs.k8s.io/structured-merge-diff/v4/typed"
+	"sigs.k8s.io/structured-merge-diff/v4/value"
 )
 
 type Operation interface {

--- a/internal/cli/options.go
+++ b/internal/cli/options.go
@@ -24,7 +24,7 @@ import (
 	"io/ioutil"
 	"os"
 
-	"sigs.k8s.io/structured-merge-diff/v5/typed"
+	"sigs.k8s.io/structured-merge-diff/v4/typed"
 )
 
 var (

--- a/internal/fixture/state.go
+++ b/internal/fixture/state.go
@@ -477,7 +477,7 @@ func (cs ChangeParser) run(state *State) error {
 	// Swap the schema in for use with the live object so it merges.
 	// If the schema is incompatible, this will fail validation.
 
-	liveWithNewSchema, err := typed.AsTyped(state.Live.AsValue(), cs.Parser.Schema, state.Live.TypeRef())
+	liveWithNewSchema, err := typed.AsTyped(state.Live.AsValue(), &cs.Parser.Schema, state.Live.TypeRef())
 	if err != nil {
 		return err
 	}

--- a/internal/fixture/state.go
+++ b/internal/fixture/state.go
@@ -20,10 +20,10 @@ import (
 	"bytes"
 	"fmt"
 
-	"sigs.k8s.io/structured-merge-diff/v5/fieldpath"
-	"sigs.k8s.io/structured-merge-diff/v5/merge"
-	"sigs.k8s.io/structured-merge-diff/v5/typed"
-	"sigs.k8s.io/structured-merge-diff/v5/value"
+	"sigs.k8s.io/structured-merge-diff/v4/fieldpath"
+	"sigs.k8s.io/structured-merge-diff/v4/merge"
+	"sigs.k8s.io/structured-merge-diff/v4/typed"
+	"sigs.k8s.io/structured-merge-diff/v4/value"
 )
 
 // For the sake of tests, a parser is something that can retrieve a

--- a/internal/fixture/state_test.go
+++ b/internal/fixture/state_test.go
@@ -20,7 +20,7 @@ import (
 	"fmt"
 	"testing"
 
-	"sigs.k8s.io/structured-merge-diff/v5/typed"
+	"sigs.k8s.io/structured-merge-diff/v4/typed"
 )
 
 func TestFixTabs(t *testing.T) {

--- a/merge/conflict.go
+++ b/merge/conflict.go
@@ -21,7 +21,7 @@ import (
 	"sort"
 	"strings"
 
-	"sigs.k8s.io/structured-merge-diff/v5/fieldpath"
+	"sigs.k8s.io/structured-merge-diff/v4/fieldpath"
 )
 
 // Conflict is a conflict on a specific field with the current manager of

--- a/merge/conflict_test.go
+++ b/merge/conflict_test.go
@@ -19,9 +19,9 @@ package merge_test
 import (
 	"testing"
 
-	"sigs.k8s.io/structured-merge-diff/v5/fieldpath"
-	"sigs.k8s.io/structured-merge-diff/v5/merge"
-	"sigs.k8s.io/structured-merge-diff/v5/value"
+	"sigs.k8s.io/structured-merge-diff/v4/fieldpath"
+	"sigs.k8s.io/structured-merge-diff/v4/merge"
+	"sigs.k8s.io/structured-merge-diff/v4/value"
 )
 
 var (

--- a/merge/deduced_test.go
+++ b/merge/deduced_test.go
@@ -19,9 +19,9 @@ package merge_test
 import (
 	"testing"
 
-	"sigs.k8s.io/structured-merge-diff/v5/fieldpath"
-	. "sigs.k8s.io/structured-merge-diff/v5/internal/fixture"
-	"sigs.k8s.io/structured-merge-diff/v5/merge"
+	"sigs.k8s.io/structured-merge-diff/v4/fieldpath"
+	. "sigs.k8s.io/structured-merge-diff/v4/internal/fixture"
+	"sigs.k8s.io/structured-merge-diff/v4/merge"
 )
 
 func TestDeduced(t *testing.T) {

--- a/merge/default_keys_test.go
+++ b/merge/default_keys_test.go
@@ -16,10 +16,10 @@ package merge_test
 import (
 	"testing"
 
-	"sigs.k8s.io/structured-merge-diff/v5/fieldpath"
-	. "sigs.k8s.io/structured-merge-diff/v5/internal/fixture"
-	"sigs.k8s.io/structured-merge-diff/v5/merge"
-	"sigs.k8s.io/structured-merge-diff/v5/typed"
+	"sigs.k8s.io/structured-merge-diff/v4/fieldpath"
+	. "sigs.k8s.io/structured-merge-diff/v4/internal/fixture"
+	"sigs.k8s.io/structured-merge-diff/v4/merge"
+	"sigs.k8s.io/structured-merge-diff/v4/typed"
 )
 
 // portListParser sets the default value of key "protocol" to "TCP"

--- a/merge/extract_apply_test.go
+++ b/merge/extract_apply_test.go
@@ -19,9 +19,9 @@ package merge_test
 import (
 	"testing"
 
-	"sigs.k8s.io/structured-merge-diff/v5/fieldpath"
-	. "sigs.k8s.io/structured-merge-diff/v5/internal/fixture"
-	"sigs.k8s.io/structured-merge-diff/v5/typed"
+	"sigs.k8s.io/structured-merge-diff/v4/fieldpath"
+	. "sigs.k8s.io/structured-merge-diff/v4/internal/fixture"
+	"sigs.k8s.io/structured-merge-diff/v4/typed"
 )
 
 var extractParser = func() Parser {

--- a/merge/field_level_overrides_test.go
+++ b/merge/field_level_overrides_test.go
@@ -3,10 +3,10 @@ package merge_test
 import (
 	"testing"
 
-	"sigs.k8s.io/structured-merge-diff/v5/fieldpath"
-	"sigs.k8s.io/structured-merge-diff/v5/internal/fixture"
-	"sigs.k8s.io/structured-merge-diff/v5/merge"
-	"sigs.k8s.io/structured-merge-diff/v5/typed"
+	"sigs.k8s.io/structured-merge-diff/v4/fieldpath"
+	"sigs.k8s.io/structured-merge-diff/v4/internal/fixture"
+	"sigs.k8s.io/structured-merge-diff/v4/merge"
+	"sigs.k8s.io/structured-merge-diff/v4/typed"
 )
 
 func TestFieldLevelOverrides(t *testing.T) {

--- a/merge/ignore_test.go
+++ b/merge/ignore_test.go
@@ -19,8 +19,8 @@ package merge_test
 import (
 	"testing"
 
-	"sigs.k8s.io/structured-merge-diff/v5/fieldpath"
-	. "sigs.k8s.io/structured-merge-diff/v5/internal/fixture"
+	"sigs.k8s.io/structured-merge-diff/v4/fieldpath"
+	. "sigs.k8s.io/structured-merge-diff/v4/internal/fixture"
 )
 
 func TestIgnoredFields(t *testing.T) {

--- a/merge/key_test.go
+++ b/merge/key_test.go
@@ -19,9 +19,9 @@ package merge_test
 import (
 	"testing"
 
-	"sigs.k8s.io/structured-merge-diff/v5/fieldpath"
-	. "sigs.k8s.io/structured-merge-diff/v5/internal/fixture"
-	"sigs.k8s.io/structured-merge-diff/v5/typed"
+	"sigs.k8s.io/structured-merge-diff/v4/fieldpath"
+	. "sigs.k8s.io/structured-merge-diff/v4/internal/fixture"
+	"sigs.k8s.io/structured-merge-diff/v4/typed"
 )
 
 var associativeListParser = func() Parser {

--- a/merge/leaf_test.go
+++ b/merge/leaf_test.go
@@ -19,10 +19,10 @@ package merge_test
 import (
 	"testing"
 
-	"sigs.k8s.io/structured-merge-diff/v5/fieldpath"
-	. "sigs.k8s.io/structured-merge-diff/v5/internal/fixture"
-	"sigs.k8s.io/structured-merge-diff/v5/merge"
-	"sigs.k8s.io/structured-merge-diff/v5/typed"
+	"sigs.k8s.io/structured-merge-diff/v4/fieldpath"
+	. "sigs.k8s.io/structured-merge-diff/v4/internal/fixture"
+	"sigs.k8s.io/structured-merge-diff/v4/merge"
+	"sigs.k8s.io/structured-merge-diff/v4/typed"
 )
 
 var leafFieldsParser = func() Parser {

--- a/merge/multiple_appliers_test.go
+++ b/merge/multiple_appliers_test.go
@@ -23,11 +23,11 @@ import (
 	"testing"
 
 	"gopkg.in/yaml.v2"
-	"sigs.k8s.io/structured-merge-diff/v5/fieldpath"
-	. "sigs.k8s.io/structured-merge-diff/v5/internal/fixture"
-	"sigs.k8s.io/structured-merge-diff/v5/merge"
-	"sigs.k8s.io/structured-merge-diff/v5/typed"
-	"sigs.k8s.io/structured-merge-diff/v5/value"
+	"sigs.k8s.io/structured-merge-diff/v4/fieldpath"
+	. "sigs.k8s.io/structured-merge-diff/v4/internal/fixture"
+	"sigs.k8s.io/structured-merge-diff/v4/merge"
+	"sigs.k8s.io/structured-merge-diff/v4/typed"
+	"sigs.k8s.io/structured-merge-diff/v4/value"
 )
 
 func TestMultipleAppliersSet(t *testing.T) {

--- a/merge/nested_test.go
+++ b/merge/nested_test.go
@@ -19,9 +19,9 @@ package merge_test
 import (
 	"testing"
 
-	"sigs.k8s.io/structured-merge-diff/v5/fieldpath"
-	. "sigs.k8s.io/structured-merge-diff/v5/internal/fixture"
-	"sigs.k8s.io/structured-merge-diff/v5/typed"
+	"sigs.k8s.io/structured-merge-diff/v4/fieldpath"
+	. "sigs.k8s.io/structured-merge-diff/v4/internal/fixture"
+	"sigs.k8s.io/structured-merge-diff/v4/typed"
 )
 
 var nestedTypeParser = func() Parser {

--- a/merge/obsolete_versions_test.go
+++ b/merge/obsolete_versions_test.go
@@ -20,10 +20,10 @@ import (
 	"fmt"
 	"testing"
 
-	"sigs.k8s.io/structured-merge-diff/v5/fieldpath"
-	. "sigs.k8s.io/structured-merge-diff/v5/internal/fixture"
-	"sigs.k8s.io/structured-merge-diff/v5/merge"
-	"sigs.k8s.io/structured-merge-diff/v5/typed"
+	"sigs.k8s.io/structured-merge-diff/v4/fieldpath"
+	. "sigs.k8s.io/structured-merge-diff/v4/internal/fixture"
+	"sigs.k8s.io/structured-merge-diff/v4/merge"
+	"sigs.k8s.io/structured-merge-diff/v4/typed"
 )
 
 // specificVersionConverter doesn't convert and return the exact same

--- a/merge/preserve_unknown_test.go
+++ b/merge/preserve_unknown_test.go
@@ -19,9 +19,9 @@ package merge_test
 import (
 	"testing"
 
-	"sigs.k8s.io/structured-merge-diff/v5/fieldpath"
-	. "sigs.k8s.io/structured-merge-diff/v5/internal/fixture"
-	"sigs.k8s.io/structured-merge-diff/v5/typed"
+	"sigs.k8s.io/structured-merge-diff/v4/fieldpath"
+	. "sigs.k8s.io/structured-merge-diff/v4/internal/fixture"
+	"sigs.k8s.io/structured-merge-diff/v4/typed"
 )
 
 var preserveUnknownParser = func() Parser {

--- a/merge/real_test.go
+++ b/merge/real_test.go
@@ -21,8 +21,8 @@ import (
 	"path/filepath"
 	"testing"
 
-	. "sigs.k8s.io/structured-merge-diff/v5/internal/fixture"
-	"sigs.k8s.io/structured-merge-diff/v5/typed"
+	. "sigs.k8s.io/structured-merge-diff/v4/internal/fixture"
+	"sigs.k8s.io/structured-merge-diff/v4/typed"
 )
 
 func testdata(file string) string {

--- a/merge/schema_change_test.go
+++ b/merge/schema_change_test.go
@@ -19,10 +19,10 @@ package merge_test
 import (
 	"testing"
 
-	"sigs.k8s.io/structured-merge-diff/v5/fieldpath"
-	. "sigs.k8s.io/structured-merge-diff/v5/internal/fixture"
-	"sigs.k8s.io/structured-merge-diff/v5/merge"
-	"sigs.k8s.io/structured-merge-diff/v5/typed"
+	"sigs.k8s.io/structured-merge-diff/v4/fieldpath"
+	. "sigs.k8s.io/structured-merge-diff/v4/internal/fixture"
+	"sigs.k8s.io/structured-merge-diff/v4/merge"
+	"sigs.k8s.io/structured-merge-diff/v4/typed"
 )
 
 var structParser = func() *typed.Parser {

--- a/merge/set_test.go
+++ b/merge/set_test.go
@@ -19,9 +19,9 @@ package merge_test
 import (
 	"testing"
 
-	"sigs.k8s.io/structured-merge-diff/v5/fieldpath"
-	. "sigs.k8s.io/structured-merge-diff/v5/internal/fixture"
-	"sigs.k8s.io/structured-merge-diff/v5/typed"
+	"sigs.k8s.io/structured-merge-diff/v4/fieldpath"
+	. "sigs.k8s.io/structured-merge-diff/v4/internal/fixture"
+	"sigs.k8s.io/structured-merge-diff/v4/typed"
 )
 
 var setFieldsParser = func() Parser {

--- a/merge/union_test.go
+++ b/merge/union_test.go
@@ -19,10 +19,10 @@ package merge_test
 import (
 	"testing"
 
-	"sigs.k8s.io/structured-merge-diff/v5/fieldpath"
-	. "sigs.k8s.io/structured-merge-diff/v5/internal/fixture"
-	"sigs.k8s.io/structured-merge-diff/v5/merge"
-	"sigs.k8s.io/structured-merge-diff/v5/typed"
+	"sigs.k8s.io/structured-merge-diff/v4/fieldpath"
+	. "sigs.k8s.io/structured-merge-diff/v4/internal/fixture"
+	"sigs.k8s.io/structured-merge-diff/v4/merge"
+	"sigs.k8s.io/structured-merge-diff/v4/typed"
 )
 
 var unionFieldsParser = func() Parser {

--- a/merge/update.go
+++ b/merge/update.go
@@ -16,8 +16,8 @@ package merge
 import (
 	"fmt"
 
-	"sigs.k8s.io/structured-merge-diff/v5/fieldpath"
-	"sigs.k8s.io/structured-merge-diff/v5/typed"
+	"sigs.k8s.io/structured-merge-diff/v4/fieldpath"
+	"sigs.k8s.io/structured-merge-diff/v4/typed"
 )
 
 // Converter is an interface to the conversion logic. The converter

--- a/schema/elements_test.go
+++ b/schema/elements_test.go
@@ -161,7 +161,7 @@ func TestCopyInto(t *testing.T) {
 			theCopy := Schema{}
 			s.CopyInto(&theCopy)
 
-			if !reflect.DeepEqual(s, theCopy) {
+			if !reflect.DeepEqual(&s, &theCopy) {
 				t.Fatal("")
 			}
 
@@ -170,7 +170,7 @@ func TestCopyInto(t *testing.T) {
 			theCopy = Schema{}
 			s.CopyInto(&theCopy)
 
-			if !reflect.DeepEqual(s, theCopy) {
+			if !reflect.DeepEqual(&s, &theCopy) {
 				t.Fatal("")
 			}
 		})

--- a/schema/elements_test.go
+++ b/schema/elements_test.go
@@ -161,7 +161,7 @@ func TestCopyInto(t *testing.T) {
 			theCopy := Schema{}
 			s.CopyInto(&theCopy)
 
-			if !reflect.DeepEqual(&s, &theCopy) {
+			if !reflect.DeepEqual(s, theCopy) {
 				t.Fatal("")
 			}
 
@@ -170,7 +170,7 @@ func TestCopyInto(t *testing.T) {
 			theCopy = Schema{}
 			s.CopyInto(&theCopy)
 
-			if !reflect.DeepEqual(&s, &theCopy) {
+			if !reflect.DeepEqual(s, theCopy) {
 				t.Fatal("")
 			}
 		})

--- a/schema/equals_test.go
+++ b/schema/equals_test.go
@@ -31,18 +31,18 @@ func fuzzInterface(i *interface{}, c fuzz.Continue) {
 	*i = &m
 }
 
-func (Schema) Generate(rand *rand.Rand, size int) reflect.Value {
+func (*Schema) Generate(rand *rand.Rand, size int) reflect.Value {
 	s := Schema{}
 	f := fuzz.New().RandSource(rand).MaxDepth(4)
 	f.Fuzz(&s)
-	return reflect.ValueOf(s)
+	return reflect.ValueOf(&s)
 }
 
-func (Map) Generate(rand *rand.Rand, size int) reflect.Value {
+func (*Map) Generate(rand *rand.Rand, size int) reflect.Value {
 	m := Map{}
 	f := fuzz.New().RandSource(rand).MaxDepth(4).Funcs(fuzzInterface)
 	f.Fuzz(&m)
-	return reflect.ValueOf(m)
+	return reflect.ValueOf(&m)
 }
 
 func (TypeDef) Generate(rand *rand.Rand, size int) reflect.Value {
@@ -73,13 +73,13 @@ func TestEquals(t *testing.T) {
 	// The "copy known fields" section of these function is to break if folks
 	// add new fields without fixing the Equals function and this test.
 	funcs := []interface{}{
-		func(x Schema) bool {
-			if !x.Equals(&x) {
+		func(x *Schema) bool {
+			if !x.Equals(x) {
 				return false
 			}
 			var y Schema
 			y.Types = x.Types
-			return x.Equals(&y) == reflect.DeepEqual(&x, &y)
+			return x.Equals(&y) == reflect.DeepEqual(x, &y)
 		},
 		func(x TypeDef) bool {
 			if !x.Equals(&x) {
@@ -109,8 +109,8 @@ func TestEquals(t *testing.T) {
 			y.Map = x.Map
 			return x.Equals(&y) == reflect.DeepEqual(x, y)
 		},
-		func(x Map) bool {
-			if !x.Equals(&x) {
+		func(x *Map) bool {
+			if !x.Equals(x) {
 				return false
 			}
 			var y Map
@@ -118,7 +118,7 @@ func TestEquals(t *testing.T) {
 			y.ElementRelationship = x.ElementRelationship
 			y.Fields = x.Fields
 			y.Unions = x.Unions
-			return x.Equals(&y) == reflect.DeepEqual(&x, &y)
+			return x.Equals(&y) == reflect.DeepEqual(x, &y)
 		},
 		func(x Union) bool {
 			if !x.Equals(&x) {

--- a/schema/equals_test.go
+++ b/schema/equals_test.go
@@ -31,10 +31,10 @@ func fuzzInterface(i *interface{}, c fuzz.Continue) {
 	*i = &m
 }
 
-func (*Schema) Generate(rand *rand.Rand, size int) reflect.Value {
-	s := &Schema{}
+func (Schema) Generate(rand *rand.Rand, size int) reflect.Value {
+	s := Schema{}
 	f := fuzz.New().RandSource(rand).MaxDepth(4)
-	f.Fuzz(s)
+	f.Fuzz(&s)
 	return reflect.ValueOf(s)
 }
 
@@ -73,13 +73,13 @@ func TestEquals(t *testing.T) {
 	// The "copy known fields" section of these function is to break if folks
 	// add new fields without fixing the Equals function and this test.
 	funcs := []interface{}{
-		func(x *Schema) bool {
-			if !x.Equals(x) {
+		func(x Schema) bool {
+			if !x.Equals(&x) {
 				return false
 			}
 			var y Schema
 			y.Types = x.Types
-			return x.Equals(&y) == reflect.DeepEqual(x, &y)
+			return x.Equals(&y) == reflect.DeepEqual(&x, &y)
 		},
 		func(x TypeDef) bool {
 			if !x.Equals(&x) {

--- a/smd/main.go
+++ b/smd/main.go
@@ -22,7 +22,7 @@ import (
 	"flag"
 	"log"
 
-	"sigs.k8s.io/structured-merge-diff/v5/internal/cli"
+	"sigs.k8s.io/structured-merge-diff/v4/internal/cli"
 )
 
 func main() {

--- a/typed/comparison_test.go
+++ b/typed/comparison_test.go
@@ -3,8 +3,8 @@ package typed_test
 import (
 	"testing"
 
-	"sigs.k8s.io/structured-merge-diff/v5/fieldpath"
-	"sigs.k8s.io/structured-merge-diff/v5/typed"
+	"sigs.k8s.io/structured-merge-diff/v4/fieldpath"
+	"sigs.k8s.io/structured-merge-diff/v4/typed"
 )
 
 func TestComparisonExcludeFields(t *testing.T) {

--- a/typed/deduced_test.go
+++ b/typed/deduced_test.go
@@ -20,8 +20,8 @@ import (
 	"fmt"
 	"testing"
 
-	"sigs.k8s.io/structured-merge-diff/v5/typed"
-	"sigs.k8s.io/structured-merge-diff/v5/value"
+	"sigs.k8s.io/structured-merge-diff/v4/typed"
+	"sigs.k8s.io/structured-merge-diff/v4/value"
 )
 
 func TestValidateDeducedType(t *testing.T) {

--- a/typed/helpers.go
+++ b/typed/helpers.go
@@ -21,9 +21,9 @@ import (
 	"fmt"
 	"strings"
 
-	"sigs.k8s.io/structured-merge-diff/v5/fieldpath"
-	"sigs.k8s.io/structured-merge-diff/v5/schema"
-	"sigs.k8s.io/structured-merge-diff/v5/value"
+	"sigs.k8s.io/structured-merge-diff/v4/fieldpath"
+	"sigs.k8s.io/structured-merge-diff/v4/schema"
+	"sigs.k8s.io/structured-merge-diff/v4/value"
 )
 
 // ValidationError reports an error about a particular field

--- a/typed/helpers_test.go
+++ b/typed/helpers_test.go
@@ -4,8 +4,8 @@ import (
 	"strings"
 	"testing"
 
-	"sigs.k8s.io/structured-merge-diff/v5/internal/fixture"
-	"sigs.k8s.io/structured-merge-diff/v5/typed"
+	"sigs.k8s.io/structured-merge-diff/v4/internal/fixture"
+	"sigs.k8s.io/structured-merge-diff/v4/typed"
 )
 
 func TestInvalidOverride(t *testing.T) {

--- a/typed/merge.go
+++ b/typed/merge.go
@@ -17,9 +17,9 @@ limitations under the License.
 package typed
 
 import (
-	"sigs.k8s.io/structured-merge-diff/v5/fieldpath"
-	"sigs.k8s.io/structured-merge-diff/v5/schema"
-	"sigs.k8s.io/structured-merge-diff/v5/value"
+	"sigs.k8s.io/structured-merge-diff/v4/fieldpath"
+	"sigs.k8s.io/structured-merge-diff/v4/schema"
+	"sigs.k8s.io/structured-merge-diff/v4/value"
 )
 
 type mergingWalker struct {

--- a/typed/merge_test.go
+++ b/typed/merge_test.go
@@ -20,8 +20,8 @@ import (
 	"fmt"
 	"testing"
 
-	"sigs.k8s.io/structured-merge-diff/v5/typed"
-	"sigs.k8s.io/structured-merge-diff/v5/value"
+	"sigs.k8s.io/structured-merge-diff/v4/typed"
+	"sigs.k8s.io/structured-merge-diff/v4/value"
 )
 
 type mergeTestCase struct {

--- a/typed/parser.go
+++ b/typed/parser.go
@@ -20,8 +20,8 @@ import (
 	"fmt"
 
 	yaml "gopkg.in/yaml.v2"
-	"sigs.k8s.io/structured-merge-diff/v5/schema"
-	"sigs.k8s.io/structured-merge-diff/v5/value"
+	"sigs.k8s.io/structured-merge-diff/v4/schema"
+	"sigs.k8s.io/structured-merge-diff/v4/value"
 )
 
 // YAMLObject is an object encoded in YAML.

--- a/typed/parser.go
+++ b/typed/parser.go
@@ -29,14 +29,12 @@ type YAMLObject string
 
 // Parser implements YAMLParser and allows introspecting the schema.
 type Parser struct {
-	Schema *schema.Schema
+	Schema schema.Schema
 }
 
 // create builds an unvalidated parser.
 func create(s YAMLObject) (*Parser, error) {
-	p := Parser{
-		Schema: &schema.Schema{},
-	}
+	p := Parser{}
 	err := yaml.Unmarshal([]byte(s), &p.Schema)
 	return &p, err
 }
@@ -76,7 +74,7 @@ func (p *Parser) TypeNames() (names []string) {
 // errors are deferred until a further function is called.
 func (p *Parser) Type(name string) ParseableType {
 	return ParseableType{
-		Schema:  p.Schema,
+		Schema:  &p.Schema,
 		TypeRef: schema.TypeRef{NamedType: &name},
 	}
 }

--- a/typed/parser_test.go
+++ b/typed/parser_test.go
@@ -23,7 +23,7 @@ import (
 	"testing"
 
 	yaml "gopkg.in/yaml.v2"
-	"sigs.k8s.io/structured-merge-diff/v5/typed"
+	"sigs.k8s.io/structured-merge-diff/v4/typed"
 )
 
 func testdata(file string) string {

--- a/typed/reconcile_schema.go
+++ b/typed/reconcile_schema.go
@@ -20,8 +20,8 @@ import (
 	"fmt"
 	"sync"
 
-	"sigs.k8s.io/structured-merge-diff/v5/fieldpath"
-	"sigs.k8s.io/structured-merge-diff/v5/schema"
+	"sigs.k8s.io/structured-merge-diff/v4/fieldpath"
+	"sigs.k8s.io/structured-merge-diff/v4/schema"
 )
 
 var fmPool = sync.Pool{

--- a/typed/reconcile_schema_test.go
+++ b/typed/reconcile_schema_test.go
@@ -20,8 +20,8 @@ import (
 	"fmt"
 	"testing"
 
-	"sigs.k8s.io/structured-merge-diff/v5/fieldpath"
-	"sigs.k8s.io/structured-merge-diff/v5/typed"
+	"sigs.k8s.io/structured-merge-diff/v4/fieldpath"
+	"sigs.k8s.io/structured-merge-diff/v4/typed"
 )
 
 type reconcileTestCase struct {

--- a/typed/remove.go
+++ b/typed/remove.go
@@ -14,9 +14,9 @@ limitations under the License.
 package typed
 
 import (
-	"sigs.k8s.io/structured-merge-diff/v5/fieldpath"
-	"sigs.k8s.io/structured-merge-diff/v5/schema"
-	"sigs.k8s.io/structured-merge-diff/v5/value"
+	"sigs.k8s.io/structured-merge-diff/v4/fieldpath"
+	"sigs.k8s.io/structured-merge-diff/v4/schema"
+	"sigs.k8s.io/structured-merge-diff/v4/value"
 )
 
 type removingWalker struct {

--- a/typed/remove_test.go
+++ b/typed/remove_test.go
@@ -20,9 +20,9 @@ import (
 	"fmt"
 	"testing"
 
-	"sigs.k8s.io/structured-merge-diff/v5/fieldpath"
-	"sigs.k8s.io/structured-merge-diff/v5/typed"
-	"sigs.k8s.io/structured-merge-diff/v5/value"
+	"sigs.k8s.io/structured-merge-diff/v4/fieldpath"
+	"sigs.k8s.io/structured-merge-diff/v4/typed"
+	"sigs.k8s.io/structured-merge-diff/v4/value"
 )
 
 type removeTestCase struct {

--- a/typed/symdiff_test.go
+++ b/typed/symdiff_test.go
@@ -20,8 +20,8 @@ import (
 	"fmt"
 	"testing"
 
-	"sigs.k8s.io/structured-merge-diff/v5/fieldpath"
-	"sigs.k8s.io/structured-merge-diff/v5/typed"
+	"sigs.k8s.io/structured-merge-diff/v4/fieldpath"
+	"sigs.k8s.io/structured-merge-diff/v4/typed"
 )
 
 type symdiffTestCase struct {

--- a/typed/tofieldset.go
+++ b/typed/tofieldset.go
@@ -19,9 +19,9 @@ package typed
 import (
 	"sync"
 
-	"sigs.k8s.io/structured-merge-diff/v5/fieldpath"
-	"sigs.k8s.io/structured-merge-diff/v5/schema"
-	"sigs.k8s.io/structured-merge-diff/v5/value"
+	"sigs.k8s.io/structured-merge-diff/v4/fieldpath"
+	"sigs.k8s.io/structured-merge-diff/v4/schema"
+	"sigs.k8s.io/structured-merge-diff/v4/value"
 )
 
 var tPool = sync.Pool{

--- a/typed/toset_test.go
+++ b/typed/toset_test.go
@@ -20,9 +20,9 @@ import (
 	"fmt"
 	"testing"
 
-	"sigs.k8s.io/structured-merge-diff/v5/fieldpath"
-	"sigs.k8s.io/structured-merge-diff/v5/typed"
-	"sigs.k8s.io/structured-merge-diff/v5/value"
+	"sigs.k8s.io/structured-merge-diff/v4/fieldpath"
+	"sigs.k8s.io/structured-merge-diff/v4/typed"
+	"sigs.k8s.io/structured-merge-diff/v4/value"
 )
 
 type objSetPair struct {

--- a/typed/typed.go
+++ b/typed/typed.go
@@ -21,9 +21,9 @@ import (
 	"strings"
 	"sync"
 
-	"sigs.k8s.io/structured-merge-diff/v5/fieldpath"
-	"sigs.k8s.io/structured-merge-diff/v5/schema"
-	"sigs.k8s.io/structured-merge-diff/v5/value"
+	"sigs.k8s.io/structured-merge-diff/v4/fieldpath"
+	"sigs.k8s.io/structured-merge-diff/v4/schema"
+	"sigs.k8s.io/structured-merge-diff/v4/value"
 )
 
 // AsTyped accepts a value and a type and returns a TypedValue. 'v' must have

--- a/typed/union.go
+++ b/typed/union.go
@@ -20,8 +20,8 @@ import (
 	"fmt"
 	"strings"
 
-	"sigs.k8s.io/structured-merge-diff/v5/schema"
-	"sigs.k8s.io/structured-merge-diff/v5/value"
+	"sigs.k8s.io/structured-merge-diff/v4/schema"
+	"sigs.k8s.io/structured-merge-diff/v4/value"
 )
 
 func normalizeUnions(w *mergingWalker) error {

--- a/typed/union_test.go
+++ b/typed/union_test.go
@@ -19,7 +19,7 @@ package typed_test
 import (
 	"testing"
 
-	"sigs.k8s.io/structured-merge-diff/v5/typed"
+	"sigs.k8s.io/structured-merge-diff/v4/typed"
 )
 
 var unionParser = func() typed.ParseableType {

--- a/typed/validate.go
+++ b/typed/validate.go
@@ -19,9 +19,9 @@ package typed
 import (
 	"sync"
 
-	"sigs.k8s.io/structured-merge-diff/v5/fieldpath"
-	"sigs.k8s.io/structured-merge-diff/v5/schema"
-	"sigs.k8s.io/structured-merge-diff/v5/value"
+	"sigs.k8s.io/structured-merge-diff/v4/fieldpath"
+	"sigs.k8s.io/structured-merge-diff/v4/schema"
+	"sigs.k8s.io/structured-merge-diff/v4/value"
 )
 
 var vPool = sync.Pool{

--- a/typed/validate_test.go
+++ b/typed/validate_test.go
@@ -21,8 +21,8 @@ import (
 	"strings"
 	"testing"
 
-	"sigs.k8s.io/structured-merge-diff/v5/schema"
-	"sigs.k8s.io/structured-merge-diff/v5/typed"
+	"sigs.k8s.io/structured-merge-diff/v4/schema"
+	"sigs.k8s.io/structured-merge-diff/v4/typed"
 )
 
 type validationTestCase struct {


### PR DESCRIPTION
Can we live with that? Everything still passes, but at least we don't have to bump the major, so any backport/cherry-pick will be much easier to sell.