### PR TITLE
tofieldset: Add tests to show it already allow duplicates

### DIFF
--- a/typed/tofieldset.go
+++ b/typed/tofieldset.go
@@ -94,9 +94,31 @@ func (v *toFieldSetWalker) doScalar(t *schema.Scalar) ValidationErrors {
 }
 
 func (v *toFieldSetWalker) visitListItems(t *schema.List, list value.List) (errs ValidationErrors) {
+	// Keeps track of the PEs we've seen
+	seen := fieldpath.MakePathElementSet(list.Length())
+	// Keeps tracks of the PEs we've counted as duplicates
+	duplicates := fieldpath.MakePathElementSet(list.Length())
 	for i := 0; i < list.Length(); i++ {
 		child := list.At(i)
 		pe, _ := listItemToPathElement(v.allocator, v.schema, t, child)
+		if seen.Has(pe) {
+			if duplicates.Has(pe) {
+				// do nothing
+			} else {
+				v.set.Insert(append(v.path, pe))
+				duplicates.Insert(pe)
+			}
+		} else {
+			seen.Insert(pe)
+		}
+	}
+
+	for i := 0; i < list.Length(); i++ {
+		child := list.At(i)
+		pe, _ := listItemToPathElement(v.allocator, v.schema, t, child)
+		if duplicates.Has(pe) {
+			continue
+		}
 		v2 := v.prepareDescent(pe, t.ElementType)
 		v2.value = child
 		errs = append(errs, v2.toFieldSet()...)

--- a/typed/toset_test.go
+++ b/typed/toset_test.go
@@ -155,7 +155,12 @@ var fieldsetCases = []fieldsetTestCase{{
 			_P("setStr", _V("b")),
 			_P("setStr", _V("c")),
 		)},
-		{`{"setBool":[true,false]}`, _NS(
+		{`{"setStr":["a","b","c","a","b","c","c"]}`, _NS(
+			_P("setStr", _V("a")),
+			_P("setStr", _V("b")),
+			_P("setStr", _V("c")),
+		)},
+		{`{"setBool":[true,false,true]}`, _NS(
 			_P("setBool", _V(true)),
 			_P("setBool", _V(false)),
 		)},
@@ -244,6 +249,16 @@ var fieldsetCases = []fieldsetTestCase{{
 			_P("list", _KBF("key", "b", "id", 1), "key"),
 			_P("list", _KBF("key", "b", "id", 1), "id"),
 		)},
+		{`{"list":[{"key":"a","id":1,"nv":2},{"key":"a","id":2,"nv":3},{"key":"b","id":1},{"key":"a","id":2,"bv":true}]}`, _NS(
+			_P("list", _KBF("key", "a", "id", 1)),
+			_P("list", _KBF("key", "a", "id", 1), "key"),
+			_P("list", _KBF("key", "a", "id", 1), "id"),
+			_P("list", _KBF("key", "a", "id", 1), "nv"),
+			_P("list", _KBF("key", "a", "id", 2)),
+			_P("list", _KBF("key", "b", "id", 1)),
+			_P("list", _KBF("key", "b", "id", 1), "key"),
+			_P("list", _KBF("key", "b", "id", 1), "id"),
+		)},
 		{`{"atomicList":["a","a","a"]}`, _NS(_P("atomicList"))},
 	},
 }}
@@ -257,9 +272,9 @@ func (tt fieldsetTestCase) test(t *testing.T) {
 		v := v
 		t.Run(fmt.Sprintf("%v-%v", tt.name, i), func(t *testing.T) {
 			t.Parallel()
-			tv, err := parser.Type(tt.rootTypeName).FromYAML(v.object)
+			tv, err := parser.Type(tt.rootTypeName).FromYAML(v.object, typed.AllowDuplicates)
 			if err != nil {
-				t.Errorf("failed to parse object: %v", err)
+				t.Fatalf("failed to parse object: %v", err)
 			}
 			fs, err := tv.ToFieldSet()
 			if err != nil {


### PR DESCRIPTION
Continuation of #247.

This uses the pattern that I've generally used to solve the problem, which is to not try to be too smart about duplicate entries, and just record the path element for the whole thing, rather than try to track all the fields within. It's not super relevant because no one should ever be able to apply duplicates, so they wouldn't really have conflicts with sub-fields anyway, we've decided that they should have a conflict with the idea of "duplicates" (de-duplicating is a conflict).

/assign @alexzielenski 