### PR TITLE
Use EqualsUsing in Typed.Compare()

### DIFF
--- a/typed/typed.go
+++ b/typed/typed.go
@@ -129,12 +129,13 @@ func (tv TypedValue) Compare(rhs *TypedValue) (c *Comparison, err error) {
 		Modified: fieldpath.NewSet(),
 		Added:    fieldpath.NewSet(),
 	}
+	a := value.NewFreelistAllocator()
 	_, err = merge(&tv, rhs, func(w *mergingWalker) {
 		if w.lhs == nil {
 			c.Added.Insert(w.path)
 		} else if w.rhs == nil {
 			c.Removed.Insert(w.path)
-		} else if !value.Equals(w.rhs, w.lhs) {
+		} else if !value.EqualsUsing(a, w.rhs, w.lhs) {
 			// TODO: Equality is not sufficient for this.
 			// Need to implement equality check on the value type.
 			c.Modified.Insert(w.path)


### PR DESCRIPTION
Results are mostly positive, with some huge gains in some cases and minor negative gains in others.

```
name                                              old time/op    new time/op    delta
DeducedSimple-8                                     57.5µs ± 0%    59.4µs ± 0%   +3.19%  (p=0.008 n=5+5)
DeducedNested-8                                      123µs ± 0%     122µs ± 0%   -0.50%  (p=0.008 n=5+5)
DeducedNestedAcrossVersion-8                         167µs ± 0%     169µs ± 0%   +1.11%  (p=0.008 n=5+5)
LeafConflictAcrossVersion-8                         77.6µs ± 0%    81.4µs ± 0%   +4.80%  (p=0.008 n=5+5)
MultipleApplierRecursiveRealConversion-8            1.15ms ± 0%    1.16ms ± 0%   +0.54%  (p=0.008 n=5+5)
Operations/Pod/Create-8                             69.6µs ± 0%    70.1µs ± 0%   +0.68%  (p=0.008 n=5+5)
Operations/Pod/Apply-8                               180µs ± 0%     177µs ± 0%   -1.65%  (p=0.008 n=5+5)
Operations/Pod/ApplyTwice-8                          416µs ± 0%     414µs ± 0%   -0.44%  (p=0.008 n=5+5)
Operations/Pod/Update-8                              169µs ± 0%     173µs ± 0%   +2.19%  (p=0.008 n=5+5)
Operations/Pod/UpdateVersion-8                       241µs ± 0%     253µs ± 0%   +4.80%  (p=0.008 n=5+5)
Operations/Node/Create-8                             105µs ± 0%     107µs ± 0%   +1.95%  (p=0.008 n=5+5)
Operations/Node/Apply-8                              265µs ± 0%     277µs ± 0%   +4.31%  (p=0.008 n=5+5)
Operations/Node/ApplyTwice-8                         623µs ± 0%     658µs ± 0%   +5.58%  (p=0.008 n=5+5)
Operations/Node/Update-8                             268µs ± 0%     297µs ± 0%  +11.01%  (p=0.008 n=5+5)
Operations/Node/UpdateVersion-8                      390µs ± 0%     390µs ± 0%   -0.12%  (p=0.008 n=5+5)
Operations/Endpoints/Create-8                       7.01µs ± 0%    7.70µs ± 0%   +9.78%  (p=0.008 n=5+5)
Operations/Endpoints/Apply-8                        17.2µs ± 0%    16.4µs ± 0%   -4.74%  (p=0.008 n=5+5)
Operations/Endpoints/ApplyTwice-8                   1.14ms ± 0%    0.98ms ± 0%  -14.01%  (p=0.008 n=5+5)
Operations/Endpoints/Update-8                        988µs ± 0%     874µs ± 0%  -11.48%  (p=0.008 n=5+5)
Operations/Endpoints/UpdateVersion-8                2.26ms ± 0%    2.04ms ± 0%   -9.82%  (p=0.008 n=5+5)
Operations/Node100%override/Create-8                 110µs ± 0%     114µs ± 0%   +3.70%  (p=0.008 n=5+5)
Operations/Node100%override/Apply-8                  279µs ± 0%     276µs ± 0%   -1.00%  (p=0.008 n=5+5)
Operations/Node100%override/ApplyTwice-8             637µs ± 0%     606µs ± 0%   -4.86%  (p=0.008 n=5+5)
Operations/Node100%override/Update-8                 271µs ± 0%     287µs ± 0%   +5.64%  (p=0.008 n=5+5)
Operations/Node100%override/UpdateVersion-8          398µs ± 0%     383µs ± 0%   -3.58%  (p=0.008 n=5+5)
Operations/Node10%override/Create-8                  108µs ± 0%     107µs ± 0%   -1.18%  (p=0.008 n=5+5)
Operations/Node10%override/Apply-8                   268µs ± 0%     268µs ± 0%   -0.09%  (p=0.008 n=5+5)
Operations/Node10%override/ApplyTwice-8              624µs ± 0%     628µs ± 0%   +0.74%  (p=0.008 n=5+5)
Operations/Node10%override/Update-8                  267µs ± 0%     262µs ± 0%   -2.06%  (p=0.008 n=5+5)
Operations/Node10%override/UpdateVersion-8           402µs ± 0%     388µs ± 0%   -3.61%  (p=0.008 n=5+5)
Operations/Endpoints100%override/Create-8           7.08µs ± 0%    7.17µs ± 0%   +1.33%  (p=0.008 n=5+5)
Operations/Endpoints100%override/Apply-8            15.6µs ± 0%    15.7µs ± 0%   +0.27%  (p=0.008 n=5+5)
Operations/Endpoints100%override/ApplyTwice-8        990µs ± 0%     873µs ± 0%  -11.82%  (p=0.008 n=5+5)
Operations/Endpoints100%override/Update-8            980µs ± 0%     858µs ± 0%  -12.43%  (p=0.008 n=5+5)
Operations/Endpoints100%override/UpdateVersion-8    1.93ms ± 0%    1.79ms ± 0%   -7.31%  (p=0.008 n=5+5)
Operations/Endpoints10%override/Create-8            7.17µs ± 0%    7.33µs ± 0%   +2.19%  (p=0.008 n=5+5)
Operations/Endpoints10%override/Apply-8             17.0µs ± 0%    16.0µs ± 0%   -6.01%  (p=0.008 n=5+5)
Operations/Endpoints10%override/ApplyTwice-8        1.00ms ± 0%    0.88ms ± 0%  -11.68%  (p=0.008 n=5+5)
Operations/Endpoints10%override/Update-8            1.13ms ± 0%    0.86ms ± 0%  -24.00%  (p=0.008 n=5+5)
Operations/Endpoints10%override/UpdateVersion-8     2.17ms ± 0%    1.81ms ± 0%  -16.72%  (p=0.008 n=5+5)
Operations/PrometheusCRD/Create-8                    582µs ± 0%     577µs ± 0%   -0.78%  (p=0.008 n=5+5)
Operations/PrometheusCRD/Apply-8                    1.54ms ± 0%    1.51ms ± 0%   -2.22%  (p=0.008 n=5+5)
Operations/PrometheusCRD/ApplyTwice-8               3.75ms ± 0%    3.48ms ± 0%   -7.19%  (p=0.008 n=5+5)
Operations/PrometheusCRD/Update-8                   1.95ms ± 0%    1.58ms ± 0%  -18.88%  (p=0.008 n=5+5)
Operations/PrometheusCRD/UpdateVersion-8            2.75ms ± 0%    2.29ms ± 0%  -16.68%  (p=0.008 n=5+5)
Operations/apiresourceimport/Create-8               2.93ms ± 0%    2.91ms ± 0%   -0.65%  (p=0.008 n=5+5)
Operations/apiresourceimport/Apply-8                8.44ms ± 0%    8.08ms ± 0%   -4.33%  (p=0.008 n=5+5)
Operations/apiresourceimport/ApplyTwice-8           16.4ms ± 0%    14.9ms ± 0%   -9.07%  (p=0.008 n=5+5)
Operations/apiresourceimport/Update-8               4.61ms ± 0%    5.32ms ± 0%  +15.48%  (p=0.008 n=5+5)
Operations/apiresourceimport/UpdateVersion-8        6.32ms ± 0%    6.16ms ± 0%   -2.57%  (p=0.008 n=5+5)

name                                              old alloc/op   new alloc/op   delta
DeducedSimple-8                                     28.4kB ± 0%    29.7kB ± 0%   +4.32%  (p=0.008 n=5+5)
DeducedNested-8                                     56.7kB ± 0%    58.2kB ± 0%   +2.65%  (p=0.008 n=5+5)
DeducedNestedAcrossVersion-8                        75.6kB ± 0%    78.3kB ± 0%   +3.45%  (p=0.008 n=5+5)
LeafConflictAcrossVersion-8                         40.2kB ± 0%    42.3kB ± 0%   +5.33%  (p=0.008 n=5+5)
MultipleApplierRecursiveRealConversion-8             714kB ± 0%     714kB ± 0%   +0.11%  (p=0.008 n=5+5)
Operations/Pod/Create-8                             21.0kB ± 0%    21.3kB ± 0%   +1.47%  (p=0.008 n=5+5)
Operations/Pod/Apply-8                              52.5kB ± 0%    52.8kB ± 0%   +0.58%  (p=0.008 n=5+5)
Operations/Pod/ApplyTwice-8                          106kB ± 0%     107kB ± 0%   +0.47%  (p=0.008 n=5+5)
Operations/Pod/Update-8                             39.5kB ± 0%    40.0kB ± 0%   +1.25%  (p=0.008 n=5+5)
Operations/Pod/UpdateVersion-8                      51.9kB ± 0%    52.7kB ± 0%   +1.42%  (p=0.008 n=5+5)
Operations/Node/Create-8                            29.9kB ± 0%    30.2kB ± 0%   +0.99%  (p=0.008 n=5+5)
Operations/Node/Apply-8                             73.5kB ± 0%    73.8kB ± 0%   +0.36%  (p=0.008 n=5+5)
Operations/Node/ApplyTwice-8                         153kB ± 0%     149kB ± 0%   -2.33%  (p=0.008 n=5+5)
Operations/Node/Update-8                            60.9kB ± 0%    57.4kB ± 0%   -5.75%  (p=0.008 n=5+5)
Operations/Node/UpdateVersion-8                     83.3kB ± 0%    75.9kB ± 0%   -8.86%  (p=0.008 n=5+5)
Operations/Endpoints/Create-8                       3.54kB ± 0%    3.84kB ± 0%   +8.59%  (p=0.008 n=5+5)
Operations/Endpoints/Apply-8                        6.39kB ± 0%    6.70kB ± 0%   +4.77%  (p=0.008 n=5+5)
Operations/Endpoints/ApplyTwice-8                    174kB ± 0%     110kB ± 0%  -36.40%  (p=0.008 n=5+5)
Operations/Endpoints/Update-8                        167kB ± 0%     104kB ± 0%  -37.78%  (p=0.008 n=5+5)
Operations/Endpoints/UpdateVersion-8                 329kB ± 0%     203kB ± 0%  -38.46%  (p=0.008 n=5+5)
Operations/Node100%override/Create-8                29.9kB ± 0%    30.2kB ± 0%   +1.00%  (p=0.008 n=5+5)
Operations/Node100%override/Apply-8                 73.5kB ± 0%    73.8kB ± 0%   +0.38%  (p=0.008 n=5+5)
Operations/Node100%override/ApplyTwice-8             153kB ± 0%     149kB ± 0%   -2.32%  (p=0.008 n=5+5)
Operations/Node100%override/Update-8                61.0kB ± 0%    57.4kB ± 0%   -5.80%  (p=0.008 n=5+5)
Operations/Node100%override/UpdateVersion-8         83.3kB ± 0%    75.9kB ± 0%   -8.85%  (p=0.008 n=5+5)
Operations/Node10%override/Create-8                 29.9kB ± 0%    30.2kB ± 0%   +1.01%  (p=0.008 n=5+5)
Operations/Node10%override/Apply-8                  73.5kB ± 0%    73.8kB ± 0%   +0.38%  (p=0.008 n=5+5)
Operations/Node10%override/ApplyTwice-8              153kB ± 0%     149kB ± 0%   -2.37%  (p=0.008 n=5+5)
Operations/Node10%override/Update-8                 60.9kB ± 0%    57.4kB ± 0%   -5.77%  (p=0.008 n=5+5)
Operations/Node10%override/UpdateVersion-8          83.3kB ± 0%    75.9kB ± 0%   -8.84%  (p=0.008 n=5+5)
Operations/Endpoints100%override/Create-8           3.54kB ± 0%    3.84kB ± 0%   +8.62%  (p=0.008 n=5+5)
Operations/Endpoints100%override/Apply-8            6.39kB ± 0%    6.70kB ± 0%   +4.77%  (p=0.008 n=5+5)
Operations/Endpoints100%override/ApplyTwice-8        174kB ± 0%     110kB ± 0%  -36.40%  (p=0.008 n=5+5)
Operations/Endpoints100%override/Update-8            167kB ± 0%     104kB ± 0%  -37.77%  (p=0.008 n=5+5)
Operations/Endpoints100%override/UpdateVersion-8     329kB ± 0%     203kB ± 0%  -38.48%  (p=0.008 n=5+5)
Operations/Endpoints10%override/Create-8            3.54kB ± 0%    3.84kB ± 0%   +8.59%  (p=0.008 n=5+5)
Operations/Endpoints10%override/Apply-8             6.39kB ± 0%    6.70kB ± 0%   +4.77%  (p=0.008 n=5+5)
Operations/Endpoints10%override/ApplyTwice-8         174kB ± 0%     110kB ± 0%  -36.40%  (p=0.008 n=5+5)
Operations/Endpoints10%override/Update-8             167kB ± 0%     104kB ± 0%  -37.76%  (p=0.008 n=5+5)
Operations/Endpoints10%override/UpdateVersion-8      329kB ± 0%     203kB ± 0%  -38.47%  (p=0.008 n=5+5)
Operations/PrometheusCRD/Create-8                    165kB ± 0%     165kB ± 0%   +0.15%  (p=0.008 n=5+5)
Operations/PrometheusCRD/Apply-8                     471kB ± 0%     471kB ± 0%   +0.06%  (p=0.008 n=5+5)
Operations/PrometheusCRD/ApplyTwice-8                959kB ± 0%     936kB ± 0%   -2.46%  (p=0.008 n=5+5)
Operations/PrometheusCRD/Update-8                    342kB ± 0%     318kB ± 0%   -7.08%  (p=0.008 n=5+5)
Operations/PrometheusCRD/UpdateVersion-8             473kB ± 0%     425kB ± 0%  -10.16%  (p=0.008 n=5+5)
Operations/apiresourceimport/Create-8                679kB ± 0%     679kB ± 0%   +0.03%  (p=0.008 n=5+5)
Operations/apiresourceimport/Apply-8                1.94MB ± 0%    1.94MB ± 0%   -0.04%  (p=0.008 n=5+5)
Operations/apiresourceimport/ApplyTwice-8           3.60MB ± 0%    3.57MB ± 0%   -0.88%  (p=0.008 n=5+5)
Operations/apiresourceimport/Update-8               1.05MB ± 0%    1.02MB ± 0%   -2.86%  (p=0.008 n=5+5)
Operations/apiresourceimport/UpdateVersion-8        1.41MB ± 0%    1.35MB ± 0%   -4.19%  (p=0.008 n=5+5)

name                                              old allocs/op  new allocs/op  delta
DeducedSimple-8                                        671 ± 0%       703 ± 0%   +4.77%  (p=0.008 n=5+5)
DeducedNested-8                                      1.29k ± 0%     1.34k ± 0%   +3.32%  (p=0.008 n=5+5)
DeducedNestedAcrossVersion-8                         1.75k ± 0%     1.83k ± 0%   +4.51%  (p=0.008 n=5+5)
LeafConflictAcrossVersion-8                            887 ± 0%       943 ± 0%   +6.31%  (p=0.008 n=5+5)
MultipleApplierRecursiveRealConversion-8             7.53k ± 0%     7.58k ± 0%   +0.64%  (p=0.008 n=5+5)
Operations/Pod/Create-8                                473 ± 0%       481 ± 0%   +1.69%  (p=0.008 n=5+5)
Operations/Pod/Apply-8                               1.25k ± 0%     1.26k ± 0%   +0.64%  (p=0.008 n=5+5)
Operations/Pod/ApplyTwice-8                          2.61k ± 0%     2.62k ± 0%   +0.23%  (p=0.008 n=5+5)
Operations/Pod/Update-8                                971 ± 0%       976 ± 0%   +0.51%  (p=0.008 n=5+5)
Operations/Pod/UpdateVersion-8                       1.40k ± 0%     1.40k ± 0%   +0.36%  (p=0.008 n=5+5)
Operations/Node/Create-8                               557 ± 0%       565 ± 0%   +1.44%  (p=0.008 n=5+5)
Operations/Node/Apply-8                              1.56k ± 0%     1.57k ± 0%   +0.45%  (p=0.008 n=5+5)
Operations/Node/ApplyTwice-8                         3.51k ± 0%     3.37k ± 0%   -4.07%  (p=0.008 n=5+5)
Operations/Node/Update-8                             1.41k ± 0%     1.26k ± 0%  -10.09%  (p=0.008 n=5+5)
Operations/Node/UpdateVersion-8                      2.16k ± 0%     1.87k ± 0%  -13.64%  (p=0.008 n=5+5)
Operations/Endpoints/Create-8                         76.0 ± 0%      84.0 ± 0%  +10.53%  (p=0.008 n=5+5)
Operations/Endpoints/Apply-8                           148 ± 0%       156 ± 0%   +5.41%  (p=0.008 n=5+5)
Operations/Endpoints/ApplyTwice-8                    6.33k ± 0%     2.35k ± 0%  -62.91%  (p=0.008 n=5+5)
Operations/Endpoints/Update-8                        6.17k ± 0%     2.20k ± 0%  -64.44%  (p=0.008 n=5+5)
Operations/Endpoints/UpdateVersion-8                 12.2k ± 0%      4.3k ± 0%  -65.09%  (p=0.008 n=5+5)
Operations/Node100%override/Create-8                   557 ± 0%       565 ± 0%   +1.44%  (p=0.008 n=5+5)
Operations/Node100%override/Apply-8                  1.56k ± 0%     1.57k ± 0%   +0.51%  (p=0.008 n=5+5)
Operations/Node100%override/ApplyTwice-8             3.51k ± 0%     3.37k ± 0%   -4.07%  (p=0.008 n=5+5)
Operations/Node100%override/Update-8                 1.41k ± 0%     1.26k ± 0%  -10.16%  (p=0.008 n=5+5)
Operations/Node100%override/UpdateVersion-8          2.16k ± 0%     1.87k ± 0%  -13.59%  (p=0.008 n=5+5)
Operations/Node10%override/Create-8                    557 ± 0%       565 ± 0%   +1.44%  (p=0.008 n=5+5)
Operations/Node10%override/Apply-8                   1.56k ± 0%     1.57k ± 0%   +0.51%  (p=0.008 n=5+5)
Operations/Node10%override/ApplyTwice-8              3.51k ± 0%     3.37k ± 0%   -4.10%  (p=0.008 n=5+5)
Operations/Node10%override/Update-8                  1.41k ± 0%     1.26k ± 0%  -10.16%  (p=0.008 n=5+5)
Operations/Node10%override/UpdateVersion-8           2.16k ± 0%     1.87k ± 0%  -13.64%  (p=0.008 n=5+5)
Operations/Endpoints100%override/Create-8             76.0 ± 0%      84.0 ± 0%  +10.53%  (p=0.008 n=5+5)
Operations/Endpoints100%override/Apply-8               148 ± 0%       156 ± 0%   +5.41%  (p=0.008 n=5+5)
Operations/Endpoints100%override/ApplyTwice-8        6.33k ± 0%     2.35k ± 0%  -62.90%  (p=0.008 n=5+5)
Operations/Endpoints100%override/Update-8            6.17k ± 0%     2.20k ± 0%  -64.44%  (p=0.008 n=5+5)
Operations/Endpoints100%override/UpdateVersion-8     12.2k ± 0%      4.3k ± 0%  -65.09%  (p=0.008 n=5+5)
Operations/Endpoints10%override/Create-8              76.0 ± 0%      84.0 ± 0%  +10.53%  (p=0.008 n=5+5)
Operations/Endpoints10%override/Apply-8                148 ± 0%       156 ± 0%   +5.41%  (p=0.008 n=5+5)
Operations/Endpoints10%override/ApplyTwice-8         6.33k ± 0%     2.35k ± 0%  -62.90%  (p=0.008 n=5+5)
Operations/Endpoints10%override/Update-8             6.17k ± 0%     2.20k ± 0%  -64.44%  (p=0.008 n=5+5)
Operations/Endpoints10%override/UpdateVersion-8      12.2k ± 0%      4.3k ± 0%  -65.09%  (p=0.008 n=5+5)
Operations/PrometheusCRD/Create-8                    3.67k ± 0%     3.68k ± 0%   +0.19%  (p=0.008 n=5+5)
Operations/PrometheusCRD/Apply-8                     10.2k ± 0%     10.2k ± 0%   +0.08%  (p=0.008 n=5+5)
Operations/PrometheusCRD/ApplyTwice-8                21.2k ± 0%     20.0k ± 0%   -5.89%  (p=0.008 n=5+5)
Operations/PrometheusCRD/Update-8                    8.23k ± 0%     6.98k ± 0%  -15.26%  (p=0.008 n=5+5)
Operations/PrometheusCRD/UpdateVersion-8             12.7k ± 0%     10.2k ± 0%  -19.83%  (p=0.008 n=5+5)
Operations/apiresourceimport/Create-8                15.4k ± 0%     15.4k ± 0%   +0.05%  (p=0.008 n=5+5)
Operations/apiresourceimport/Apply-8                 43.0k ± 0%     43.0k ± 0%   -0.01%  (p=0.008 n=5+5)
Operations/apiresourceimport/ApplyTwice-8            82.8k ± 0%     81.8k ± 0%   -1.25%  (p=0.008 n=5+5)
Operations/apiresourceimport/Update-8                27.4k ± 0%     26.3k ± 0%   -3.72%  (p=0.008 n=5+5)
Operations/apiresourceimport/UpdateVersion-8         39.3k ± 0%     37.3k ± 0%   -5.17%  (p=0.008 n=5+5)
```