### PR TITLE
Split merge and compare

### DIFF
--- a/typed/compare.go
+++ b/typed/compare.go
@@ -1,0 +1,401 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package typed
+
+import (
+	"sigs.k8s.io/structured-merge-diff/v4/fieldpath"
+	"sigs.k8s.io/structured-merge-diff/v4/schema"
+	"sigs.k8s.io/structured-merge-diff/v4/value"
+)
+
+type compareWalker struct {
+	lhs     value.Value
+	rhs     value.Value
+	schema  *schema.Schema
+	typeRef schema.TypeRef
+
+	// Current path that we are comparing
+	path fieldpath.Path
+
+	// How to compare. Called after schema validation for all leaf fields.
+	rule compareRule
+
+	// If set, called after non-leaf items have been compared. (`out` is
+	// probably already set.)
+	postItemHook compareRule
+
+	// output of the merge operation (nil if none)
+	out *interface{}
+
+	// internal housekeeping--don't set when constructing.
+	inLeaf bool // Set to true if we're in a "big leaf"--atomic map/list
+
+	// Allocate only as many walkers as needed for the depth by storing them here.
+	spareWalkers *[]*compareWalker
+
+	allocator value.Allocator
+}
+
+// compareRule examine w.lhs and w.rhs (up to one of which may be nil) and
+// optionally set w.out. If lhs and rhs are both set, they will be of
+// comparable type.
+type compareRule func(w *compareWalker)
+
+// compare compares stuff.
+func (w *compareWalker) compare(prefixFn func() string) (errs ValidationErrors) {
+	if w.lhs == nil && w.rhs == nil {
+		// check this condidition here instead of everywhere below.
+		return errorf("at least one of lhs and rhs must be provided")
+	}
+	a, ok := w.schema.Resolve(w.typeRef)
+	if !ok {
+		return errorf("schema error: no type found matching: %v", *w.typeRef.NamedType)
+	}
+
+	alhs := deduceAtom(a, w.lhs)
+	arhs := deduceAtom(a, w.rhs)
+
+	// deduceAtom does not fix the type for nil values
+	// nil is a wildcard and will accept whatever form the other operand takes
+	if w.rhs == nil {
+		errs = append(errs, handleAtom(alhs, w.typeRef, w)...)
+	} else if w.lhs == nil || alhs.Equals(&arhs) {
+		errs = append(errs, handleAtom(arhs, w.typeRef, w)...)
+	} else {
+		w2 := *w
+		errs = append(errs, handleAtom(alhs, w.typeRef, &w2)...)
+		errs = append(errs, handleAtom(arhs, w.typeRef, w)...)
+	}
+
+	if !w.inLeaf && w.postItemHook != nil {
+		w.postItemHook(w)
+	}
+	return errs.WithLazyPrefix(prefixFn)
+}
+
+// doLeaf should be called on leaves before descending into children, if there
+// will be a descent. It modifies w.inLeaf.
+func (w *compareWalker) doLeaf() {
+	if w.inLeaf {
+		// We're in a "big leaf", an atomic map or list. Ignore
+		// subsequent leaves.
+		return
+	}
+	w.inLeaf = true
+
+	// We don't recurse into leaf fields for merging.
+	w.rule(w)
+}
+
+func (w *compareWalker) doScalar(t *schema.Scalar) ValidationErrors {
+	// Make sure at least one side is a valid scalar.
+	lerrs := validateScalar(t, w.lhs, "lhs: ")
+	rerrs := validateScalar(t, w.rhs, "rhs: ")
+	if len(lerrs) > 0 && len(rerrs) > 0 {
+		return append(lerrs, rerrs...)
+	}
+
+	// All scalars are leaf fields.
+	w.doLeaf()
+
+	return nil
+}
+
+func (w *compareWalker) prepareDescent(pe fieldpath.PathElement, tr schema.TypeRef) *compareWalker {
+	if w.spareWalkers == nil {
+		// first descent.
+		w.spareWalkers = &[]*compareWalker{}
+	}
+	var w2 *compareWalker
+	if n := len(*w.spareWalkers); n > 0 {
+		w2, *w.spareWalkers = (*w.spareWalkers)[n-1], (*w.spareWalkers)[:n-1]
+	} else {
+		w2 = &compareWalker{}
+	}
+	*w2 = *w
+	w2.typeRef = tr
+	w2.path = append(w2.path, pe)
+	w2.lhs = nil
+	w2.rhs = nil
+	w2.out = nil
+	return w2
+}
+
+func (w *compareWalker) finishDescent(w2 *compareWalker) {
+	// if the descent caused a realloc, ensure that we reuse the buffer
+	// for the next sibling.
+	w.path = w2.path[:len(w2.path)-1]
+	*w.spareWalkers = append(*w.spareWalkers, w2)
+}
+
+func (w *compareWalker) derefMap(prefix string, v value.Value) (value.Map, ValidationErrors) {
+	if v == nil {
+		return nil, nil
+	}
+	m, err := mapValue(w.allocator, v)
+	if err != nil {
+		return nil, errorf("%v: %v", prefix, err)
+	}
+	return m, nil
+}
+
+func (w *compareWalker) visitListItems(t *schema.List, lhs, rhs value.List) (errs ValidationErrors) {
+	rLen := 0
+	if rhs != nil {
+		rLen = rhs.Length()
+	}
+	lLen := 0
+	if lhs != nil {
+		lLen = lhs.Length()
+	}
+	outLen := lLen
+	if outLen < rLen {
+		outLen = rLen
+	}
+	out := make([]interface{}, 0, outLen)
+
+	rhsOrder, observedRHS, rhsErrs := w.indexListPathElements(t, rhs)
+	errs = append(errs, rhsErrs...)
+	lhsOrder, observedLHS, lhsErrs := w.indexListPathElements(t, lhs)
+	errs = append(errs, lhsErrs...)
+
+	sharedOrder := make([]*fieldpath.PathElement, 0, rLen)
+	for i := range rhsOrder {
+		pe := &rhsOrder[i]
+		if _, ok := observedLHS.Get(*pe); ok {
+			sharedOrder = append(sharedOrder, pe)
+		}
+	}
+
+	var nextShared *fieldpath.PathElement
+	if len(sharedOrder) > 0 {
+		nextShared = sharedOrder[0]
+		sharedOrder = sharedOrder[1:]
+	}
+
+	lLen, rLen = len(lhsOrder), len(rhsOrder)
+	for lI, rI := 0, 0; lI < lLen || rI < rLen; {
+		if lI < lLen && rI < rLen {
+			pe := lhsOrder[lI]
+			if pe.Equals(rhsOrder[rI]) {
+				// merge LHS & RHS items
+				lChild, _ := observedLHS.Get(pe)
+				rChild, _ := observedRHS.Get(pe)
+				mergeOut, errs := w.mergeListItem(t, pe, lChild, rChild)
+				errs = append(errs, errs...)
+				if mergeOut != nil {
+					out = append(out, *mergeOut)
+				}
+				lI++
+				rI++
+
+				nextShared = nil
+				if len(sharedOrder) > 0 {
+					nextShared = sharedOrder[0]
+					sharedOrder = sharedOrder[1:]
+				}
+				continue
+			}
+			if _, ok := observedRHS.Get(pe); ok && nextShared != nil && !nextShared.Equals(lhsOrder[lI]) {
+				// shared item, but not the one we want in this round
+				lI++
+				continue
+			}
+		}
+		if lI < lLen {
+			pe := lhsOrder[lI]
+			if _, ok := observedRHS.Get(pe); !ok {
+				// take LHS item
+				lChild, _ := observedLHS.Get(pe)
+				mergeOut, errs := w.mergeListItem(t, pe, lChild, nil)
+				errs = append(errs, errs...)
+				if mergeOut != nil {
+					out = append(out, *mergeOut)
+				}
+				lI++
+				continue
+			}
+		}
+		if rI < rLen {
+			// Take the RHS item, merge with matching LHS item if possible
+			pe := rhsOrder[rI]
+			lChild, _ := observedLHS.Get(pe) // may be nil
+			rChild, _ := observedRHS.Get(pe)
+			mergeOut, errs := w.mergeListItem(t, pe, lChild, rChild)
+			errs = append(errs, errs...)
+			if mergeOut != nil {
+				out = append(out, *mergeOut)
+			}
+			rI++
+			// Advance nextShared, if we are merging nextShared.
+			if nextShared != nil && nextShared.Equals(pe) {
+				nextShared = nil
+				if len(sharedOrder) > 0 {
+					nextShared = sharedOrder[0]
+					sharedOrder = sharedOrder[1:]
+				}
+			}
+		}
+	}
+
+	if len(out) > 0 {
+		i := interface{}(out)
+		w.out = &i
+	}
+
+	return errs
+}
+
+func (w *compareWalker) indexListPathElements(t *schema.List, list value.List) ([]fieldpath.PathElement, fieldpath.PathElementValueMap, ValidationErrors) {
+	var errs ValidationErrors
+	length := 0
+	if list != nil {
+		length = list.Length()
+	}
+	observed := fieldpath.MakePathElementValueMap(length)
+	pes := make([]fieldpath.PathElement, 0, length)
+	for i := 0; i < length; i++ {
+		child := list.At(i)
+		pe, err := listItemToPathElement(w.allocator, w.schema, t, i, child)
+		if err != nil {
+			errs = append(errs, errorf("element %v: %v", i, err.Error())...)
+			// If we can't construct the path element, we can't
+			// even report errors deeper in the schema, so bail on
+			// this element.
+			continue
+		}
+		// Ignore repeated occurences of `pe`.
+		if _, found := observed.Get(pe); found {
+			continue
+		}
+		observed.Insert(pe, child)
+		pes = append(pes, pe)
+	}
+	return pes, observed, errs
+}
+
+func (w *compareWalker) mergeListItem(t *schema.List, pe fieldpath.PathElement, lChild, rChild value.Value) (out *interface{}, errs ValidationErrors) {
+	w2 := w.prepareDescent(pe, t.ElementType)
+	w2.lhs = lChild
+	w2.rhs = rChild
+	errs = append(errs, w2.compare(pe.String)...)
+	if w2.out != nil {
+		out = w2.out
+	}
+	w.finishDescent(w2)
+	return
+}
+
+func (w *compareWalker) derefList(prefix string, v value.Value) (value.List, ValidationErrors) {
+	if v == nil {
+		return nil, nil
+	}
+	l, err := listValue(w.allocator, v)
+	if err != nil {
+		return nil, errorf("%v: %v", prefix, err)
+	}
+	return l, nil
+}
+
+func (w *compareWalker) doList(t *schema.List) (errs ValidationErrors) {
+	lhs, _ := w.derefList("lhs: ", w.lhs)
+	if lhs != nil {
+		defer w.allocator.Free(lhs)
+	}
+	rhs, _ := w.derefList("rhs: ", w.rhs)
+	if rhs != nil {
+		defer w.allocator.Free(rhs)
+	}
+
+	// If both lhs and rhs are empty/null, treat it as a
+	// leaf: this helps preserve the empty/null
+	// distinction.
+	emptyPromoteToLeaf := (lhs == nil || lhs.Length() == 0) && (rhs == nil || rhs.Length() == 0)
+
+	if t.ElementRelationship == schema.Atomic || emptyPromoteToLeaf {
+		w.doLeaf()
+		return nil
+	}
+
+	if lhs == nil && rhs == nil {
+		return nil
+	}
+
+	errs = w.visitListItems(t, lhs, rhs)
+
+	return errs
+}
+
+func (w *compareWalker) visitMapItem(t *schema.Map, out map[string]interface{}, key string, lhs, rhs value.Value) (errs ValidationErrors) {
+	fieldType := t.ElementType
+	if sf, ok := t.FindField(key); ok {
+		fieldType = sf.Type
+	}
+	pe := fieldpath.PathElement{FieldName: &key}
+	w2 := w.prepareDescent(pe, fieldType)
+	w2.lhs = lhs
+	w2.rhs = rhs
+	errs = append(errs, w2.compare(pe.String)...)
+	if w2.out != nil {
+		out[key] = *w2.out
+	}
+	w.finishDescent(w2)
+	return errs
+}
+
+func (w *compareWalker) visitMapItems(t *schema.Map, lhs, rhs value.Map) (errs ValidationErrors) {
+	out := map[string]interface{}{}
+
+	value.MapZipUsing(w.allocator, lhs, rhs, value.Unordered, func(key string, lhsValue, rhsValue value.Value) bool {
+		errs = append(errs, w.visitMapItem(t, out, key, lhsValue, rhsValue)...)
+		return true
+	})
+	if len(out) > 0 {
+		i := interface{}(out)
+		w.out = &i
+	}
+
+	return errs
+}
+
+func (w *compareWalker) doMap(t *schema.Map) (errs ValidationErrors) {
+	lhs, _ := w.derefMap("lhs: ", w.lhs)
+	if lhs != nil {
+		defer w.allocator.Free(lhs)
+	}
+	rhs, _ := w.derefMap("rhs: ", w.rhs)
+	if rhs != nil {
+		defer w.allocator.Free(rhs)
+	}
+	// If both lhs and rhs are empty/null, treat it as a
+	// leaf: this helps preserve the empty/null
+	// distinction.
+	emptyPromoteToLeaf := (lhs == nil || lhs.Empty()) && (rhs == nil || rhs.Empty())
+
+	if t.ElementRelationship == schema.Atomic || emptyPromoteToLeaf {
+		w.doLeaf()
+		return nil
+	}
+
+	if lhs == nil && rhs == nil {
+		return nil
+	}
+
+	errs = append(errs, w.visitMapItems(t, lhs, rhs)...)
+
+	return errs
+}


