### PR TITLE
fix: update apidiff script to install tool and set up remote repository

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .idea
+_output


### PR DESCRIPTION
fix error when execute apidiff.sh
1. 
```
./hack/apidiff.sh: line 58: GOBIN: unbound variable
```

2. 
```
./hack/apidiff.sh: line 98: apidiff: command not found
```
3. 
```
fatal: Not a valid object name origin/master
``` 

ref: https://github.com/kubernetes-sigs/structured-merge-diff/issues/276