### PR TITLE
merge: Add tests for merging with lists that have duplicates

### DIFF
--- a/merge/duplicates_test.go
+++ b/merge/duplicates_test.go
@@ -1,0 +1,707 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package merge_test
+
+import (
+	"testing"
+
+	"sigs.k8s.io/structured-merge-diff/v4/fieldpath"
+	. "sigs.k8s.io/structured-merge-diff/v4/internal/fixture"
+	"sigs.k8s.io/structured-merge-diff/v4/merge"
+	"sigs.k8s.io/structured-merge-diff/v4/typed"
+)
+
+var duplicatesParser = func() Parser {
+	parser, err := typed.NewParser(`types:
+- name: type
+  map:
+    fields:
+      - name: list
+        type:
+          namedType: associativeList
+      - name: unrelated
+        type:
+          scalar: numeric
+      - name: set
+        type:
+          namedType: set
+- name: associativeList
+  list:
+    elementType:
+      namedType: myElement
+    elementRelationship: associative
+    keys:
+    - name
+- name: myElement
+  map:
+    fields:
+    - name: name
+      type:
+        scalar: string
+    - name: value1
+      type:
+        scalar: numeric
+    - name: value2
+      type:
+        scalar: numeric
+- name: set
+  list:
+    elementType:
+      scalar: numeric
+    elementRelationship: set
+`)
+	if err != nil {
+		panic(err)
+	}
+	return SameVersionParser{T: parser.Type("type")}
+}()
+
+func TestDuplicates(t *testing.T) {
+	tests := map[string]TestCase{
+		"sets/ownership/duplicates": {
+			Ops: []Operation{
+				Update{
+					Manager: "updater-one",
+					Object: `
+						set: [1, 1, 3, 4]
+					`,
+					APIVersion: "v1",
+				},
+			},
+			Managed: fieldpath.ManagedFields{
+				"updater-one": fieldpath.NewVersionedSet(
+					_NS(
+						_P("set", _V(1)),
+						_P("set", _V(3)),
+						_P("set", _V(4)),
+					),
+					"v1",
+					false,
+				),
+				"updater-two": fieldpath.NewVersionedSet(
+					_NS(
+						_P("set", _V(1)),
+					),
+					"v1",
+					false,
+				),
+			},
+		},
+		"sets/ownership/add_duplicate": {
+			Ops: []Operation{
+				Update{
+					Manager: "updater-one",
+					Object: `
+						set: [1, 3, 4]
+					`,
+					APIVersion: "v1",
+				},
+				Update{
+					Manager: "updater-two",
+					Object: `
+						set: [1, 1, 3, 4]
+					`,
+					APIVersion: "v1",
+				},
+			},
+			Managed: fieldpath.ManagedFields{
+				"updater-one": fieldpath.NewVersionedSet(
+					_NS(
+						_P("set", _V(3)),
+						_P("set", _V(4)),
+					),
+					"v1",
+					false,
+				),
+				"updater-two": fieldpath.NewVersionedSet(
+					_NS(
+						_P("set", _V(1)),
+					),
+					"v1",
+					false,
+				),
+			},
+		},
+		"sets/ownership/remove_duplicate": {
+			Ops: []Operation{
+				Update{
+					Manager: "updater-one",
+					Object: `
+						set: [1, 1, 3, 4]
+					`,
+					APIVersion: "v1",
+				},
+				Update{
+					Manager: "updater-two",
+					Object: `
+						set: [1, 3, 4]
+					`,
+					APIVersion: "v1",
+				},
+			},
+			Managed: fieldpath.ManagedFields{
+				"updater-one": fieldpath.NewVersionedSet(
+					_NS(
+						_P("set", _V(3)),
+						_P("set", _V(4)),
+					),
+					"v1",
+					false,
+				),
+				"updater-two": fieldpath.NewVersionedSet(
+					_NS(
+						_P("set", _V(1)),
+					),
+					"v1",
+					false,
+				),
+			},
+		},
+		"sets/merging/remove_duplicate": {
+			Ops: []Operation{
+				Update{
+					Manager: "updater",
+					Object: `
+						set: [1, 1, 3, 4]
+					`,
+					APIVersion: "v1",
+				},
+				Apply{
+					Manager: "applier",
+					Object: `
+						set: [1]
+					`,
+					APIVersion: "v1",
+					Conflicts: merge.Conflicts{
+						{Manager: "updater", Path: _P("set", _V(1))},
+					},
+				},
+				ForceApply{
+					Manager: "applier",
+					Object: `
+						set: [1]
+					`,
+					APIVersion: "v1",
+				},
+			},
+			Object: `
+				set: [1, 3, 4]
+			`,
+			APIVersion: "v1",
+			Managed: fieldpath.ManagedFields{
+				"updater": fieldpath.NewVersionedSet(
+					_NS(
+						_P("set", _V(3)),
+						_P("set", _V(4)),
+					),
+					"v1",
+					false,
+				),
+				"applier": fieldpath.NewVersionedSet(
+					_NS(
+						_P("set", _V(1)),
+					),
+					"v1",
+					true,
+				),
+			},
+		},
+		"sets/merging/ignore_duplicate": {
+			Ops: []Operation{
+				Update{
+					Manager: "updater",
+					Object: `
+						set: [1, 1, 3, 4]
+					`,
+					APIVersion: "v1",
+				},
+				Apply{
+					Manager: "applier",
+					Object: `
+						set: [5]
+					`,
+					APIVersion: "v1",
+				},
+			},
+			Object: `
+				set: [1, 1, 3, 4, 5]
+			`,
+			APIVersion: "v1",
+			Managed: fieldpath.ManagedFields{
+				"updater": fieldpath.NewVersionedSet(
+					_NS(
+						_P("set", _V(1)),
+						_P("set", _V(3)),
+						_P("set", _V(4)),
+					),
+					"v1",
+					false,
+				),
+				"applier": fieldpath.NewVersionedSet(
+					_NS(
+						_P("set", _V(5)),
+					),
+					"v1",
+					true,
+				),
+			},
+		},
+		"list/ownership/duplicated_items": {
+			Ops: []Operation{
+				Update{
+					Manager: "updater",
+					Object: `
+						list:
+						- name: a
+						  value1: 1
+						- name: a
+						  value1: 2
+						- name: b
+						  value1: 3
+					`,
+					APIVersion: "v1",
+				},
+			},
+			// `name: a` is only owned once.
+			Managed: fieldpath.ManagedFields{
+				"updater": fieldpath.NewVersionedSet(
+					_NS(
+						_P("list", _KBF("name", "a")),
+						_P("list", _KBF("name", "a"), "name"),
+						_P("list", _KBF("name", "a"), "value1"),
+						_P("list", _KBF("name", "b")),
+						_P("list", _KBF("name", "b"), "name"),
+						_P("list", _KBF("name", "b"), "value1"),
+					),
+					"v1",
+					false,
+				),
+			},
+		},
+		"list/ownership/change_duplicated_items": {
+			Ops: []Operation{
+				Update{
+					Manager: "updater-one",
+					Object: `
+						list:
+						- name: a
+						  value1: 1
+						- name: a
+						  value1: 2
+						- name: b
+						  value1: 3
+					`,
+					APIVersion: "v1",
+				},
+				Update{
+					Manager: "updater-two",
+					Object: `
+						list:
+						- name: a
+						  value1: 1
+						- name: a
+						  value1: 3
+						- name: b
+						  value1: 3
+					`,
+					APIVersion: "v1",
+				},
+			},
+			// `name: a` is only owned once, by actor who changed some of it.
+			Managed: fieldpath.ManagedFields{
+				"updater-one": fieldpath.NewVersionedSet(
+					_NS(
+						_P("list", _KBF("name", "b")),
+						_P("list", _KBF("name", "b"), "name"),
+						_P("list", _KBF("name", "b"), "value1"),
+					),
+					"v1",
+					false,
+				),
+				"updater-two": fieldpath.NewVersionedSet(
+					_NS(
+						_P("list", _KBF("name", "a")),
+						_P("list", _KBF("name", "a"), "name"),
+						_P("list", _KBF("name", "a"), "value1"),
+					),
+					"v1",
+					false,
+				),
+			},
+		},
+		"list/ownership/change_fields_duplicated_items": {
+			Ops: []Operation{
+				Update{
+					Manager: "updater-one",
+					Object: `
+						list:
+						- name: a
+						  value1: 1
+						- name: a
+						  value1: 2
+						- name: b
+						  value1: 3
+					`,
+					APIVersion: "v1",
+				},
+				Update{
+					Manager: "updater-two",
+					Object: `
+						list:
+						- name: a
+						  value1: 1
+						- name: a
+						  value1: 2
+						  value2: 3 # New field
+						- name: b
+						  value1: 3
+					`,
+					APIVersion: "v1",
+				},
+			},
+			Managed: fieldpath.ManagedFields{
+				"updater-one": fieldpath.NewVersionedSet(
+					_NS(
+						_P("list", _KBF("name", "a")),
+						_P("list", _KBF("name", "a"), "name"),
+						_P("list", _KBF("name", "a"), "value1"),
+						_P("list", _KBF("name", "b")),
+						_P("list", _KBF("name", "b"), "name"),
+						_P("list", _KBF("name", "b"), "value1"),
+					),
+					"v1",
+					false,
+				),
+				"updater-two": fieldpath.NewVersionedSet(
+					_NS(
+						_P("list", _KBF("name", "a"), "value2"),
+					),
+					"v1",
+					false,
+				),
+			},
+		},
+		"list/ownership/add_duplicated_items_different_field": {
+			Ops: []Operation{
+				Update{
+					Manager: "updater-one",
+					Object: `
+						list:
+						- name: a
+						  value1: 1
+						- name: b
+						  value1: 3
+					`,
+					APIVersion: "v1",
+				},
+				Update{
+					Manager: "updater-two",
+					Object: `
+						list:
+						- name: a
+						  value1: 1
+						- name: a
+						  value2: 3 # New field
+						- name: b
+						  value1: 3
+					`,
+					APIVersion: "v1",
+				},
+			},
+			Managed: fieldpath.ManagedFields{
+				"updater-one": fieldpath.NewVersionedSet(
+					_NS(
+						_P("list", _KBF("name", "a"), "value1"),
+						_P("list", _KBF("name", "b")),
+						_P("list", _KBF("name", "b"), "name"),
+						_P("list", _KBF("name", "b"), "value1"),
+					),
+					"v1",
+					false,
+				),
+				"updater-two": fieldpath.NewVersionedSet(
+					_NS(
+						_P("list", _KBF("name", "a")),
+						_P("list", _KBF("name", "a"), "name"),
+						_P("list", _KBF("name", "a"), "value2"),
+					),
+					"v1",
+					false,
+				),
+			},
+		},
+		"list/merge/unrelated_with_duplicated_items": {
+			Ops: []Operation{
+				Update{
+					Manager: "updater",
+					Object: `
+						list:
+						- name: a
+						  value1: 1
+						- name: a
+						  value1: 2
+						- name: b
+						  value1: 3
+					`,
+					APIVersion: "v1",
+				},
+				Apply{
+					Manager: "applier",
+					Object: `
+						unrelated: 5
+					`,
+					APIVersion: "v1",
+				},
+			},
+			Object: `
+				list:
+				- name: a
+				  value1: 1
+				- name: a
+				  value1: 2
+				- name: b
+				  value1: 3
+				unrelated: 5
+			`,
+			APIVersion: "v1",
+			Managed: fieldpath.ManagedFields{
+				"updater": fieldpath.NewVersionedSet(
+					_NS(
+						_P("list", _KBF("name", "a")),
+						_P("list", _KBF("name", "a"), "name"),
+						_P("list", _KBF("name", "a"), "value1"),
+						_P("list", _KBF("name", "b")),
+						_P("list", _KBF("name", "b"), "name"),
+						_P("list", _KBF("name", "b"), "value1"),
+					),
+					"v1",
+					false,
+				),
+				"applier": fieldpath.NewVersionedSet(
+					_NS(
+						_P("unrelated"),
+					),
+					"v1",
+					true,
+				),
+			},
+		},
+		"list/merge/change_duplicated_item": {
+			Ops: []Operation{
+				Update{
+					Manager: "updater",
+					Object: `
+						list:
+						- name: a
+						  value1: 1
+						- name: a
+						  value1: 2
+						- name: b
+						  value1: 3
+					`,
+					APIVersion: "v1",
+				},
+				Apply{
+					Manager: "applier",
+					Object: `
+						list:
+						- name: a
+						  value1: 3
+					`,
+					APIVersion: "v1",
+					Conflicts: merge.Conflicts{
+						// TODO: I think that's the right way of doing it but not totally sure.
+						{Manager: "updater", Path: _P("list", _KBF("name", "a"))},
+						{Manager: "updater", Path: _P("list", _KBF("name", "a"), "name")},
+						{Manager: "updater", Path: _P("list", _KBF("name", "a"), "value1")},
+					},
+				},
+				ForceApply{
+					Manager: "applier",
+					Object: `
+						list:
+						- name: a
+						  value1: 3
+					`,
+					APIVersion: "v1",
+				},
+			},
+			Object: `
+				list:
+				- name: a
+				  value1: 3
+				- name: b
+				  value1: 3
+			`,
+			APIVersion: "v1",
+			Managed: fieldpath.ManagedFields{
+				"updater": fieldpath.NewVersionedSet(
+					_NS(
+						_P("list", _KBF("name", "b")),
+						_P("list", _KBF("name", "b"), "name"),
+						_P("list", _KBF("name", "b"), "value1"),
+					),
+					"v1",
+					false,
+				),
+				"applier": fieldpath.NewVersionedSet(
+					_NS(
+						_P("list", _KBF("name", "a")),
+						_P("list", _KBF("name", "a"), "name"),
+						_P("list", _KBF("name", "a"), "value1"),
+					),
+					"v1",
+					true,
+				),
+			},
+		},
+		"list/merge/unchanged_duplicated_item": {
+			Ops: []Operation{
+				Update{
+					Manager: "updater",
+					Object: `
+						list:
+						- name: a
+						  value1: 1
+						- name: a
+						  value1: 2
+						- name: b
+						  value1: 3
+					`,
+					APIVersion: "v1",
+				},
+				Apply{
+					Manager: "applier",
+					// TODO: Should it be different if we had applied the other value?
+					Object: `
+						list:
+						- name: a
+						  value1: 2
+					`,
+					APIVersion: "v1",
+					Conflicts: merge.Conflicts{
+						// TODO: I think that's the right way of doing it but not totally sure.
+						{Manager: "updater", Path: _P("list", _KBF("name", "a"))},
+						{Manager: "updater", Path: _P("list", _KBF("name", "a"), "name")},
+						{Manager: "updater", Path: _P("list", _KBF("name", "a"), "value1")},
+					},
+				},
+				ForceApply{
+					Manager: "applier",
+					Object: `
+						list:
+						- name: a
+						  value1: 3
+					`,
+					APIVersion: "v1",
+				},
+			},
+			Object: `
+				list:
+				- name: a
+				  value1: 3
+				- name: b
+				  value1: 3
+			`,
+			APIVersion: "v1",
+			Managed: fieldpath.ManagedFields{
+				"updater": fieldpath.NewVersionedSet(
+					_NS(
+						_P("list", _KBF("name", "b")),
+						_P("list", _KBF("name", "b"), "name"),
+						_P("list", _KBF("name", "b"), "value1"),
+					),
+					"v1",
+					false,
+				),
+				"applier": fieldpath.NewVersionedSet(
+					_NS(
+						_P("list", _KBF("name", "a")),
+						_P("list", _KBF("name", "a"), "name"),
+						_P("list", _KBF("name", "a"), "value1"),
+					),
+					"v1",
+					true,
+				),
+			},
+		},
+		"list/merge/change_non_duplicated_item": {
+			Ops: []Operation{
+				Update{
+					Manager: "updater",
+					Object: `
+						list:
+						- name: a
+						  value1: 1
+						- name: a
+						  value1: 2
+						- name: b
+						  value1: 3
+					`,
+					APIVersion: "v1",
+				},
+				Apply{
+					Manager: "applier",
+					Object: `
+						list:
+						- name: b
+						  value1: 4
+					`,
+					APIVersion: "v1",
+				},
+			},
+			Object: `
+				list:
+				- name: a
+				  value1: 1
+				- name: a
+				  value1: 2
+				- name: b
+				  value1: 4
+			`,
+			APIVersion: "v1",
+			Managed: fieldpath.ManagedFields{
+				"updater": fieldpath.NewVersionedSet(
+					_NS(
+						_P("list", _KBF("name", "a")),
+						_P("list", _KBF("name", "a"), "name"),
+						_P("list", _KBF("name", "a"), "value1"),
+					),
+					"v1",
+					false,
+				),
+				"applier": fieldpath.NewVersionedSet(
+					_NS(
+						_P("list", _KBF("name", "b")),
+						_P("list", _KBF("name", "b"), "name"),
+						_P("list", _KBF("name", "b"), "value1"),
+					),
+					"v1",
+					true,
+				),
+			},
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			if err := test.Test(duplicatesParser); err != nil {
+				t.Fatal(err)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Tried to capture some of the discussions we've had in the form of unit-tests to make sure we properly capture the behavior we want. Let me know if there are use-cases that I'm missing.

I have basically found three cases:
1. Merging with an object that has a list with duplicates, but the change is unrelated to the list
2. Merging with an object that has a list with duplicates, the change modifies the list, but not a duplicated item
3. Merging with an object that has a list with duplicates, the change modifies a duplicated item

I think unarguable the first two should apply the change without de-dupping, since that's very clear that's what people would expect (their intent is not about the items they haven't specified). The last one is a little more controversial, but since i don't think we're going to allow them to apply duplicates, I think removing all the duplicates with the applied value is the "saner" option. Happy to have a discussion about it.

cc @alexzielenski @thockin 