### PR TITLE
use our own fork of go-yaml

### DIFF
--- a/fieldpath/fromvalue_test.go
+++ b/fieldpath/fromvalue_test.go
@@ -19,8 +19,8 @@ package fieldpath
 import (
 	"testing"
 
-	"gopkg.in/yaml.v2"
 	"sigs.k8s.io/structured-merge-diff/v4/value"
+	yaml "sigs.k8s.io/yaml/goyaml.v2"
 )
 
 func TestFromValue(t *testing.T) {

--- a/fieldpath/set_test.go
+++ b/fieldpath/set_test.go
@@ -22,8 +22,8 @@ import (
 	"math/rand"
 	"testing"
 
-	"gopkg.in/yaml.v2"
 	"sigs.k8s.io/structured-merge-diff/v4/schema"
+	yaml "sigs.k8s.io/yaml/goyaml.v2"
 )
 
 type randomPathAlphabet []PathElement

--- a/go.mod
+++ b/go.mod
@@ -1,12 +1,11 @@
 module sigs.k8s.io/structured-merge-diff/v4
 
-require gopkg.in/yaml.v2 v2.2.8
-
 require (
-	github.com/google/go-cmp v0.5.9 // indirect
+	github.com/google/go-cmp v0.5.9
 	github.com/google/gofuzz v1.0.0
 	github.com/json-iterator/go v1.1.12
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
+	sigs.k8s.io/yaml v1.4.0
 )
 
 go 1.13

--- a/go.sum
+++ b/go.sum
@@ -19,5 +19,5 @@ github.com/stretchr/testify v1.3.0 h1:TivCn/peBQ7UY8ooIcPgZFpTNSz0Q2U6UrFlUfqbe0
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
-gopkg.in/yaml.v2 v2.2.8 h1:obN1ZagJSUGI0Ek/LBmuj4SNLPfIny3KsKFopxRdj10=
-gopkg.in/yaml.v2 v2.2.8/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
+sigs.k8s.io/yaml v1.4.0 h1:Mk1wCc2gy/F0THH0TAp1QYyJNzRm2KCLy3o5ASXVI5E=
+sigs.k8s.io/yaml v1.4.0/go.mod h1:Ejl7/uTz7PSA4eKMyQCUTnhZYNmLIl+5c2lQPGR2BPY=

--- a/merge/multiple_appliers_test.go
+++ b/merge/multiple_appliers_test.go
@@ -22,12 +22,12 @@ import (
 	"strings"
 	"testing"
 
-	"gopkg.in/yaml.v2"
 	"sigs.k8s.io/structured-merge-diff/v4/fieldpath"
 	. "sigs.k8s.io/structured-merge-diff/v4/internal/fixture"
 	"sigs.k8s.io/structured-merge-diff/v4/merge"
 	"sigs.k8s.io/structured-merge-diff/v4/typed"
 	"sigs.k8s.io/structured-merge-diff/v4/value"
+	yaml "sigs.k8s.io/yaml/goyaml.v2"
 )
 
 func TestMultipleAppliersSet(t *testing.T) {

--- a/typed/parser.go
+++ b/typed/parser.go
@@ -19,9 +19,9 @@ package typed
 import (
 	"fmt"
 
-	yaml "gopkg.in/yaml.v2"
 	"sigs.k8s.io/structured-merge-diff/v4/schema"
 	"sigs.k8s.io/structured-merge-diff/v4/value"
+	yaml "sigs.k8s.io/yaml/goyaml.v2"
 )
 
 // YAMLObject is an object encoded in YAML.

--- a/typed/parser_test.go
+++ b/typed/parser_test.go
@@ -22,8 +22,8 @@ import (
 	"strings"
 	"testing"
 
-	yaml "gopkg.in/yaml.v2"
 	"sigs.k8s.io/structured-merge-diff/v4/typed"
+	yaml "sigs.k8s.io/yaml/goyaml.v2"
 )
 
 func testdata(file string) string {

--- a/value/equals_test.go
+++ b/value/equals_test.go
@@ -21,8 +21,8 @@ import (
 	"path/filepath"
 	"testing"
 
-	"gopkg.in/yaml.v2"
 	"sigs.k8s.io/structured-merge-diff/v4/value"
+	yaml "sigs.k8s.io/yaml/goyaml.v2"
 )
 
 func testdata(file string) string {

--- a/value/value.go
+++ b/value/value.go
@@ -23,7 +23,7 @@ import (
 	"strings"
 
 	jsoniter "github.com/json-iterator/go"
-	"gopkg.in/yaml.v2"
+	yaml "sigs.k8s.io/yaml/goyaml.v2"
 )
 
 var (


### PR DESCRIPTION
We have our own fork of go-yaml https://github.com/kubernetes-sigs/yaml/pull/76 so we can simplify the dependency graph in kubernetes if we end the path in kubernetes-sigs/yaml

```
go mod why gopkg.in/yaml.v2
# gopkg.in/yaml.v2
k8s.io/apiextensions-apiserver/examples/client-go/pkg/client/applyconfiguration/internal
sigs.k8s.io/structured-merge-diff/v4/typed
gopkg.in/yaml.v2

```