### PR TITLE
typed: Allow duplicates when we merge

### DIFF
--- a/typed/merge_test.go
+++ b/typed/merge_test.go
@@ -328,6 +328,34 @@ var mergeCases = []mergeTestCase{{
 		`{"setStr":["a","b","c","d","e","f","g","h","i","j"]}`,
 		`{"setStr":["1","b","2","h","3","e","4","k","l"]}`,
 		`{"setStr":["a","1","b","c","d","f","g","2","h","i","j","3","e","4","k","l"]}`,
+	}, { // We have a duplicate in LHS
+		`{"setStr":["a","b","b"]}`,
+		`{"setStr":["c"]}`,
+		`{"setStr":["a","b","b","c"]}`,
+	}, { // We have a duplicate in LHS.
+		`{"setStr":["a","b","b"]}`,
+		`{"setStr":["b"]}`,
+		`{"setStr":["a","b"]}`,
+	}, { // We have a duplicate in LHS.
+		`{"setStr":["a","b","b"]}`,
+		`{"setStr":["a"]}`,
+		`{"setStr":["a","b","b"]}`,
+	}, { // We have a duplicate in LHS.
+		`{"setStr":["a","b","c","d","e","c"]}`,
+		`{"setStr":["1","b","2","e","d"]}`,
+		`{"setStr":["a","1","b","c","2","e","c","d"]}`,
+	}, { // We have a duplicate in LHS, also present in RHS, keep only one.
+		`{"setStr":["a","b","c","d","e","c"]}`,
+		`{"setStr":["1","b","2","c","e","d"]}`,
+		`{"setStr":["a","1","b","2","c","e","d"]}`,
+	}, { // We have 2 duplicates in LHS, one is replaced.
+		`{"setStr":["a","a","b","b"]}`,
+		`{"setStr":["b","c","d"]}`,
+		`{"setStr":["a","a","b","c","d"]}`,
+	}, { // We have 2 duplicates in LHS, and nothing on the right
+		`{"setStr":["a","a","b","b"]}`,
+		`{"setStr":[]}`,
+		`{"setStr":["a","a","b","b"]}`,
 	}, {
 		`{"setBool":[true]}`,
 		`{"setBool":[false]}`,
@@ -336,6 +364,22 @@ var mergeCases = []mergeTestCase{{
 		`{"setNumeric":[1,2,3.14159]}`,
 		`{"setNumeric":[1,2,3]}`,
 		`{"setNumeric":[1,2,3.14159,3]}`,
+	}, {
+		`{"setStr":["c","a","g","f","c","a"]}`,
+		`{"setStr":["c","f","a","g"]}`,
+		`{"setStr":["c","f","a","g"]}`,
+	}, {
+		`{"setNumeric":[1,2,3.14159,1,2]}`,
+		`{"setNumeric":[1,2,3]}`,
+		`{"setNumeric":[1,2,3.14159,3]}`,
+	}, {
+		`{"setBool":[true,false,true]}`,
+		`{"setBool":[false]}`,
+		`{"setBool":[true,false,true]}`,
+	}, {
+		`{"setBool":[true,false,true]}`,
+		`{"setBool":[true]}`,
+		`{"setBool":[true, false]}`,
 	},
 	},
 }, {
@@ -423,6 +467,18 @@ var mergeCases = []mergeTestCase{{
 		`{"atomicList":["a","a","a"]}`,
 		`{"atomicList":["a","a"]}`,
 		`{"atomicList":["a","a"]}`,
+	}, {
+		`{"list":[{"key":"a","id":1,"bv":true},{"key":"b","id":2},{"key":"a","id":1,"bv":false,"nv":2}]}`,
+		`{"list":[{"key":"a","id":1,"nv":3},{"key":"c","id":3},{"key":"b","id":2}]}`,
+		`{"list":[{"key":"a","id":1,"bv":true,"nv":3},{"key":"c","id":3},{"key":"b","id":2}]}`,
+	}, {
+		`{"list":[{"key":"a","id":1,"nv":1},{"key":"a","id":1,"nv":2}]}`,
+		`{"list":[]}`,
+		`{"list":[{"key":"a","id":1,"nv":1},{"key":"a","id":1,"nv":2}]}`,
+	}, {
+		`{"list":[{"key":"a","id":1,"nv":1},{"key":"a","id":1,"nv":2}]}`,
+		`{}`,
+		`{"list":[{"key":"a","id":1,"nv":1},{"key":"a","id":1,"nv":2}]}`,
 	}},
 }}
 
@@ -437,18 +493,16 @@ func (tt mergeTestCase) test(t *testing.T) {
 		t.Run(fmt.Sprintf("%v-valid-%v", tt.name, i), func(t *testing.T) {
 			t.Parallel()
 			pt := parser.Type(tt.rootTypeName)
-
-			lhs, err := pt.FromYAML(triplet.lhs)
+			// Former object can have duplicates in sets.
+			lhs, err := pt.FromYAML(triplet.lhs, typed.AllowDuplicates)
 			if err != nil {
 				t.Fatalf("unable to parser/validate lhs yaml: %v\n%v", err, triplet.lhs)
 			}
-
 			rhs, err := pt.FromYAML(triplet.rhs)
 			if err != nil {
 				t.Fatalf("unable to parser/validate rhs yaml: %v\n%v", err, triplet.rhs)
 			}
-
-			out, err := pt.FromYAML(triplet.out)
+			out, err := pt.FromYAML(triplet.out, typed.AllowDuplicates)
 			if err != nil {
 				t.Fatalf("unable to parser/validate out yaml: %v\n%v", err, triplet.out)
 			}

--- a/typed/merge_test.go
+++ b/typed/merge_test.go
@@ -470,7 +470,7 @@ var mergeCases = []mergeTestCase{{
 	}, {
 		`{"list":[{"key":"a","id":1,"bv":true},{"key":"b","id":2},{"key":"a","id":1,"bv":false,"nv":2}]}`,
 		`{"list":[{"key":"a","id":1,"nv":3},{"key":"c","id":3},{"key":"b","id":2}]}`,
-		`{"list":[{"key":"a","id":1,"bv":true,"nv":3},{"key":"c","id":3},{"key":"b","id":2}]}`,
+		`{"list":[{"key":"a","id":1,"nv":3},{"key":"c","id":3},{"key":"b","id":2}]}`,
 	}, {
 		`{"list":[{"key":"a","id":1,"nv":1},{"key":"a","id":1,"nv":2}]}`,
 		`{"list":[]}`,


### PR DESCRIPTION
The goal is to ignore duplicates if they are not included in the partial object, and to replace all of the occurences if they are in the partial object.

/assign @liggitt 
/cc @alexzielenski 