### PR TITLE
fixture: Show diff when managers don't match

### DIFF
--- a/internal/fixture/state.go
+++ b/internal/fixture/state.go
@@ -588,7 +588,7 @@ func (tc TestCase) TestWithConverter(parser Parser, converter merge.Converter) e
 
 	if tc.Managed != nil {
 		if diff := state.Managers.Difference(tc.Managed); len(diff) != 0 {
-			return fmt.Errorf("expected Managers to be:\n%v\ngot:\n%v", tc.Managed, state.Managers)
+			return fmt.Errorf("expected Managers to be:\n%v\ngot:\n%v\ndiff:\n%v", tc.Managed, state.Managers, diff)
 		}
 	}
 


### PR DESCRIPTION
Very minor nit. We have the diff when the managers don't match, but we don't print it which makes debugging harder than it has to be. Let's print it  to help.