### PR TITLE
fieldpath: Allow map to be updated

### DIFF
--- a/fieldpath/pathelementmap.go
+++ b/fieldpath/pathelementmap.go
@@ -53,6 +53,7 @@ func (spev sortedPathElementValues) Less(i, j int) bool {
 func (spev sortedPathElementValues) Swap(i, j int) { spev[i], spev[j] = spev[j], spev[i] }
 
 // Insert adds the pathelement and associated value in the map.
+// If insert is called twice with the same PathElement, the value is replaced.
 func (s *PathElementValueMap) Insert(pe PathElement, v value.Value) {
 	loc := sort.Search(len(s.members), func(i int) bool {
 		return !s.members[i].PathElement.Less(pe)
@@ -62,6 +63,7 @@ func (s *PathElementValueMap) Insert(pe PathElement, v value.Value) {
 		return
 	}
 	if s.members[loc].PathElement.Equals(pe) {
+		s.members[loc].Value = v
 		return
 	}
 	s.members = append(s.members, pathElementValue{})

--- a/fieldpath/pathelementmap_test.go
+++ b/fieldpath/pathelementmap_test.go
@@ -47,4 +47,11 @@ func TestPathElementValueMap(t *testing.T) {
 	} else if !value.Equals(val, value.NewValueInterface(2)) {
 		t.Fatalf("Unexpected value found: %#v", val)
 	}
+
+	m.Insert(PathElement{FieldName: strptr("carrot")}, value.NewValueInterface("fork"))
+	if val, ok := m.Get(PathElement{FieldName: strptr("carrot")}); !ok {
+		t.Fatal("Missing path-element in map")
+	} else if !value.Equals(val, value.NewValueInterface("fork")) {
+		t.Fatalf("Unexpected value found: %#v", val)
+	}
 }


### PR DESCRIPTION
Minor change that will become important and was a little misleading to me. If you add something to the PathElementValueMap twice, the second value will be dropped (as opposed to the first).

/assign @alexzielenski 