### PR TITLE
Check inlined struct field's kind before recursively calling value.buildStructCacheEntry

### DIFF
--- a/value/reflectcache.go
+++ b/value/reflectcache.go
@@ -154,7 +154,9 @@ func buildStructCacheEntry(t reflect.Type, infos map[string]*FieldCacheEntry, fi
 			if field.Type.Kind() == reflect.Ptr {
 				e = field.Type.Elem()
 			}
-			buildStructCacheEntry(e, infos, append(fieldPath, field.Index))
+			if e.Kind() == reflect.Struct {
+				buildStructCacheEntry(e, infos, append(fieldPath, field.Index))
+			}
 			continue
 		}
 		info := &FieldCacheEntry{JsonName: jsonName, isOmitEmpty: isOmitempty, fieldPath: append(fieldPath, field.Index), fieldType: field.Type}

--- a/value/reflectcache_test.go
+++ b/value/reflectcache_test.go
@@ -77,3 +77,76 @@ func TestToUnstructured(t *testing.T) {
 		})
 	}
 }
+
+func TestTypeReflectEntryOf(t *testing.T) {
+	testString := ""
+	tests := map[string]struct {
+		arg  interface{}
+		want *TypeReflectCacheEntry
+	}{
+		"StructWithStringField": {
+			arg: struct {
+				F1 string `json:"f1"`
+			}{},
+			want: &TypeReflectCacheEntry{
+				structFields: map[string]*FieldCacheEntry{
+					"f1": {
+						JsonName:  "f1",
+						fieldPath: [][]int{{0}},
+						fieldType: reflect.TypeOf(testString),
+						TypeEntry: &TypeReflectCacheEntry{},
+					},
+				},
+				orderedStructFields: []*FieldCacheEntry{
+					{
+						JsonName:  "f1",
+						fieldPath: [][]int{{0}},
+						fieldType: reflect.TypeOf(testString),
+						TypeEntry: &TypeReflectCacheEntry{},
+					},
+				},
+			},
+		},
+		"StructWith*StringFieldOmitempty": {
+			arg: struct {
+				F1 *string `json:"f1,omitempty"`
+			}{},
+			want: &TypeReflectCacheEntry{
+				structFields: map[string]*FieldCacheEntry{
+					"f1": {
+						JsonName:    "f1",
+						isOmitEmpty: true,
+						fieldPath:   [][]int{{0}},
+						fieldType:   reflect.TypeOf(&testString),
+						TypeEntry:   &TypeReflectCacheEntry{},
+					},
+				},
+				orderedStructFields: []*FieldCacheEntry{
+					{
+						JsonName:    "f1",
+						isOmitEmpty: true,
+						fieldPath:   [][]int{{0}},
+						fieldType:   reflect.TypeOf(&testString),
+						TypeEntry:   &TypeReflectCacheEntry{},
+					},
+				},
+			},
+		},
+		"StructWithInlinedField": {
+			arg: struct {
+				F1 string `json:",inline"`
+			}{},
+			want: &TypeReflectCacheEntry{
+				structFields:        map[string]*FieldCacheEntry{},
+				orderedStructFields: []*FieldCacheEntry{},
+			},
+		},
+	}
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			if got := TypeReflectEntryOf(reflect.TypeOf(tt.arg)); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("TypeReflectEntryOf() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Fixes #230 

This PR proposes to check an inlined struct field's kind before making a recursive call while building a cache entry for a struct [here](https://github.com/kubernetes-sigs/structured-merge-diff/blob/bbe0f82a74e23f330b2f85323da73e72f563c74a/value/reflectcache.go#L157), and adds some tests for `value.TypeReflectEntryOf`.