### PR TITLE
Use EqualsUsing recursively

### DIFF
--- a/value/equals_test.go
+++ b/value/equals_test.go
@@ -1,0 +1,88 @@
+/*
+Copyright 2023 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package value_test
+
+import (
+	"io/ioutil"
+	"path/filepath"
+	"testing"
+
+	"gopkg.in/yaml.v2"
+	"sigs.k8s.io/structured-merge-diff/v4/value"
+)
+
+func testdata(file string) string {
+	return filepath.Join("..", "internal", "testdata", file)
+}
+
+func read(file string) []byte {
+	s, err := ioutil.ReadFile(file)
+	if err != nil {
+		panic(err)
+	}
+	return s
+}
+
+func BenchmarkEquals(b *testing.B) {
+	benches := []struct {
+		filename string
+	}{
+		{
+			filename: "pod.yaml",
+		},
+		{
+			filename: "endpoints.yaml",
+		},
+		{
+			filename: "list.yaml",
+		},
+		{
+			filename: "node.yaml",
+		},
+		{
+			filename: "prometheus-crd.yaml",
+		},
+	}
+
+	for _, bench := range benches {
+		b.Run(bench.filename, func(b *testing.B) {
+			var obj interface{}
+			err := yaml.Unmarshal(read(testdata(bench.filename)), &obj)
+			if err != nil {
+				b.Fatalf("Failed to unmarshal object: %v", err)
+			}
+			v := value.NewValueInterface(obj)
+			b.Run("Equals", func(b *testing.B) {
+				b.ReportAllocs()
+				for i := 0; i < b.N; i++ {
+					if !value.Equals(v, v) {
+						b.Fatalf("Object should be equal")
+					}
+				}
+			})
+			b.Run("EqualsUsingFreelist", func(b *testing.B) {
+				b.ReportAllocs()
+				a := value.NewFreelistAllocator()
+				for i := 0; i < b.N; i++ {
+					if !value.EqualsUsing(a, v, v) {
+						b.Fatalf("Object should be equal")
+					}
+				}
+			})
+		})
+	}
+}

--- a/value/mapreflect.go
+++ b/value/mapreflect.go
@@ -136,7 +136,7 @@ func (r mapReflect) EqualsUsing(a Allocator, m Map) bool {
 		if !ok {
 			return false
 		}
-		return Equals(vr.mustReuse(lhsVal, entry, nil, nil), value)
+		return EqualsUsing(a, vr.mustReuse(lhsVal, entry, nil, nil), value)
 	})
 }
 

--- a/value/mapunstructured.go
+++ b/value/mapunstructured.go
@@ -88,12 +88,12 @@ func (m mapUnstructuredInterface) EqualsUsing(a Allocator, other Map) bool {
 	}
 	vv := a.allocValueUnstructured()
 	defer a.Free(vv)
-	return other.Iterate(func(key string, value Value) bool {
+	return other.IterateUsing(a, func(key string, value Value) bool {
 		lhsVal, ok := m[key]
 		if !ok {
 			return false
 		}
-		return Equals(vv.reuse(lhsVal), value)
+		return EqualsUsing(a, vv.reuse(lhsVal), value)
 	})
 }
 
@@ -168,12 +168,12 @@ func (m mapUnstructuredString) EqualsUsing(a Allocator, other Map) bool {
 	}
 	vv := a.allocValueUnstructured()
 	defer a.Free(vv)
-	return other.Iterate(func(key string, value Value) bool {
+	return other.IterateUsing(a, func(key string, value Value) bool {
 		lhsVal, ok := m[key]
 		if !ok {
 			return false
 		}
-		return Equals(vv.reuse(lhsVal), value)
+		return EqualsUsing(a, vv.reuse(lhsVal), value)
 	})
 }
 


### PR DESCRIPTION
Currently, EqualsUsing recurses with Equals, which loses the allocator that you're using, defeating the whole point. Address that in all places I could find. I don't think that code-path is specifically used anywhere so this has no impact on benchmarks.