### PR TITLE
chore: omit comparison to bool constant

### DIFF
--- a/value/scalar.go
+++ b/value/scalar.go
@@ -43,7 +43,7 @@ func IntCompare(lhs, rhs int64) int {
 func BoolCompare(lhs, rhs bool) int {
 	if lhs == rhs {
 		return 0
-	} else if lhs == false {
+	} else if !lhs {
 		return -1
 	}
 	return 1


### PR DESCRIPTION
Simple one-line change to avoid comparison to bool constant.