### PR TITLE
deep copy slice object during append

### DIFF
--- a/merge/conflict.go
+++ b/merge/conflict.go
@@ -112,7 +112,7 @@ func ConflictsFromManagers(sets fieldpath.ManagedFields) Conflicts {
 		set.Set().Iterate(func(p fieldpath.Path) {
 			conflicts = append(conflicts, Conflict{
 				Manager: manager,
-				Path:    p,
+				Path:    p.Copy(),
 			})
 		})
 	}

--- a/merge/conflict_test.go
+++ b/merge/conflict_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package merge_test
 
 import (
+	"reflect"
 	"testing"
 
 	"sigs.k8s.io/structured-merge-diff/v4/fieldpath"
@@ -90,5 +91,46 @@ func TestToSet(t *testing.T) {
 	actual := conflicts.ToSet()
 	if !expected.Equals(actual) {
 		t.Fatalf("expected\n%v\n, but got\n%v\n", expected, actual)
+	}
+}
+
+func TestConflictsFromManagers(t *testing.T) {
+	type args struct {
+		sets fieldpath.ManagedFields
+	}
+	tests := []struct {
+		name string
+		args args
+		want string
+	}{
+		{
+			name: "test with common prefix",
+			args: args{
+				sets: fieldpath.ManagedFields{
+					"Bob": fieldpath.NewVersionedSet(
+						_NS(
+							_P("spec", "template", "spec", "containers", _KBF("name", "probe"), "livenessProbe", "exec", "command"),
+							_P("spec", "template", "spec", "containers", _KBF("name", "probe"), "livenessProbe", "periodSeconds"),
+							_P("spec", "template", "spec", "containers", _KBF("name", "probe"), "readinessProbe", "exec", "command"),
+							_P("spec", "template", "spec", "containers", _KBF("name", "probe"), "readinessProbe", "periodSeconds"),
+						),
+						"v1",
+						false,
+					),
+				},
+			},
+			want: `conflicts with "Bob":
+- .spec.template.spec.containers[name="probe"].livenessProbe.periodSeconds
+- .spec.template.spec.containers[name="probe"].livenessProbe.exec.command
+- .spec.template.spec.containers[name="probe"].readinessProbe.periodSeconds
+- .spec.template.spec.containers[name="probe"].readinessProbe.exec.command`,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := merge.ConflictsFromManagers(tt.args.sets); !reflect.DeepEqual(got.Error(), tt.want) {
+				t.Errorf("ConflictsFromManagers() = %v, want %v", got, tt.want)
+			}
+		})
 	}
 }

--- a/merge/conflict_test.go
+++ b/merge/conflict_test.go
@@ -94,7 +94,6 @@ func TestToSet(t *testing.T) {
 }
 
 func TestConflictsFromManagers(t *testing.T) {
-
 	got := merge.ConflictsFromManagers(fieldpath.ManagedFields{
 		"Bob": fieldpath.NewVersionedSet(
 			_NS(


### PR DESCRIPTION
Since p is slice, its value is changed during the tree traversal(iterate). Hence use deep copy instead.

fixes https://github.com/kubernetes/kubernetes/issues/119141