### PR DESCRIPTION
This is NOT an incompatible change. It doesn't change the behavior, doesn't change the API and should be safe to backport (and I'm planning on backporting this).

This is actually one of the first step to change the comparison function in order to solve the leniency problem.
/assign @jpbetz @alexzielenski 
/cc @thockin 

Performance improvements can be pretty noticeable for specific benchmarks (up to -50% in CPU).
```
name                                                    old time/op    new time/op    delta
pkg:sigs.k8s.io/structured-merge-diff/v4/merge goos:darwin goarch:amd64
DeducedSimple-8                                           65.6µs ±10%    59.0µs ± 0%   -9.98%  (p=0.016 n=5+4)
DeducedNested-8                                            135µs ± 6%     124µs ± 1%   -8.26%  (p=0.008 n=5+5)
DeducedNestedAcrossVersion-8                               181µs ± 0%     169µs ± 1%   -6.53%  (p=0.016 n=4+5)
LeafConflictAcrossVersion-8                                130µs ±29%      81µs ± 0%  -37.92%  (p=0.016 n=5+4)
MultipleApplierRecursiveRealConversion-8                  1.75ms ±37%    1.20ms ± 3%  -31.22%  (p=0.032 n=5+5)
Operations/Pod/Create-8                                   70.0µs ± 1%    68.4µs ± 3%     ~     (p=0.095 n=5+5)
Operations/Pod/Apply-8                                     179µs ± 3%     179µs ± 2%     ~     (p=0.841 n=5+5)
Operations/Pod/ApplyTwice-8                                443µs ± 1%     438µs ± 3%     ~     (p=0.310 n=5+5)
Operations/Pod/ApplyTwiceNoCompare-8                       417µs ± 3%     416µs ± 3%     ~     (p=0.841 n=5+5)
Operations/Pod/Update-8                                    174µs ± 3%     164µs ± 2%   -5.59%  (p=0.008 n=5+5)
Operations/Pod/UpdateVersion-8                             244µs ± 1%     237µs ± 2%   -2.91%  (p=0.008 n=5+5)
Operations/Node/Create-8                                   111µs ± 6%     101µs ± 2%   -9.46%  (p=0.008 n=5+5)
Operations/Node/Apply-8                                    290µs ±12%     267µs ± 2%     ~     (p=0.095 n=5+5)
Operations/Node/ApplyTwice-8                               751µs ± 3%     661µs ± 0%  -11.96%  (p=0.016 n=5+4)
Operations/Node/ApplyTwiceNoCompare-8                      667µs ± 3%     623µs ± 5%   -6.57%  (p=0.008 n=5+5)
Operations/Node/Update-8                                   281µs ± 1%     255µs ± 2%   -9.23%  (p=0.008 n=5+5)
Operations/Node/UpdateVersion-8                            418µs ± 2%     374µs ± 3%  -10.63%  (p=0.008 n=5+5)
Operations/Endpoints/Create-8                             8.02µs ± 5%    6.88µs ± 1%  -14.15%  (p=0.008 n=5+5)
Operations/Endpoints/Apply-8                              17.2µs ± 2%    16.7µs ±16%     ~     (p=0.151 n=5+5)
Operations/Endpoints/ApplyTwice-8                         2.08ms ± 2%    1.78ms ± 2%  -14.43%  (p=0.008 n=5+5)
Operations/Endpoints/ApplyTwiceNoCompare-8                1.08ms ± 7%    1.04ms ±12%     ~     (p=0.548 n=5+5)
Operations/Endpoints/Update-8                             1.07ms ±13%    1.02ms ±12%     ~     (p=0.310 n=5+5)
Operations/Endpoints/UpdateVersion-8                      1.89ms ± 2%    1.92ms ±13%     ~     (p=0.841 n=5+5)
Operations/Node100%override/Create-8                       117µs ± 3%     103µs ± 3%  -11.84%  (p=0.008 n=5+5)
Operations/Node100%override/Apply-8                        299µs ± 4%     263µs ± 2%  -12.05%  (p=0.008 n=5+5)
Operations/Node100%override/ApplyTwice-8                   768µs ±10%     656µs ± 1%  -14.52%  (p=0.008 n=5+5)
Operations/Node100%override/ApplyTwiceNoCompare-8          746µs ±10%     620µs ± 3%  -16.88%  (p=0.008 n=5+5)
Operations/Node100%override/Update-8                       532µs ±21%     254µs ± 2%  -52.26%  (p=0.008 n=5+5)
Operations/Node100%override/UpdateVersion-8                527µs ± 9%     372µs ± 4%  -29.41%  (p=0.008 n=5+5)
Operations/Node10%override/Create-8                        125µs ±17%     103µs ±10%  -17.99%  (p=0.008 n=5+5)
Operations/Node10%override/Apply-8                         387µs ± 7%     264µs ± 1%  -31.65%  (p=0.016 n=5+4)
Operations/Node10%override/ApplyTwice-8                   1.05ms ±16%    0.66ms ± 1%  -37.68%  (p=0.008 n=5+5)
Operations/Node10%override/ApplyTwiceNoCompare-8           896µs ±12%     624µs ± 1%  -30.39%  (p=0.016 n=5+4)
Operations/Node10%override/Update-8                        340µs ±16%     255µs ± 2%  -25.07%  (p=0.008 n=5+5)
Operations/Node10%override/UpdateVersion-8                 422µs ± 2%     369µs ± 2%  -12.55%  (p=0.008 n=5+5)
Operations/Endpoints100%override/Create-8                 8.08µs ± 6%    6.92µs ± 3%  -14.29%  (p=0.008 n=5+5)
Operations/Endpoints100%override/Apply-8                  20.9µs ±28%    15.8µs ± 2%  -24.51%  (p=0.008 n=5+5)
Operations/Endpoints100%override/ApplyTwice-8             3.21ms ±27%    1.78ms ± 2%  -44.52%  (p=0.008 n=5+5)
Operations/Endpoints100%override/ApplyTwiceNoCompare-8    1.51ms ±28%    0.90ms ± 4%  -40.22%  (p=0.008 n=5+5)
Operations/Endpoints100%override/Update-8                 1.34ms ±17%    0.90ms ± 3%  -33.01%  (p=0.008 n=5+5)
Operations/Endpoints100%override/UpdateVersion-8          2.08ms ± 4%    1.76ms ± 5%  -15.61%  (p=0.008 n=5+5)
Operations/Endpoints10%override/Create-8                  8.57µs ±20%    6.91µs ± 4%  -19.30%  (p=0.008 n=5+5)
Operations/Endpoints10%override/Apply-8                   20.4µs ± 4%    15.6µs ± 3%  -23.34%  (p=0.008 n=5+5)
Operations/Endpoints10%override/ApplyTwice-8              2.35ms ± 3%    1.77ms ± 3%  -24.79%  (p=0.008 n=5+5)
Operations/Endpoints10%override/ApplyTwiceNoCompare-8     1.26ms ± 3%    0.92ms ± 2%  -27.14%  (p=0.008 n=5+5)
Operations/Endpoints10%override/Update-8                  1.25ms ± 5%    0.89ms ± 4%  -28.74%  (p=0.008 n=5+5)
Operations/Endpoints10%override/UpdateVersion-8           2.43ms ±12%    1.76ms ± 3%  -27.43%  (p=0.008 n=5+5)
Operations/PrometheusCRD/Create-8                          762µs ±11%     583µs ± 1%  -23.48%  (p=0.008 n=5+5)
Operations/PrometheusCRD/Apply-8                          2.96ms ±69%    1.46ms ± 3%  -50.62%  (p=0.008 n=5+5)
Operations/PrometheusCRD/ApplyTwice-8                     4.90ms ±12%    3.83ms ± 4%  -21.89%  (p=0.008 n=5+5)
Operations/PrometheusCRD/ApplyTwiceNoCompare-8            4.58ms ± 4%    3.48ms ± 3%  -24.13%  (p=0.008 n=5+5)
Operations/PrometheusCRD/Update-8                         1.82ms ± 7%    1.44ms ± 4%  -20.85%  (p=0.008 n=5+5)
Operations/PrometheusCRD/UpdateVersion-8                  2.99ms ±15%    2.16ms ± 2%  -27.77%  (p=0.008 n=5+5)
Operations/apiresourceimport/Create-8                     3.40ms ± 7%    2.80ms ± 3%  -17.72%  (p=0.008 n=5+5)
Operations/apiresourceimport/Apply-8                      9.55ms ±10%    7.59ms ± 4%  -20.53%  (p=0.008 n=5+5)
Operations/apiresourceimport/ApplyTwice-8                 19.8ms ±14%    15.4ms ± 1%  -22.45%  (p=0.008 n=5+5)
Operations/apiresourceimport/ApplyTwiceNoCompare-8        20.4ms ± 8%    14.8ms ± 3%  -27.72%  (p=0.008 n=5+5)
Operations/apiresourceimport/Update-8                     6.28ms ± 6%    4.60ms ± 3%  -26.68%  (p=0.008 n=5+5)
Operations/apiresourceimport/UpdateVersion-8              8.60ms ± 1%    6.35ms ± 3%  -26.19%  (p=0.016 n=4+5)
pkg:sigs.k8s.io/structured-merge-diff/v4/typed goos:darwin goarch:amd64
ConvertUnstructured/Pod/From-8                            30.8µs ± 3%    26.3µs ± 1%  -14.80%  (p=0.008 n=5+5)
ConvertUnstructured/Pod/To-8                              0.00ns ± 0%    0.00ns ± 0%     ~     (all equal)
ConvertUnstructured/Node/From-8                           66.3µs ± 1%    59.0µs ± 4%  -10.93%  (p=0.016 n=4+5)
ConvertUnstructured/Node/To-8                             0.00ns ± 0%    0.00ns ±38%     ~     (p=0.333 n=4+5)
ConvertUnstructured/Endpoints/From-8                      1.42ms ± 8%    1.20ms ±12%  -15.60%  (p=0.016 n=5+5)
ConvertUnstructured/Endpoints/To-8                        0.00ns ±50%    0.00ns ±43%     ~     (p=0.365 n=5+5)
ConvertUnstructured/CustomResourceDefinition/From-8        457µs ± 8%     388µs ± 1%  -15.08%  (p=0.008 n=5+5)
ConvertUnstructured/CustomResourceDefinition/To-8         0.00ns ±43%    0.00ns ± 0%     ~     (p=0.444 n=5+5)
ValidateStructured/struct-8                               16.6µs ± 3%    14.3µs ± 2%  -13.93%  (p=0.008 n=5+5)

name                                                    old alloc/op   new alloc/op   delta
pkg:sigs.k8s.io/structured-merge-diff/v4/merge goos:darwin goarch:amd64
DeducedSimple-8                                           30.4kB ± 0%    28.8kB ± 0%   -5.31%  (p=0.008 n=5+5)
DeducedNested-8                                           59.4kB ± 0%    57.1kB ± 0%   -3.85%  (p=0.008 n=5+5)
DeducedNestedAcrossVersion-8                              79.4kB ± 0%    75.1kB ± 0%   -5.34%  (p=0.008 n=5+5)
LeafConflictAcrossVersion-8                               43.0kB ± 0%    40.2kB ± 0%   -6.54%  (p=0.008 n=5+5)
MultipleApplierRecursiveRealConversion-8                   716kB ± 0%     713kB ± 0%   -0.35%  (p=0.008 n=5+5)
Operations/Pod/Create-8                                   21.3kB ± 0%    20.3kB ± 0%   -4.81%  (p=0.008 n=5+5)
Operations/Pod/Apply-8                                    53.1kB ± 0%    52.2kB ± 0%   -1.74%  (p=0.008 n=5+5)
Operations/Pod/ApplyTwice-8                                110kB ± 0%     109kB ± 0%   -1.50%  (p=0.008 n=5+5)
Operations/Pod/ApplyTwiceNoCompare-8                       107kB ± 0%     105kB ± 0%   -1.58%  (p=0.008 n=5+5)
Operations/Pod/Update-8                                   40.0kB ± 0%    38.2kB ± 0%   -4.66%  (p=0.008 n=5+5)
Operations/Pod/UpdateVersion-8                            52.7kB ± 0%    50.0kB ± 0%   -5.13%  (p=0.008 n=5+5)
Operations/Node/Create-8                                  30.2kB ± 0%    28.9kB ± 0%   -4.35%  (p=0.000 n=5+4)
Operations/Node/Apply-8                                   74.1kB ± 0%    72.9kB ± 0%   -1.66%  (p=0.008 n=5+5)
Operations/Node/ApplyTwice-8                               155kB ± 0%     153kB ± 0%   -1.21%  (p=0.008 n=5+5)
Operations/Node/ApplyTwiceNoCompare-8                      149kB ± 0%     147kB ± 0%   -1.27%  (p=0.008 n=5+5)
Operations/Node/Update-8                                  57.4kB ± 0%    55.3kB ± 0%   -3.58%  (p=0.008 n=5+5)
Operations/Node/UpdateVersion-8                           75.9kB ± 0%    73.1kB ± 0%   -3.67%  (p=0.008 n=5+5)
Operations/Endpoints/Create-8                             3.84kB ± 0%    3.44kB ± 0%  -10.64%  (p=0.008 n=5+5)
Operations/Endpoints/Apply-8                              6.99kB ± 0%    6.58kB ± 0%   -5.77%  (p=0.008 n=5+5)
Operations/Endpoints/ApplyTwice-8                          208kB ± 0%     207kB ± 0%   -0.70%  (p=0.008 n=5+5)
Operations/Endpoints/ApplyTwiceNoCompare-8                 110kB ± 0%     109kB ± 0%   -1.36%  (p=0.008 n=5+5)
Operations/Endpoints/Update-8                              104kB ± 0%     103kB ± 0%   -1.46%  (p=0.008 n=5+5)
Operations/Endpoints/UpdateVersion-8                       202kB ± 0%     200kB ± 0%   -1.30%  (p=0.008 n=5+5)
Operations/Node100%override/Create-8                      30.2kB ± 0%    28.9kB ± 0%   -4.35%  (p=0.016 n=5+4)
Operations/Node100%override/Apply-8                       74.1kB ± 0%    72.9kB ± 0%   -1.66%  (p=0.008 n=5+5)
Operations/Node100%override/ApplyTwice-8                   155kB ± 0%     153kB ± 0%   -1.23%  (p=0.008 n=5+5)
Operations/Node100%override/ApplyTwiceNoCompare-8          149kB ± 0%     147kB ± 0%   -1.28%  (p=0.008 n=5+5)
Operations/Node100%override/Update-8                      57.4kB ± 0%    55.3kB ± 0%   -3.57%  (p=0.008 n=5+5)
Operations/Node100%override/UpdateVersion-8               75.9kB ± 0%    73.1kB ± 0%   -3.68%  (p=0.008 n=5+5)
Operations/Node10%override/Create-8                       30.2kB ± 0%    28.9kB ± 0%   -4.35%  (p=0.008 n=5+5)
Operations/Node10%override/Apply-8                        74.1kB ± 0%    72.9kB ± 0%   -1.65%  (p=0.008 n=5+5)
Operations/Node10%override/ApplyTwice-8                    155kB ± 0%     153kB ± 0%   -1.20%  (p=0.008 n=5+5)
Operations/Node10%override/ApplyTwiceNoCompare-8           149kB ± 0%     147kB ± 0%   -1.25%  (p=0.008 n=5+5)
Operations/Node10%override/Update-8                       57.4kB ± 0%    55.3kB ± 0%   -3.57%  (p=0.008 n=5+5)
Operations/Node10%override/UpdateVersion-8                75.9kB ± 0%    73.1kB ± 0%   -3.68%  (p=0.008 n=5+5)
Operations/Endpoints100%override/Create-8                 3.84kB ± 0%    3.44kB ± 0%  -10.64%  (p=0.008 n=5+5)
Operations/Endpoints100%override/Apply-8                  6.99kB ± 0%    6.58kB ± 0%   -5.77%  (p=0.008 n=5+5)
Operations/Endpoints100%override/ApplyTwice-8              208kB ± 0%     207kB ± 0%   -0.70%  (p=0.008 n=5+5)
Operations/Endpoints100%override/ApplyTwiceNoCompare-8     110kB ± 0%     109kB ± 0%   -1.36%  (p=0.008 n=5+5)
Operations/Endpoints100%override/Update-8                  104kB ± 0%     103kB ± 0%   -1.46%  (p=0.008 n=5+5)
Operations/Endpoints100%override/UpdateVersion-8           202kB ± 0%     200kB ± 0%   -1.30%  (p=0.008 n=5+5)
Operations/Endpoints10%override/Create-8                  3.84kB ± 0%    3.44kB ± 0%  -10.64%  (p=0.008 n=5+5)
Operations/Endpoints10%override/Apply-8                   6.99kB ± 0%    6.58kB ± 0%   -5.78%  (p=0.000 n=4+5)
Operations/Endpoints10%override/ApplyTwice-8               208kB ± 0%     207kB ± 0%   -0.71%  (p=0.008 n=5+5)
Operations/Endpoints10%override/ApplyTwiceNoCompare-8      110kB ± 0%     109kB ± 0%   -1.36%  (p=0.008 n=5+5)
Operations/Endpoints10%override/Update-8                   104kB ± 0%     103kB ± 0%   -1.46%  (p=0.008 n=5+5)
Operations/Endpoints10%override/UpdateVersion-8            202kB ± 0%     200kB ± 0%   -1.30%  (p=0.008 n=5+5)
Operations/PrometheusCRD/Create-8                          165kB ± 0%     164kB ± 0%   -0.25%  (p=0.008 n=5+5)
Operations/PrometheusCRD/Apply-8                           471kB ± 0%     471kB ± 0%     ~     (p=0.222 n=5+5)
Operations/PrometheusCRD/ApplyTwice-8                      983kB ± 0%     981kB ± 0%   -0.17%  (p=0.008 n=5+5)
Operations/PrometheusCRD/ApplyTwiceNoCompare-8             935kB ± 0%     933kB ± 0%   -0.18%  (p=0.008 n=5+5)
Operations/PrometheusCRD/Update-8                          318kB ± 0%     315kB ± 0%   -0.74%  (p=0.008 n=5+5)
Operations/PrometheusCRD/UpdateVersion-8                   425kB ± 0%     420kB ± 0%   -1.02%  (p=0.008 n=5+5)
Operations/apiresourceimport/Create-8                      679kB ± 0%     679kB ± 0%   -0.07%  (p=0.008 n=5+5)
Operations/apiresourceimport/Apply-8                      1.94MB ± 0%    1.94MB ± 0%   +0.02%  (p=0.032 n=5+5)
Operations/apiresourceimport/ApplyTwice-8                 3.65MB ± 0%    3.65MB ± 0%     ~     (p=0.841 n=5+5)
Operations/apiresourceimport/ApplyTwiceNoCompare-8        3.56MB ± 0%    3.56MB ± 0%   +0.03%  (p=0.008 n=5+5)
Operations/apiresourceimport/Update-8                     1.02MB ± 0%    1.02MB ± 0%   -0.11%  (p=0.008 n=5+5)
Operations/apiresourceimport/UpdateVersion-8              1.35MB ± 0%    1.35MB ± 0%   -0.14%  (p=0.008 n=5+5)
pkg:sigs.k8s.io/structured-merge-diff/v4/typed goos:darwin goarch:amd64
ConvertUnstructured/Pod/From-8                            4.94kB ± 0%    4.94kB ± 0%     ~     (all equal)
ConvertUnstructured/Pod/To-8                               0.00B          0.00B          ~     (all equal)
ConvertUnstructured/Node/From-8                           13.9kB ± 0%    13.9kB ± 0%     ~     (p=1.000 n=5+4)
ConvertUnstructured/Node/To-8                              0.00B          0.00B          ~     (all equal)
ConvertUnstructured/Endpoints/From-8                       197kB ± 0%     197kB ± 0%     ~     (p=1.000 n=5+5)
ConvertUnstructured/Endpoints/To-8                         0.00B          0.00B          ~     (all equal)
ConvertUnstructured/CustomResourceDefinition/From-8       57.6kB ± 0%    57.6kB ± 0%     ~     (p=0.841 n=5+5)
ConvertUnstructured/CustomResourceDefinition/To-8          0.00B          0.00B          ~     (all equal)
ValidateStructured/struct-8                               2.74kB ± 0%    2.74kB ± 0%     ~     (all equal)

name                                                    old allocs/op  new allocs/op  delta
pkg:sigs.k8s.io/structured-merge-diff/v4/merge goos:darwin goarch:amd64
DeducedSimple-8                                              725 ± 0%       678 ± 0%   -6.48%  (p=0.008 n=5+5)
DeducedNested-8                                            1.36k ± 0%     1.29k ± 0%   -5.57%  (p=0.029 n=4+4)
DeducedNestedAcrossVersion-8                               1.86k ± 0%     1.72k ± 0%     ~     (p=0.079 n=4+5)
LeafConflictAcrossVersion-8                                  965 ± 0%       882 ± 0%   -8.60%  (p=0.008 n=5+5)
MultipleApplierRecursiveRealConversion-8                   7.62k ± 0%     7.53k ± 0%   -1.28%  (p=0.008 n=5+5)
Operations/Pod/Create-8                                      481 ± 0%       451 ± 0%   -6.24%  (p=0.008 n=5+5)
Operations/Pod/Apply-8                                     1.27k ± 0%     1.24k ± 0%   -2.29%  (p=0.008 n=5+5)
Operations/Pod/ApplyTwice-8                                2.72k ± 0%     2.70k ± 0%   -0.90%  (p=0.008 n=5+5)
Operations/Pod/ApplyTwiceNoCompare-8                       2.62k ± 0%     2.59k ± 0%   -0.95%  (p=0.000 n=5+4)
Operations/Pod/Update-8                                      976 ± 0%       949 ± 0%   -2.77%  (p=0.029 n=4+4)
Operations/Pod/UpdateVersion-8                             1.40k ± 0%     1.38k ± 0%   -1.75%  (p=0.000 n=4+5)
Operations/Node/Create-8                                     565 ± 0%       547 ± 0%   -3.19%  (p=0.008 n=5+5)
Operations/Node/Apply-8                                    1.58k ± 0%     1.56k ± 0%   -1.08%  (p=0.008 n=5+5)
Operations/Node/ApplyTwice-8                               3.56k ± 0%     3.59k ± 0%   +0.83%  (p=0.008 n=5+5)
Operations/Node/ApplyTwiceNoCompare-8                      3.37k ± 0%     3.40k ± 0%   +0.85%  (p=0.016 n=5+4)
Operations/Node/Update-8                                   1.26k ± 0%     1.29k ± 0%   +2.14%  (p=0.016 n=5+4)
Operations/Node/UpdateVersion-8                            1.87k ± 0%     1.94k ± 0%   +3.91%  (p=0.029 n=4+4)
Operations/Endpoints/Create-8                               84.0 ± 0%      72.0 ± 0%  -14.29%  (p=0.008 n=5+5)
Operations/Endpoints/Apply-8                                 164 ± 0%       152 ± 0%   -7.32%  (p=0.008 n=5+5)
Operations/Endpoints/ApplyTwice-8                          4.40k ± 0%     4.36k ± 0%   -1.01%  (p=0.000 n=5+4)
Operations/Endpoints/ApplyTwiceNoCompare-8                 2.35k ± 0%     2.30k ± 0%   -1.92%  (p=0.008 n=5+5)
Operations/Endpoints/Update-8                              2.20k ± 0%     2.15k ± 0%   -2.05%  (p=0.008 n=5+5)
Operations/Endpoints/UpdateVersion-8                       4.27k ± 0%     4.20k ± 0%   -1.83%  (p=0.008 n=5+5)
Operations/Node100%override/Create-8                         565 ± 0%       547 ± 0%   -3.19%  (p=0.008 n=5+5)
Operations/Node100%override/Apply-8                        1.58k ± 0%     1.56k ± 0%   -1.08%  (p=0.000 n=5+4)
Operations/Node100%override/ApplyTwice-8                   3.56k ± 0%     3.59k ± 0%   +0.80%  (p=0.008 n=5+5)
Operations/Node100%override/ApplyTwiceNoCompare-8          3.37k ± 0%     3.40k ± 0%   +0.86%  (p=0.008 n=5+5)
Operations/Node100%override/Update-8                       1.26k ± 0%     1.29k ± 0%   +2.14%  (p=0.008 n=5+5)
Operations/Node100%override/UpdateVersion-8                1.87k ± 0%     1.94k ± 0%   +3.85%  (p=0.016 n=5+4)
Operations/Node10%override/Create-8                          565 ± 0%       547 ± 0%   -3.19%  (p=0.008 n=5+5)
Operations/Node10%override/Apply-8                         1.58k ± 0%     1.56k ± 0%   -1.08%  (p=0.008 n=5+5)
Operations/Node10%override/ApplyTwice-8                    3.56k ± 0%     3.59k ± 0%   +0.82%  (p=0.029 n=4+4)
Operations/Node10%override/ApplyTwiceNoCompare-8           3.37k ± 0%     3.40k ± 0%   +0.89%  (p=0.016 n=5+4)
Operations/Node10%override/Update-8                        1.26k ± 0%     1.29k ± 0%   +2.14%  (p=0.008 n=5+5)
Operations/Node10%override/UpdateVersion-8                 1.87k ± 0%     1.94k ± 0%   +3.88%  (p=0.016 n=4+5)
Operations/Endpoints100%override/Create-8                   84.0 ± 0%      72.0 ± 0%  -14.29%  (p=0.008 n=5+5)
Operations/Endpoints100%override/Apply-8                     164 ± 0%       152 ± 0%   -7.32%  (p=0.008 n=5+5)
Operations/Endpoints100%override/ApplyTwice-8              4.40k ± 0%     4.36k ± 0%   -1.01%  (p=0.008 n=5+5)
Operations/Endpoints100%override/ApplyTwiceNoCompare-8     2.35k ± 0%     2.30k ± 0%   -1.92%  (p=0.008 n=5+5)
Operations/Endpoints100%override/Update-8                  2.20k ± 0%     2.15k ± 0%   -2.05%  (p=0.008 n=5+5)
Operations/Endpoints100%override/UpdateVersion-8           4.27k ± 0%     4.20k ± 0%   -1.83%  (p=0.008 n=5+5)
Operations/Endpoints10%override/Create-8                    84.0 ± 0%      72.0 ± 0%  -14.29%  (p=0.008 n=5+5)
Operations/Endpoints10%override/Apply-8                      164 ± 0%       152 ± 0%   -7.32%  (p=0.008 n=5+5)
Operations/Endpoints10%override/ApplyTwice-8               4.40k ± 0%     4.36k ± 0%   -1.01%  (p=0.000 n=5+4)
Operations/Endpoints10%override/ApplyTwiceNoCompare-8      2.35k ± 0%     2.30k ± 0%   -1.92%  (p=0.008 n=5+5)
Operations/Endpoints10%override/Update-8                   2.20k ± 0%     2.15k ± 0%   -2.05%  (p=0.008 n=5+5)
Operations/Endpoints10%override/UpdateVersion-8            4.27k ± 0%     4.20k ± 0%   -1.83%  (p=0.008 n=5+5)
Operations/PrometheusCRD/Create-8                          3.68k ± 0%     3.67k ± 0%   -0.33%  (p=0.008 n=5+5)
Operations/PrometheusCRD/Apply-8                           10.2k ± 0%     10.2k ± 0%   -0.08%  (p=0.008 n=5+5)
Operations/PrometheusCRD/ApplyTwice-8                      21.1k ± 0%     21.0k ± 0%   -0.26%  (p=0.008 n=5+5)
Operations/PrometheusCRD/ApplyTwiceNoCompare-8             20.0k ± 0%     19.9k ± 0%   -0.27%  (p=0.008 n=5+5)
Operations/PrometheusCRD/Update-8                          6.98k ± 0%     6.92k ± 0%   -0.85%  (p=0.008 n=5+5)
Operations/PrometheusCRD/UpdateVersion-8                   10.2k ± 0%     10.0k ± 0%   -1.06%  (p=0.000 n=5+4)
Operations/apiresourceimport/Create-8                      15.4k ± 0%     15.4k ± 0%   -0.10%  (p=0.008 n=5+5)
Operations/apiresourceimport/Apply-8                       43.0k ± 0%     43.0k ± 0%   -0.02%  (p=0.008 n=5+5)
Operations/apiresourceimport/ApplyTwice-8                  83.8k ± 0%     83.8k ± 0%   -0.03%  (p=0.008 n=5+5)
Operations/apiresourceimport/ApplyTwiceNoCompare-8         81.8k ± 0%     81.7k ± 0%   -0.02%  (p=0.008 n=5+5)
Operations/apiresourceimport/Update-8                      26.3k ± 0%     26.3k ± 0%   -0.14%  (p=0.000 n=5+4)
Operations/apiresourceimport/UpdateVersion-8               37.3k ± 0%     37.2k ± 0%   -0.15%  (p=0.008 n=5+5)
pkg:sigs.k8s.io/structured-merge-diff/v4/typed goos:darwin goarch:amd64
ConvertUnstructured/Pod/From-8                               162 ± 0%       162 ± 0%     ~     (all equal)
ConvertUnstructured/Pod/To-8                                0.00           0.00          ~     (all equal)
ConvertUnstructured/Node/From-8                              375 ± 0%       375 ± 0%     ~     (all equal)
ConvertUnstructured/Node/To-8                               0.00           0.00          ~     (all equal)
ConvertUnstructured/Endpoints/From-8                       5.07k ± 0%     5.07k ± 0%     ~     (p=0.913 n=5+5)
ConvertUnstructured/Endpoints/To-8                          0.00           0.00          ~     (all equal)
ConvertUnstructured/CustomResourceDefinition/From-8        1.97k ± 0%     1.97k ± 0%     ~     (all equal)
ConvertUnstructured/CustomResourceDefinition/To-8           0.00           0.00          ~     (all equal)
ValidateStructured/struct-8                                 78.0 ± 0%      78.0 ± 0%     ~     (all equal)
```