### PR TITLE
fix panic when calling ToUnstructured on nil metav1.Time

### DIFF
--- a/value/reflectcache.go
+++ b/value/reflectcache.go
@@ -184,6 +184,11 @@ func (e TypeReflectCacheEntry) ToUnstructured(sv reflect.Value) (interface{}, er
 	// This is based on https://github.com/kubernetes/kubernetes/blob/82c9e5c814eb7acc6cc0a090c057294d0667ad66/staging/src/k8s.io/apimachinery/pkg/runtime/converter.go#L505
 	// and is intended to replace it.
 
+	// Check if the object is a nil pointer.
+	if sv.Kind() == reflect.Ptr && sv.IsNil() {
+		// We're done - we don't need to store anything.
+		return nil, nil
+	}
 	// Check if the object has a custom string converter and use it if available, since it is much more efficient
 	// than round tripping through json.
 	if converter, ok := e.getUnstructuredConverter(sv); ok {
@@ -191,11 +196,6 @@ func (e TypeReflectCacheEntry) ToUnstructured(sv reflect.Value) (interface{}, er
 	}
 	// Check if the object has a custom JSON marshaller/unmarshaller.
 	if marshaler, ok := e.getJsonMarshaler(sv); ok {
-		if sv.Kind() == reflect.Ptr && sv.IsNil() {
-			// We're done - we don't need to store anything.
-			return nil, nil
-		}
-
 		data, err := marshaler.MarshalJSON()
 		if err != nil {
 			return nil, err


### PR DESCRIPTION
Currently, when calling `ToUnstructured` on a `metav1.Time` that is a `nil` pointer, you get a panic:
```
panic: value method k8s.io/apimachinery/pkg/apis/meta/v1.Time.ToUnstructured called using nil *Time pointer

goroutine 1 [running]:
k8s.io/apimachinery/pkg/apis/meta/v1.(*Time).ToUnstructured(0x100000001?)
	<autogenerated>:1 +0x48
sigs.k8s.io/structured-merge-diff/v4/value.TypeReflectCacheEntry.ToUnstructured({0x1, 0x0, 0x0, 0x0, 0x1, 0x0, 0x0, {0x0, 0x0, 0x0}}, ...)
	external/io_k8s_sigs_structured_merge_diff_v4/value/reflectcache.go:192 +0x658
k8s.io/apimachinery/pkg/runtime.toUnstructured({0x108eaaf80?, 0x14001065390?, 0x1?}, {0x108686960?, 0x14003e181b0?, 0x98?})
	external/io_k8s_apimachinery/pkg/runtime/converter.go:655 +0x6d4
k8s.io/apimachinery/pkg/runtime.structToUnstructured({0x108a15600?, 0x14001065378?, 0x1?}, {0x108686960?, 0x14003e18150?, 0x104d118f8?})
	external/io_k8s_apimachinery/pkg/runtime/converter.go:843 +0x764
k8s.io/apimachinery/pkg/runtime.toUnstructured({0x108a15600?, 0x14001065378?, 0x3?}, {0x108686960?, 0x14003e18150?, 0x98?})
	external/io_k8s_apimachinery/pkg/runtime/converter.go:692 +0x628
k8s.io/apimachinery/pkg/runtime.structToUnstructured({0x108b1ca20?, 0x14001065008?, 0x8?}, {0x10870bce0?, 0x14001783600?, 0x104d118f8?})
	external/io_k8s_apimachinery/pkg/runtime/converter.go:843 +0x764
k8s.io/apimachinery/pkg/runtime.toUnstructured({0x108b1ca20?, 0x14001065008?, 0x10823aa40?}, {0x10870bce0?, 0x14001783600?, 0x8?})
	external/io_k8s_apimachinery/pkg/runtime/converter.go:692 +0x628
k8s.io/apimachinery/pkg/runtime.(*unstructuredConverter).ToUnstructured(0x10b8d9c80, {0x108e80880, 0x14001065008})
	external/io_k8s_apimachinery/pkg/runtime/converter.go:586 +0x250
...
```

This moves the `nil` pointer check up to before we check if there is a custom converter so that we don't attempt to call `ToUnstructured` on a nil pointer which triggers the panic.

Related issues:
- https://github.com/kubernetes-sigs/structured-merge-diff/issues/229
- https://github.com/operator-framework/api/issues/269