### PR TITLE
Compatibility fix: Add back IgnoredFields

### DIFF
--- a/internal/fixture/state.go
+++ b/internal/fixture/state.go
@@ -540,6 +540,10 @@ type TestCase struct {
 	ReturnInputOnNoop bool
 	// IgnoreFilter filters out ignored fields from a fieldpath.Set.
 	IgnoreFilter map[fieldpath.APIVersion]fieldpath.Filter
+
+	// IgnoredFields containing the set to ignore for every version.
+	// IgnoredFields may not be set if IgnoreFilter is set.
+	IgnoredFields map[fieldpath.APIVersion]*fieldpath.Set
 }
 
 // Test runs the test-case using the given parser and a dummy converter.
@@ -573,6 +577,7 @@ func (tc TestCase) BenchWithConverter(parser Parser, converter merge.Converter) 
 	updaterBuilder := merge.UpdaterBuilder{
 		Converter:         converter,
 		IgnoreFilter:      tc.IgnoreFilter,
+		IgnoredFields:     tc.IgnoredFields,
 		ReturnInputOnNoop: tc.ReturnInputOnNoop,
 	}
 	state := State{
@@ -595,6 +600,7 @@ func (tc TestCase) TestWithConverter(parser Parser, converter merge.Converter) e
 	updaterBuilder := merge.UpdaterBuilder{
 		Converter:         converter,
 		IgnoreFilter:      tc.IgnoreFilter,
+		IgnoredFields:     tc.IgnoredFields,
 		ReturnInputOnNoop: tc.ReturnInputOnNoop,
 	}
 	state := State{

--- a/merge/update.go
+++ b/merge/update.go
@@ -33,6 +33,9 @@ type UpdaterBuilder struct {
 	Converter    Converter
 	IgnoreFilter map[fieldpath.APIVersion]fieldpath.Filter
 
+	// IgnoredFields provides a set of fields to ignore for each
+	IgnoredFields map[fieldpath.APIVersion]*fieldpath.Set
+
 	// Stop comparing the new object with old object after applying.
 	// This was initially used to avoid spurious etcd update, but
 	// since that's vastly inefficient, we've come-up with a better
@@ -46,6 +49,7 @@ func (u *UpdaterBuilder) BuildUpdater() *Updater {
 	return &Updater{
 		Converter:         u.Converter,
 		IgnoreFilter:      u.IgnoreFilter,
+		IgnoredFields:     u.IgnoredFields,
 		returnInputOnNoop: u.ReturnInputOnNoop,
 	}
 }
@@ -55,6 +59,9 @@ func (u *UpdaterBuilder) BuildUpdater() *Updater {
 type Updater struct {
 	// Deprecated: This will eventually become private.
 	Converter Converter
+
+	// Deprecated: This will eventually become private.
+	IgnoredFields map[fieldpath.APIVersion]*fieldpath.Set
 
 	// Deprecated: This will eventually become private.
 	IgnoreFilter map[fieldpath.APIVersion]fieldpath.Filter
@@ -70,8 +77,19 @@ func (s *Updater) update(oldObject, newObject *typed.TypedValue, version fieldpa
 		return nil, nil, fmt.Errorf("failed to compare objects: %v", err)
 	}
 
-	versions := map[fieldpath.APIVersion]*typed.Comparison{
-		version: compare.FilterFields(s.IgnoreFilter[version]),
+	var versions map[fieldpath.APIVersion]*typed.Comparison
+
+	if s.IgnoredFields != nil && s.IgnoreFilter != nil {
+		return nil, nil, fmt.Errorf("IgnoreFilter and IgnoreFilter may not both be set")
+	}
+	if s.IgnoredFields != nil {
+		versions = map[fieldpath.APIVersion]*typed.Comparison{
+			version: compare.ExcludeFields(s.IgnoredFields[version]),
+		}
+	} else {
+		versions = map[fieldpath.APIVersion]*typed.Comparison{
+			version: compare.FilterFields(s.IgnoreFilter[version]),
+		}
 	}
 
 	for manager, managerSet := range managers {
@@ -101,7 +119,12 @@ func (s *Updater) update(oldObject, newObject *typed.TypedValue, version fieldpa
 			if err != nil {
 				return nil, nil, fmt.Errorf("failed to compare objects: %v", err)
 			}
-			versions[managerSet.APIVersion()] = compare.FilterFields(s.IgnoreFilter[managerSet.APIVersion()])
+
+			if s.IgnoredFields != nil {
+				versions[managerSet.APIVersion()] = compare.ExcludeFields(s.IgnoredFields[managerSet.APIVersion()])
+			} else {
+				versions[managerSet.APIVersion()] = compare.FilterFields(s.IgnoreFilter[managerSet.APIVersion()])
+			}
 		}
 
 		conflictSet := managerSet.Set().Intersection(compare.Modified.Union(compare.Added))
@@ -154,7 +177,16 @@ func (s *Updater) Update(liveObject, newObject *typed.TypedValue, version fieldp
 		managers[manager] = fieldpath.NewVersionedSet(fieldpath.NewSet(), version, false)
 	}
 	set := managers[manager].Set().Difference(compare.Removed).Union(compare.Modified).Union(compare.Added)
-	ignoreFilter := s.IgnoreFilter[version]
+
+	if s.IgnoredFields != nil && s.IgnoreFilter != nil {
+		return nil, nil, fmt.Errorf("IgnoreFilter and IgnoreFilter may not both be set")
+	}
+	var ignoreFilter fieldpath.Filter
+	if s.IgnoredFields != nil {
+		ignoreFilter = fieldpath.NewExcludeSetFilter(s.IgnoredFields[version])
+	} else {
+		ignoreFilter = s.IgnoreFilter[version]
+	}
 	if ignoreFilter != nil {
 		set = ignoreFilter.Filter(set)
 	}
@@ -189,7 +221,15 @@ func (s *Updater) Apply(liveObject, configObject *typed.TypedValue, version fiel
 		return nil, fieldpath.ManagedFields{}, fmt.Errorf("failed to get field set: %v", err)
 	}
 
-	ignoreFilter := s.IgnoreFilter[version]
+	if s.IgnoredFields != nil && s.IgnoreFilter != nil {
+		return nil, nil, fmt.Errorf("IgnoreFilter and IgnoreFilter may not both be set")
+	}
+	var ignoreFilter fieldpath.Filter
+	if s.IgnoredFields != nil {
+		ignoreFilter = fieldpath.NewExcludeSetFilter(s.IgnoredFields[version])
+	} else {
+		ignoreFilter = s.IgnoreFilter[version]
+	}
 	if ignoreFilter != nil {
 		set = ignoreFilter.Filter(set)
 	}


### PR DESCRIPTION
This field was replaced by `IgnoreFilter` in https://github.com/kubernetes-sigs/structured-merge-diff/pull/265 but is a breaking change that has broken builds: https://github.com/kubernetes-sigs/structured-merge-diff/commit/c68c9ee5bc5f9b73b5785e38a6a28a6c5b654572#commitcomment-149056185

This adds it back with a check that errors out if `IgnoreFilter` and `IgnoredFields` are set together.