### PR TITLE
add `Set` to value interface for lists

### DIFF
--- a/value/list.go
+++ b/value/list.go
@@ -30,6 +30,7 @@ type List interface {
 	AtUsing(Allocator, int) Value
 
 	// Set sets the value at the given index to the provided value
+	// It panics if the index is negative or too large to allocate the memory.
 	Set(int, Value)
 
 	// Range returns a ListRange for iterating over the items in the list.

--- a/value/list.go
+++ b/value/list.go
@@ -28,6 +28,10 @@ type List interface {
 	// The returned Value should be given back to the Allocator when no longer needed
 	// by calling Allocator.Free(Value).
 	AtUsing(Allocator, int) Value
+
+	// Set sets the value at the given index to the provided value
+	Set(int, Value)
+
 	// Range returns a ListRange for iterating over the items in the list.
 	Range() ListRange
 	// RangeUsing uses the provided allocator and returns a ListRange for

--- a/value/listreflect.go
+++ b/value/listreflect.go
@@ -74,6 +74,17 @@ func (r listReflect) EqualsUsing(a Allocator, other List) bool {
 	return ListEqualsUsing(a, &r, other)
 }
 
+func toReflectValue(v Value) reflect.Value {
+	if vr, ok := v.(*valueReflect); ok {
+		return vr.Value
+	}
+	return reflect.ValueOf(v.Unstructured())
+}
+
+func (r listReflect) Set(i int, v Value) {
+	r.Value.Index(i).Set(toReflectValue(v))
+}
+
 type listReflectRange struct {
 	list  reflect.Value
 	vr    *valueReflect

--- a/value/listunstructured.go
+++ b/value/listunstructured.go
@@ -52,6 +52,10 @@ func (l listUnstructured) RangeUsing(a Allocator) ListRange {
 	return r
 }
 
+func (l listUnstructured) Set(i int, v Value) {
+	l[i] = v.Unstructured()
+}
+
 type listUnstructuredRange struct {
 	list listUnstructured
 	vv   *valueUnstructured

--- a/value/valuereflect_test.go
+++ b/value/valuereflect_test.go
@@ -686,6 +686,69 @@ func TestReflectListMutateSet(t *testing.T) {
 	if !reflect.DeepEqual(unstructured, expectedUnstructured) {
 		t.Errorf("expected %v but got: %v", expectedUnstructured, unstructured)
 	}
+
+	type TestType struct {
+		Field struct {
+			Nested string
+		}
+	}
+
+	myStructSlice := []TestType{
+		{
+			Field: struct{ Nested string }{Nested: "value1"},
+		},
+		{
+			Field: struct{ Nested string }{Nested: "value2"},
+		},
+	}
+	rv = MustReflect(myStructSlice)
+	if !rv.IsList() {
+		t.Error("expected IsList to be true")
+	}
+	m = rv.AsList()
+	m.Set(0, MustReflect(TestType{Field: struct{ Nested string }{Nested: "replacement"}}))
+	expectedStructSlice := []TestType{
+		{
+			Field: struct{ Nested string }{Nested: "replacement"},
+		},
+		{
+			Field: struct{ Nested string }{Nested: "value2"},
+		},
+	}
+	if !reflect.DeepEqual(myStructSlice, expectedStructSlice) {
+		t.Errorf("expected %v but got: %v", expectedStructSlice, myStructSlice)
+	}
+	expectedSliceUnstructured := []interface{}{
+		map[string]interface{}{"Field": map[string]interface{}{"Nested": "replacement"}},
+		map[string]interface{}{"Field": map[string]interface{}{"Nested": "value2"}},
+	}
+	unstructured = rv.Unstructured()
+	if !reflect.DeepEqual(unstructured, expectedSliceUnstructured) {
+		t.Errorf("expected %v but got: %v", expectedSliceUnstructured, unstructured)
+	}
+
+	// Now set using unstructured
+	m.Set(0, NewValueInterface(map[string]interface{}{"Field": map[string]interface{}{"Nested": "replacement2"}}))
+	expectedStructSlice = []TestType{
+		{
+			Field: struct{ Nested string }{Nested: "replacement2"},
+		},
+		{
+			Field: struct{ Nested string }{Nested: "value2"},
+		},
+	}
+	if !reflect.DeepEqual(myStructSlice, expectedStructSlice) {
+		t.Errorf("expected %v but got: %v", expectedStructSlice, myStructSlice)
+	}
+	expectedSliceUnstructured = []interface{}{
+		map[string]interface{}{"Field": map[string]interface{}{"Nested": "replacement2"}},
+		map[string]interface{}{"Field": map[string]interface{}{"Nested": "value2"}},
+	}
+	unstructured = rv.Unstructured()
+	if !reflect.DeepEqual(unstructured, expectedSliceUnstructured) {
+		t.Errorf("expected %v but got: %v", expectedSliceUnstructured, unstructured)
+	}
+
 }
 
 func TestReflectListAt(t *testing.T) {

--- a/value/valuereflect_test.go
+++ b/value/valuereflect_test.go
@@ -661,6 +661,33 @@ func TestReflectList(t *testing.T) {
 	}
 }
 
+func TestReflectListMutateSet(t *testing.T) {
+	myStringSlice := []string{"value1", "value2"}
+	rv := MustReflect(myStringSlice)
+	if !rv.IsList() {
+		t.Error("expected IsList to be true")
+	}
+	m := rv.AsList()
+	at0 := m.At(0)
+	if at0.AsString() != "value1" {
+		t.Errorf("expected list.At(0) to be 'value1' but got: %v", at0)
+	}
+	m.Set(0, NewValueInterface("replacement"))
+
+	// Show that the original slice was mutated
+	expectedSlice := []string{"replacement", "value2"}
+	if !reflect.DeepEqual(myStringSlice, expectedSlice) {
+		t.Errorf("expected %v but got: %v", expectedSlice, myStringSlice)
+	}
+
+	// Show that the unstructured value is also updated
+	expectedUnstructured := []interface{}{"replacement", "value2"}
+	unstructured := rv.Unstructured()
+	if !reflect.DeepEqual(unstructured, expectedUnstructured) {
+		t.Errorf("expected %v but got: %v", expectedUnstructured, unstructured)
+	}
+}
+
 func TestReflectListAt(t *testing.T) {
 	rv := MustReflect([]string{"one", "two"})
 	if !rv.IsList() {


### PR DESCRIPTION
mirrors behavior of existing Set for maps

needed to write a `Default` function that applies schema defaults to a `value.Value` in Declarative Validation

/assign @apelisse