### PR TITLE
KEP-5051: Add opt-in support for unset markers

### DIFF
--- a/merge/deduced_test.go
+++ b/merge/deduced_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package merge_test
 
 import (
+	"fmt"
 	"testing"
 
 	"sigs.k8s.io/structured-merge-diff/v4/fieldpath"
@@ -537,9 +538,7 @@ func TestDeduced(t *testing.T) {
 
 	for name, test := range tests {
 		t.Run(name, func(t *testing.T) {
-			if err := test.Test(DeducedParser); err != nil {
-				t.Fatal(err)
-			}
+			test.TestOptionCombinations(t, DeducedParser)
 		})
 	}
 }
@@ -608,19 +607,25 @@ func BenchmarkDeducedSimple(b *testing.B) {
 		},
 	}
 
-	// Make sure this passes...
-	if err := test.Test(DeducedParser); err != nil {
-		b.Fatal(err)
-	}
+	for _, enableUnsetMarkers := range []bool{false, true} {
+		test.EnableUnsetMarkers = enableUnsetMarkers
 
-	test.PreprocessOperations(DeducedParser)
+		b.Run(fmt.Sprintf("EnableUnsetMarkers=%t", enableUnsetMarkers), func(b *testing.B) {
+			// Make sure this passes...
+			if err := test.Test(DeducedParser); err != nil {
+				b.Fatal(err)
+			}
 
-	b.ReportAllocs()
-	b.ResetTimer()
-	for n := 0; n < b.N; n++ {
-		if err := test.Bench(DeducedParser); err != nil {
-			b.Fatal(err)
-		}
+			test.PreprocessOperations(DeducedParser)
+
+			b.ReportAllocs()
+			b.ResetTimer()
+			for n := 0; n < b.N; n++ {
+				if err := test.Bench(DeducedParser); err != nil {
+					b.Fatal(err)
+				}
+			}
+		})
 	}
 }
 
@@ -720,19 +725,25 @@ func BenchmarkDeducedNested(b *testing.B) {
 		APIVersion: "v1",
 	}
 
-	// Make sure this passes...
-	if err := test.Test(DeducedParser); err != nil {
-		b.Fatal(err)
-	}
+	for _, enableUnsetMarkers := range []bool{false, true} {
+		test.EnableUnsetMarkers = enableUnsetMarkers
 
-	test.PreprocessOperations(DeducedParser)
+		b.Run(fmt.Sprintf("EnableUnsetMarkers=%t", enableUnsetMarkers), func(b *testing.B) {
+			// Make sure this passes...
+			if err := test.Test(DeducedParser); err != nil {
+				b.Fatal(err)
+			}
 
-	b.ReportAllocs()
-	b.ResetTimer()
-	for n := 0; n < b.N; n++ {
-		if err := test.Bench(DeducedParser); err != nil {
-			b.Fatal(err)
-		}
+			test.PreprocessOperations(DeducedParser)
+
+			b.ReportAllocs()
+			b.ResetTimer()
+			for n := 0; n < b.N; n++ {
+				if err := test.Bench(DeducedParser); err != nil {
+					b.Fatal(err)
+				}
+			}
+		})
 	}
 }
 
@@ -832,18 +843,24 @@ func BenchmarkDeducedNestedAcrossVersion(b *testing.B) {
 		APIVersion: "v1",
 	}
 
-	// Make sure this passes...
-	if err := test.Test(DeducedParser); err != nil {
-		b.Fatal(err)
-	}
+	for _, enableUnsetMarkers := range []bool{false, true} {
+		test.EnableUnsetMarkers = enableUnsetMarkers
 
-	test.PreprocessOperations(DeducedParser)
+		b.Run(fmt.Sprintf("EnableUnsetMarkers=%t", enableUnsetMarkers), func(b *testing.B) {
+			// Make sure this passes...
+			if err := test.Test(DeducedParser); err != nil {
+				b.Fatal(err)
+			}
 
-	b.ReportAllocs()
-	b.ResetTimer()
-	for n := 0; n < b.N; n++ {
-		if err := test.Bench(DeducedParser); err != nil {
-			b.Fatal(err)
-		}
+			test.PreprocessOperations(DeducedParser)
+
+			b.ReportAllocs()
+			b.ResetTimer()
+			for n := 0; n < b.N; n++ {
+				if err := test.Bench(DeducedParser); err != nil {
+					b.Fatal(err)
+				}
+			}
+		})
 	}
 }

--- a/merge/default_keys_test.go
+++ b/merge/default_keys_test.go
@@ -167,9 +167,7 @@ func TestDefaultKeysFlat(t *testing.T) {
 
 	for name, test := range tests {
 		t.Run(name, func(t *testing.T) {
-			if err := test.Test(portListParser); err != nil {
-				t.Fatal(err)
-			}
+			test.TestOptionCombinations(t, portListParser)
 		})
 	}
 }
@@ -187,6 +185,7 @@ func TestDefaultKeysFlatErrors(t *testing.T) {
 					`,
 				},
 			},
+			Error: `associative list with keys has an element that omits key field "port"`,
 		},
 		"apply_missing_defaulted_key_ambiguous_A": {
 			Ops: []Operation{
@@ -200,6 +199,7 @@ func TestDefaultKeysFlatErrors(t *testing.T) {
 					`,
 				},
 			},
+			Error: ` .containerPorts: duplicate entries for key [port=80,protocol="TCP"]`,
 		},
 		"apply_missing_defaulted_key_ambiguous_B": {
 			Ops: []Operation{
@@ -214,13 +214,12 @@ func TestDefaultKeysFlatErrors(t *testing.T) {
 					`,
 				},
 			},
+			Error: ` .containerPorts: duplicate entries for key [port=80,protocol="TCP"]`,
 		},
 	}
 	for name, test := range tests {
 		t.Run(name, func(t *testing.T) {
-			if test.Test(portListParser) == nil {
-				t.Fatal("Should fail")
-			}
+			test.TestOptionCombinations(t, portListParser)
 		})
 	}
 }
@@ -381,9 +380,7 @@ func TestDefaultKeysNested(t *testing.T) {
 
 	for name, test := range tests {
 		t.Run(name, func(t *testing.T) {
-			if err := test.Test(bookParser); err != nil {
-				t.Fatal(err)
-			}
+			test.TestOptionCombinations(t, bookParser)
 		})
 	}
 }

--- a/merge/duplicates_test.go
+++ b/merge/duplicates_test.go
@@ -800,9 +800,7 @@ func TestDuplicates(t *testing.T) {
 
 	for name, test := range tests {
 		t.Run(name, func(t *testing.T) {
-			if err := test.Test(duplicatesParser); err != nil {
-				t.Fatal(err)
-			}
+			test.TestOptionCombinations(t, duplicatesParser)
 		})
 	}
 }

--- a/merge/extract_apply_test.go
+++ b/merge/extract_apply_test.go
@@ -747,9 +747,7 @@ func TestExtractApply(t *testing.T) {
 
 	for name, test := range tests {
 		t.Run(name, func(t *testing.T) {
-			if err := test.Test(extractParser); err != nil {
-				t.Fatal(err)
-			}
+			test.TestOptionCombinations(t, extractParser)
 		})
 	}
 }

--- a/merge/field_level_overrides_test.go
+++ b/merge/field_level_overrides_test.go
@@ -254,9 +254,7 @@ func TestFieldLevelOverrides(t *testing.T) {
 
 	for name, test := range tests {
 		t.Run(name, func(t *testing.T) {
-			if err := test.Test(overrideStructTypeParser); err != nil {
-				t.Fatal(err)
-			}
+			test.TestOptionCombinations(t, overrideStructTypeParser)
 		})
 	}
 }

--- a/merge/ignore_test.go
+++ b/merge/ignore_test.go
@@ -141,9 +141,7 @@ func TestIgnoreFilter(t *testing.T) {
 
 	for name, test := range tests {
 		t.Run(name, func(t *testing.T) {
-			if err := test.Test(DeducedParser); err != nil {
-				t.Fatal("Should fail:", err)
-			}
+			test.TestOptionCombinations(t, DeducedParser)
 		})
 	}
 }
@@ -266,9 +264,7 @@ func TestIgnoredFields(t *testing.T) {
 
 	for name, test := range tests {
 		t.Run(name, func(t *testing.T) {
-			if err := test.Test(DeducedParser); err != nil {
-				t.Fatal("Should fail:", err)
-			}
+			test.TestOptionCombinations(t, DeducedParser)
 		})
 	}
 }

--- a/merge/key_test.go
+++ b/merge/key_test.go
@@ -100,9 +100,7 @@ func TestUpdateAssociativeLists(t *testing.T) {
 
 	for name, test := range tests {
 		t.Run(name, func(t *testing.T) {
-			if err := test.Test(associativeListParser); err != nil {
-				t.Fatal(err)
-			}
+			test.TestOptionCombinations(t, associativeListParser)
 		})
 	}
 }

--- a/merge/multiple_appliers_test.go
+++ b/merge/multiple_appliers_test.go
@@ -237,9 +237,7 @@ func TestMultipleAppliersSet(t *testing.T) {
 
 	for name, test := range tests {
 		t.Run(name, func(t *testing.T) {
-			if err := test.Test(associativeListParser); err != nil {
-				t.Fatal(err)
-			}
+			test.TestOptionCombinations(t, associativeListParser)
 		})
 	}
 }
@@ -1108,9 +1106,7 @@ func TestMultipleAppliersNestedType(t *testing.T) {
 
 	for name, test := range tests {
 		t.Run(name, func(t *testing.T) {
-			if err := test.Test(nestedTypeParser); err != nil {
-				t.Fatal(err)
-			}
+			test.TestOptionCombinations(t, nestedTypeParser)
 		})
 	}
 }
@@ -1226,9 +1222,7 @@ func TestMultipleAppliersDeducedType(t *testing.T) {
 
 	for name, test := range tests {
 		t.Run(name, func(t *testing.T) {
-			if err := test.Test(DeducedParser); err != nil {
-				t.Fatal(err)
-			}
+			test.TestOptionCombinations(t, DeducedParser)
 		})
 	}
 }
@@ -1708,9 +1702,7 @@ func TestMultipleApplierAtomicMaps(t *testing.T) {
 	}
 	for name, test := range tests {
 		t.Run(name, func(t *testing.T) {
-			if err := test.Test(atomicMapParser); err != nil {
-				t.Fatal(err)
-			}
+			test.TestOptionCombinations(t, atomicMapParser)
 		})
 	}
 }

--- a/merge/nested_test.go
+++ b/merge/nested_test.go
@@ -703,9 +703,7 @@ func TestUpdateNestedType(t *testing.T) {
 
 	for name, test := range tests {
 		t.Run(name, func(t *testing.T) {
-			if err := test.Test(nestedTypeParser); err != nil {
-				t.Fatal(err)
-			}
+			test.TestOptionCombinations(t, nestedTypeParser)
 		})
 	}
 }

--- a/merge/preserve_unknown_test.go
+++ b/merge/preserve_unknown_test.go
@@ -82,9 +82,7 @@ func TestPreserveUnknownFields(t *testing.T) {
 
 	for name, test := range tests {
 		t.Run(name, func(t *testing.T) {
-			if err := test.Test(preserveUnknownParser); err != nil {
-				t.Fatal(err)
-			}
+			test.TestOptionCombinations(t, preserveUnknownParser)
 		})
 	}
 }

--- a/merge/schema_change_test.go
+++ b/merge/schema_change_test.go
@@ -172,9 +172,7 @@ func TestGranularToAtomicSchemaChanges(t *testing.T) {
 
 	for name, test := range tests {
 		t.Run(name, func(t *testing.T) {
-			if err := test.Test(structParser); err != nil {
-				t.Fatal(err)
-			}
+			test.TestOptionCombinations(t, structParser)
 		})
 	}
 }
@@ -246,9 +244,7 @@ func TestAtomicToGranularSchemaChanges(t *testing.T) {
 
 	for name, test := range tests {
 		t.Run(name, func(t *testing.T) {
-			if err := test.Test(structWithAtomicParser); err != nil {
-				t.Fatal(err)
-			}
+			test.TestOptionCombinations(t, structWithAtomicParser)
 		})
 	}
 }

--- a/merge/set_test.go
+++ b/merge/set_test.go
@@ -586,9 +586,7 @@ func TestUpdateSet(t *testing.T) {
 
 	for name, test := range tests {
 		t.Run(name, func(t *testing.T) {
-			if err := test.Test(setFieldsParser); err != nil {
-				t.Fatal(err)
-			}
+			test.TestOptionCombinations(t, setFieldsParser)
 		})
 	}
 }

--- a/merge/unset_test.go
+++ b/merge/unset_test.go
@@ -1,0 +1,867 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package merge_test
+
+import (
+	"testing"
+
+	"sigs.k8s.io/structured-merge-diff/v4/merge"
+
+	"sigs.k8s.io/structured-merge-diff/v4/fieldpath"
+	. "sigs.k8s.io/structured-merge-diff/v4/internal/fixture"
+	"sigs.k8s.io/structured-merge-diff/v4/typed"
+)
+
+var unsetFieldsParser = func() Parser {
+	parser, err := typed.NewParser(`types:
+- name: unsetFields
+  map:
+    fields:
+    - name: numeric
+      type:
+        scalar: numeric
+    - name: string
+      type:
+        scalar: string
+    - name: bool
+      type:
+        scalar: boolean
+    - name: atomicList
+      type:
+        list:
+          elementType:
+            scalar: numeric
+          elementRelationship: atomic
+    - name: atomicStruct
+      type:
+       map:
+         fields:
+         - name: name
+           type:
+             scalar: string
+         - name: value
+           type:
+             scalar: numeric
+         elementRelationship: atomic
+    - name: atomicMap
+      type:
+        map:
+          elementType:
+            scalar: numeric
+          elementRelationship: atomic
+    - name: associativeList
+      type:
+        list:
+          elementType:
+            namedType: nameValueType
+          elementRelationship: associative
+          keys:
+          - name
+    - name: multiKeyAssociativeList
+      type:
+        list:
+          elementType:
+            namedType: multiKeyType
+          elementRelationship: associative
+          keys:
+          - stringKey
+          - numericKey
+    - name: granularMap
+      type:
+        map:
+          elementType:
+            scalar: numeric
+          elementRelationship: granular
+- name: nameValueType
+  map:
+    fields:
+    - name: name
+      type:
+        scalar: string
+    - name: value
+      type:
+        scalar: numeric
+- name: multiKeyType
+  map:
+    fields:
+    - name: stringKey
+      type:
+        scalar: string
+    - name: numericKey
+      type:
+        scalar: numeric
+      default: 1
+    - name: value
+      type:
+        scalar: numeric`)
+	if err != nil {
+		panic(err)
+	}
+	return SameVersionParser{T: parser.Type("unsetFields")}
+}()
+
+func TestUnset(t *testing.T) {
+	tests := map[string]TestCase{
+		"unset_scalars": {
+			Ops: []Operation{
+				Apply{
+					Manager: "m1",
+					Object: `
+						numeric: 1
+						string: "string"
+						bool: true
+					`,
+					APIVersion: "v1",
+				},
+				ForceApply{
+					Manager: "m2",
+					Object: `
+						numeric: {k8s_io__value: unset}
+						string: {k8s_io__value: unset}
+						bool: {k8s_io__value: unset}
+					`,
+					APIVersion: "v1",
+				},
+			},
+			Object:     ``,
+			APIVersion: "v1",
+			Managed: fieldpath.ManagedFields{
+				"m1": fieldpath.NewVersionedSet(
+					_NS(),
+					"v1",
+					true,
+				),
+				"m2": fieldpath.NewVersionedSet(
+					_NS(
+						_P("numeric"),
+						_P("string"),
+						_P("bool"),
+					),
+					"v1",
+					true,
+				),
+			},
+		},
+		"unset_atomic_list": {
+			Ops: []Operation{
+				Apply{
+					Manager: "m1",
+					Object: `
+						atomicList: [1, 2]
+					`,
+					APIVersion: "v1",
+				},
+				ForceApply{
+					Manager: "m2",
+					Object: `
+						atomicList: {k8s_io__value: unset}
+					`,
+					APIVersion: "v1",
+				},
+			},
+			Object:     ``,
+			APIVersion: "v1",
+			Managed: fieldpath.ManagedFields{
+				"m1": fieldpath.NewVersionedSet(
+					_NS(),
+					"v1",
+					true,
+				),
+				"m2": fieldpath.NewVersionedSet(
+					_NS(
+						_P("atomicList"),
+					),
+					"v1",
+					true,
+				),
+			},
+		},
+		"unset_atomic_map": {
+			Ops: []Operation{
+				Apply{
+					Manager: "m1",
+					Object: `
+						atomicMap: {k1: 1, k2: 2}
+					`,
+					APIVersion: "v1",
+				},
+				ForceApply{
+					Manager: "m2",
+					Object: `
+						atomicMap: {k8s_io__value: unset}
+					`,
+					APIVersion: "v1",
+				},
+			},
+			Object:     ``,
+			APIVersion: "v1",
+			Managed: fieldpath.ManagedFields{
+				"m1": fieldpath.NewVersionedSet(
+					_NS(),
+					"v1",
+					true,
+				),
+				"m2": fieldpath.NewVersionedSet(
+					_NS(
+						_P("atomicMap"),
+					),
+					"v1",
+					true,
+				),
+			},
+		},
+		"unset_one_entry_of_associative_list": {
+			Ops: []Operation{
+				Apply{
+					Manager: "m1",
+					Object: `
+						associativeList: [{name: "a", value: 1}, {name: "b", value: 2}]
+					`,
+					APIVersion: "v1",
+				},
+				ForceApply{
+					Manager: "m2",
+					Object: `
+						associativeList: [{name: "b", k8s_io__value: unset}]
+					`,
+					APIVersion: "v1",
+				},
+			},
+			Object: `
+				associativeList: [{name: "a", value: 1}]
+			`,
+			APIVersion: "v1",
+			Managed: fieldpath.ManagedFields{
+				"m1": fieldpath.NewVersionedSet(
+					_NS(
+						_P("associativeList", _KBF("name", "a")),
+						_P("associativeList", _KBF("name", "a"), "name"),
+						_P("associativeList", _KBF("name", "a"), "value"),
+					),
+					"v1",
+					true,
+				),
+				"m2": fieldpath.NewVersionedSet(
+					_NS(
+						_P("associativeList", _KBF("name", "b")), // Tracks ownership of the whole unset map entry
+					),
+					"v1",
+					true,
+				),
+			},
+		},
+		"unset_all_entries_of_associative_list": {
+			Ops: []Operation{
+				Apply{
+					Manager: "m1",
+					Object: `
+						associativeList: [
+							{name: "a", value: 1},
+							{name: "b", value: 2}
+						]
+					`,
+					APIVersion: "v1",
+				},
+				ForceApply{
+					Manager: "m2",
+					Object: `
+						associativeList: [
+							{name: "a", k8s_io__value: unset},
+							{name: "b", k8s_io__value: unset}
+						]
+					`,
+					APIVersion: "v1",
+				},
+			},
+			Object:     ``,
+			APIVersion: "v1",
+			Managed: fieldpath.ManagedFields{
+				"m1": fieldpath.NewVersionedSet(
+					_NS(),
+					"v1",
+					true,
+				),
+				"m2": fieldpath.NewVersionedSet(
+					_NS(
+						_P("associativeList", _KBF("name", "a")),
+						_P("associativeList", _KBF("name", "b")),
+					),
+					"v1",
+					true,
+				),
+			},
+		},
+		"unset_granular_map": {
+			Ops: []Operation{
+				Apply{
+					Manager: "m1",
+					Object: `
+						granularMap: {"a": 1, "b": 2}
+					`,
+					APIVersion: "v1",
+				},
+				ForceApply{
+					Manager: "m2",
+					Object: `
+						granularMap: {"b": {k8s_io__value: unset}}
+					`,
+					APIVersion: "v1",
+				},
+			},
+			Object: `
+				granularMap: {"a": 1}
+			`,
+			APIVersion: "v1",
+			Managed: fieldpath.ManagedFields{
+				"m1": fieldpath.NewVersionedSet(
+					_NS(
+						_P("granularMap", "a"),
+					),
+					"v1",
+					true,
+				),
+				"m2": fieldpath.NewVersionedSet(
+					_NS(
+						_P("granularMap", "b"), // Tracks ownership of the whole unset map entry
+					),
+					"v1",
+					true,
+				),
+			},
+		},
+		"unset_atomic_struct": {
+			Ops: []Operation{
+				Apply{
+					Manager: "m1",
+					Object: `
+						atomicStruct: {name: a, value: 1}
+					`,
+					APIVersion: "v1",
+				},
+				ForceApply{
+					Manager: "m2",
+					Object: `
+						atomicStruct: {k8s_io__value: unset}
+					`,
+					APIVersion: "v1",
+				},
+			},
+			Object:     ``,
+			APIVersion: "v1",
+			Managed: fieldpath.ManagedFields{
+				"m1": fieldpath.NewVersionedSet(
+					_NS(),
+					"v1",
+					true,
+				),
+				"m2": fieldpath.NewVersionedSet(
+					_NS(
+						_P("atomicStruct"),
+					),
+					"v1",
+					true,
+				),
+			},
+		},
+
+		// conflict tests
+		"conflict_unset_scalar": {
+			Ops: []Operation{
+				Apply{
+					Manager: "m1",
+					Object: `
+						numeric: 1
+						string: "string"
+						bool: true
+					`,
+					APIVersion: "v1",
+				},
+				Apply{
+					Manager: "m2",
+					Object: `
+						numeric: {k8s_io__value: unset}
+						string: {k8s_io__value: unset}
+						bool: {k8s_io__value: unset}
+					`,
+					APIVersion: "v1",
+					Conflicts: merge.Conflicts{
+						{Manager: "m1", Path: _P("numeric")},
+						{Manager: "m1", Path: _P("string")},
+						{Manager: "m1", Path: _P("bool")},
+					},
+				},
+			},
+			Object: `
+				numeric: 1
+				string: "string"
+				bool: true
+			`,
+			APIVersion: "v1",
+			Managed: fieldpath.ManagedFields{
+				"m1": fieldpath.NewVersionedSet(
+					_NS(
+						_P("numeric"),
+						_P("string"),
+						_P("bool"),
+					),
+					"v1",
+					true,
+				),
+			},
+		},
+		"conflict_unset_atomic_list": {
+			Ops: []Operation{
+				Apply{
+					Manager: "m1",
+					Object: `
+						atomicList: [1, 2]
+					`,
+					APIVersion: "v1",
+				},
+				Apply{
+					Manager: "m2",
+					Object: `
+						atomicList: {k8s_io__value: unset}
+					`,
+					APIVersion: "v1",
+					Conflicts: merge.Conflicts{
+						{Manager: "m1", Path: _P("atomicList")},
+					},
+				},
+			},
+			Object: `
+				atomicList: [1, 2]
+			`,
+			APIVersion: "v1",
+			Managed: fieldpath.ManagedFields{
+				"m1": fieldpath.NewVersionedSet(
+					_NS(
+						_P("atomicList"),
+					),
+					"v1",
+					true,
+				),
+			},
+		},
+		"conflict_unset_atomic_map": {
+			Ops: []Operation{
+				Apply{
+					Manager: "m1",
+					Object: `
+						atomicMap: {k1: 1, k2: 2}
+					`,
+					APIVersion: "v1",
+				},
+				Apply{
+					Manager: "m2",
+					Object: `
+						atomicMap: {k8s_io__value: unset}
+					`,
+					APIVersion: "v1",
+					Conflicts: merge.Conflicts{
+						{Manager: "m1", Path: _P("atomicMap")},
+					},
+				},
+			},
+			Object: `
+				atomicMap: {k1: 1, k2: 2}
+			`,
+			APIVersion: "v1",
+			Managed: fieldpath.ManagedFields{
+				"m1": fieldpath.NewVersionedSet(
+					_NS(
+						_P("atomicMap"),
+					),
+					"v1",
+					true,
+				),
+			},
+		},
+		"conflict_unset_associative_list": {
+			Ops: []Operation{
+				Apply{
+					Manager: "m1",
+					Object: `
+						associativeList: [{name: "a", value: 1}, {name: "b", value: 2}]
+					`,
+					APIVersion: "v1",
+				},
+				Apply{
+					Manager: "m2",
+					Object: `
+						associativeList: [{name: "b", k8s_io__value: unset}]
+					`,
+					APIVersion: "v1",
+					Conflicts: merge.Conflicts{
+						{Manager: "m1", Path: _P("associativeList", _KBF("name", "b"))},
+					},
+				},
+			},
+			Object: `
+				associativeList: [{name: "a", value: 1}, {name: "b", value: 2}]
+			`,
+			APIVersion: "v1",
+			Managed: fieldpath.ManagedFields{
+				"m1": fieldpath.NewVersionedSet(
+					_NS(
+						_P("associativeList", _KBF("name", "a")),
+						_P("associativeList", _KBF("name", "a"), "name"),
+						_P("associativeList", _KBF("name", "a"), "value"),
+						_P("associativeList", _KBF("name", "b")),
+						_P("associativeList", _KBF("name", "b"), "name"),
+						_P("associativeList", _KBF("name", "b"), "value"),
+					),
+					"v1",
+					true,
+				),
+			},
+		},
+		"conflict_unset_granular_map": {
+			Ops: []Operation{
+				Apply{
+					Manager: "m1",
+					Object: `
+						granularMap: {"a": 1, "b": 2}
+					`,
+					APIVersion: "v1",
+				},
+				Apply{
+					Manager: "m2",
+					Object: `
+						granularMap: {"b": {k8s_io__value: unset}}
+					`,
+					APIVersion: "v1",
+					Conflicts: []merge.Conflict{
+						{Manager: "m1", Path: _P("granularMap", "b")},
+					},
+				},
+			},
+			Object: `
+				granularMap: {"a": 1, "b": 2}
+			`,
+			APIVersion: "v1",
+			Managed: fieldpath.ManagedFields{
+				"m1": fieldpath.NewVersionedSet(
+					_NS(
+						_P("granularMap", "a"),
+						_P("granularMap", "b"),
+					),
+					"v1",
+					true,
+				),
+			},
+		},
+		"conflict_unset_atomic_struct": {
+			Ops: []Operation{
+				Apply{
+					Manager: "m1",
+					Object: `
+						atomicStruct: {name: a, value: 1}
+					`,
+					APIVersion: "v1",
+				},
+				Apply{
+					Manager: "m2",
+					Object: `
+						atomicStruct: {k8s_io__value: unset}
+					`,
+					APIVersion: "v1",
+					Conflicts: []merge.Conflict{
+						{Manager: "m1", Path: _P("atomicStruct")},
+					},
+				},
+			},
+			Object: `
+				atomicStruct: {name: a, value: 1}
+			`,
+			APIVersion: "v1",
+			Managed: fieldpath.ManagedFields{
+				"m1": fieldpath.NewVersionedSet(
+					_NS(
+						_P("atomicStruct"),
+					),
+					"v1",
+					true,
+				),
+			},
+		},
+
+		// Field management of owned unset fields
+		"unset_associative_list_key_ownership_respected": {
+			Ops: []Operation{
+				Apply{
+					Manager: "m1",
+					Object: `
+						associativeList:
+						- name: item1
+						  value: 1
+						- name: item2
+						  value: 2
+					`,
+					APIVersion: "v1",
+				},
+				ForceApply{
+					Manager: "m2",
+					Object: `
+						associativeList:
+						- name: item1
+						  k8s_io__value: unset
+					`,
+					APIVersion: "v1",
+				},
+				// Subsequent operation from m1 should not be able to set the item
+				Apply{
+					Manager: "m1",
+					Object: `
+						associativeList:
+						- name: item1
+						  value: 5
+						- name: item2
+						  value: 2
+					`,
+					APIVersion: "v1",
+					Conflicts: []merge.Conflict{
+						{Manager: "m2", Path: _P("associativeList", _KBF("name", "item1"))},
+					},
+				},
+			},
+			Object: `
+				associativeList:
+				- name: item2
+				  value: 2
+			`,
+			APIVersion: "v1",
+			Managed: fieldpath.ManagedFields{
+				"m1": fieldpath.NewVersionedSet(
+					_NS(
+						_P("associativeList", _KBF("name", "item2")),
+						_P("associativeList", _KBF("name", "item2"), "name"),
+						_P("associativeList", _KBF("name", "item2"), "value"),
+					),
+					"v1",
+					true,
+				),
+				"m2": fieldpath.NewVersionedSet(
+					_NS(
+						_P("associativeList", _KBF("name", "item1")),
+					),
+					"v1",
+					true,
+				),
+			},
+		},
+		"unset_scalar_ownership_respected": {
+			Ops: []Operation{
+				Apply{
+					Manager: "m1",
+					Object: `
+						string: test
+					`,
+					APIVersion: "v1",
+				},
+				ForceApply{
+					Manager: "m2",
+					Object: `
+						string: {k8s_io__value: unset}
+					`,
+					APIVersion: "v1",
+				},
+				// Subsequent operation from m1 should not be able to set the field
+				Apply{
+					Manager: "m1",
+					Object: `
+						string: newvalue
+					`,
+					APIVersion: "v1",
+					Conflicts: []merge.Conflict{
+						{Manager: "m2", Path: _P("string")},
+					},
+				},
+			},
+			Object:     ``,
+			APIVersion: "v1",
+			Managed: fieldpath.ManagedFields{
+				"m1": fieldpath.NewVersionedSet(
+					_NS(),
+					"v1",
+					true,
+				),
+				"m2": fieldpath.NewVersionedSet(
+					_NS(
+						_P("string"),
+					),
+					"v1",
+					true,
+				),
+			},
+		},
+
+		// shared ownership of unset fields
+		"unset_same_field_multiple_managers": {
+			Ops: []Operation{
+				Apply{
+					Manager: "m1",
+					Object: `
+						string: {k8s_io__value: unset}
+					`,
+					APIVersion: "v1",
+				},
+				Apply{
+					Manager: "m2",
+					Object: `
+						string: {k8s_io__value: unset}
+					`,
+					APIVersion: "v1",
+				},
+			},
+			Object:     ``,
+			APIVersion: "v1",
+			Managed: fieldpath.ManagedFields{
+				"m1": fieldpath.NewVersionedSet(
+					_NS(
+						_P("string"),
+					),
+					"v1",
+					true,
+				),
+				"m2": fieldpath.NewVersionedSet(
+					_NS(
+						_P("string"),
+					),
+					"v1",
+					true,
+				),
+			},
+		},
+
+		// defaulteed map keys
+		"unset_multi_key_with_default_associative_list": {
+			Ops: []Operation{
+				Apply{
+					Manager: "m1",
+					Object: `
+						multiKeyAssociativeList:
+						- stringKey: "a"
+						  numericKey: 1
+						  value: 1
+						- stringKey: "b" 
+						  numericKey: 2
+						  value: 2
+					`,
+					APIVersion: "v1",
+				},
+				ForceApply{
+					Manager: "m2",
+					Object: `
+						multiKeyAssociativeList:
+						- stringKey: "a" # numericKey should default to 1.
+						  k8s_io__value: unset
+					`,
+					APIVersion: "v1",
+				},
+			},
+			Object: `
+				multiKeyAssociativeList:
+				- stringKey: "b"
+				  numericKey: 2 
+				  value: 2
+			`,
+			APIVersion: "v1",
+			Managed: fieldpath.ManagedFields{
+				"m1": fieldpath.NewVersionedSet(
+					_NS(
+						_P("multiKeyAssociativeList", _KBF("stringKey", "b", "numericKey", 2)),
+						_P("multiKeyAssociativeList", _KBF("stringKey", "b", "numericKey", 2), "stringKey"),
+						_P("multiKeyAssociativeList", _KBF("stringKey", "b", "numericKey", 2), "numericKey"),
+						_P("multiKeyAssociativeList", _KBF("stringKey", "b", "numericKey", 2), "value"),
+					),
+					"v1",
+					true,
+				),
+				"m2": fieldpath.NewVersionedSet(
+					_NS(
+						_P("multiKeyAssociativeList", _KBF("stringKey", "a", "numericKey", 1)),
+					),
+					"v1",
+					true,
+				),
+			},
+		},
+
+		// Validation tests
+		"invalid_marker_on_granular_map": {
+			Ops: []Operation{
+				Apply{
+					Manager: "m1",
+					Object: `
+						granularMap: {k8s_io__value: unset}
+					`,
+					APIVersion: "v1",
+					Error:      "failed to extract markers: .granularMap: markers are only allowed on atomic maps and associative list entries",
+				},
+			},
+		},
+		"invalid_marker_on_associative_list": {
+			Ops: []Operation{
+				Apply{
+					Manager: "m1",
+					Object: `
+						associativeList: {k8s_io__value: unset}
+					`,
+					APIVersion: "v1",
+					Error:      "failed to extract markers: .associativeList: markers are only allowed on atomic lists",
+				},
+			},
+		},
+		"invalid_marker_in_atomic_list": {
+			Ops: []Operation{
+				Apply{
+					Manager: "m1",
+					Object: `
+						atomicList: [
+							{k8s_io__value: unset}
+						]
+					`,
+					APIVersion: "v1",
+					Error:      "failed to extract markers: .atomicList: markers are not allowed in the contents of atomics",
+				},
+			},
+		},
+		"invalid_marker_in_atomic_map": {
+			Ops: []Operation{
+				Apply{
+					Manager: "m1",
+					Object: `
+						atomicMap: {k1: {k8s_io__value: unset}}
+					`,
+					APIVersion: "v1",
+					Error:      "failed to extract markers: .atomicMap: markers are not allowed in the contents of atomics",
+				},
+			},
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			// We don't use TestOptionCombinations because we expect these tests to pass with EnableUnsetMarkers=true
+			test.EnableUnsetMarkers = true
+			if err := test.Test(unsetFieldsParser); err != nil {
+				t.Fatal(err)
+			}
+		})
+	}
+}

--- a/typed/helpers_test.go
+++ b/typed/helpers_test.go
@@ -1,7 +1,6 @@
 package typed_test
 
 import (
-	"strings"
 	"testing"
 
 	"sigs.k8s.io/structured-merge-diff/v4/internal/fixture"
@@ -38,10 +37,8 @@ func TestInvalidOverride(t *testing.T) {
 			},
 		},
 		APIVersion: "v1",
+		Error:      "no type found matching: inlined type",
 	}
 
-	if err := test.Test(sameVersionParser); err == nil ||
-		!strings.Contains(err.Error(), "no type found matching: inlined type") {
-		t.Fatal(err)
-	}
+	test.TestOptionCombinations(t, sameVersionParser)
 }

--- a/typed/markers.go
+++ b/typed/markers.go
@@ -1,0 +1,321 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package typed
+
+import (
+	"fmt"
+	"sync"
+
+	"sigs.k8s.io/structured-merge-diff/v4/fieldpath"
+	"sigs.k8s.io/structured-merge-diff/v4/schema"
+	"sigs.k8s.io/structured-merge-diff/v4/value"
+)
+
+const (
+	// markerKey is the key used to store marker values in the object.
+	markerKey = "k8s_io__value"
+
+	// unsetMarkerValue is the value used to indicate that a marker is unset.
+	unsetMarkerValue = "unset"
+)
+
+var mPool = sync.Pool{
+	New: func() interface{} { return &markerExtractorWalker{} },
+}
+
+func (tv TypedValue) markerExtractorWalker() *markerExtractorWalker {
+	v := mPool.Get().(*markerExtractorWalker)
+	v.value = tv.value
+	v.schema = tv.schema
+	v.typeRef = tv.typeRef
+	v.unsetMarkers = &fieldpath.Set{}
+	v.orphanedFields = &fieldpath.Set{}
+	if v.allocator == nil {
+		v.allocator = value.NewFreelistAllocator()
+	}
+	return v
+}
+
+func (v *markerExtractorWalker) finished() {
+	v.schema = nil
+	v.typeRef = schema.TypeRef{}
+	v.path = nil
+	v.unsetMarkers = nil
+	v.orphanedFields = nil
+	mPool.Put(v)
+}
+
+type markerExtractorWalker struct {
+	value   value.Value
+	schema  *schema.Schema
+	typeRef schema.TypeRef
+
+	unsetMarkers   *fieldpath.Set
+	orphanedFields *fieldpath.Set // Map or list fields that only contain marker children.
+
+	path                      fieldpath.Path
+	parentElementRelationship []*schema.ElementRelationship // Track the element relationships of parents for marker validation.
+
+	// Allocate only as many walkers as needed for the depth by storing them here.
+	spareWalkers *[]*markerExtractorWalker
+	allocator    value.Allocator
+}
+
+func (v *markerExtractorWalker) prepareDescent(pe fieldpath.PathElement, tr schema.TypeRef) *markerExtractorWalker {
+	if v.spareWalkers == nil {
+		// first descent.
+		v.spareWalkers = &[]*markerExtractorWalker{}
+	}
+	var v2 *markerExtractorWalker
+	if n := len(*v.spareWalkers); n > 0 {
+		v2, *v.spareWalkers = (*v.spareWalkers)[n-1], (*v.spareWalkers)[:n-1]
+	} else {
+		v2 = &markerExtractorWalker{}
+	}
+	*v2 = *v
+	v2.typeRef = tr
+	v2.path = append(v2.path, pe)
+
+	// Track the element relationships of parents
+	v2.parentElementRelationship = append(v2.parentElementRelationship, v.resolveElementRelationship())
+	return v2
+}
+
+func (v *markerExtractorWalker) finishDescent(v2 *markerExtractorWalker) {
+	// if the descent caused a realloc, ensure that we reuse the buffer
+	// for the next sibling.
+	v.path = v2.path[:len(v2.path)-1]
+	v.parentElementRelationship = v2.parentElementRelationship[:len(v2.parentElementRelationship)-1]
+	*v.spareWalkers = append(*v.spareWalkers, v2)
+}
+
+func (v *markerExtractorWalker) extractMarkers() ValidationErrors {
+	return resolveSchema(v.schema, v.typeRef, v.value, v)
+}
+
+func (v *markerExtractorWalker) resolveElementRelationship() *schema.ElementRelationship {
+	if v.typeRef.ElementRelationship != nil {
+		return v.typeRef.ElementRelationship
+	} else if resolvedType, ok := v.schema.Resolve(v.typeRef); ok {
+		if resolvedType.Map != nil {
+			return &resolvedType.Map.ElementRelationship
+		} else if resolvedType.List != nil {
+			return &resolvedType.List.ElementRelationship
+		}
+	}
+	return nil
+}
+
+func (v *markerExtractorWalker) nearestElementRelationship() *schema.ElementRelationship {
+	for i := len(v.parentElementRelationship) - 1; i >= 0; i-- {
+		if v.parentElementRelationship[i] != nil {
+			return v.parentElementRelationship[i]
+		}
+	}
+	return nil
+}
+
+func (v *markerExtractorWalker) nearestElementRelationshipIs(relationship schema.ElementRelationship) bool {
+	rel := v.nearestElementRelationship()
+	return rel != nil && *rel == relationship
+}
+
+// validateMarkerLocation returns true if the current value is a marker and false otherwise.
+// It the value is a marker, it returns a list of errors if the marker is not in a valid location.
+func (v *markerExtractorWalker) validateMarkerLocation(t interface{}) (bool, ValidationErrors) {
+	isMarker, errs := v.validateUnsetMarker()
+	if !isMarker {
+		return false, errs
+	}
+
+	// Check if we're inside an atomic structure first
+	if v.nearestElementRelationshipIs(schema.Atomic) {
+		return false, ValidationErrors{{ErrorMessage: "markers are not allowed in the contents of atomics"}}.WithPath(v.path[:len(v.path)-1].String())
+	}
+
+	switch t := t.(type) {
+	case *schema.Map:
+		if v.nearestElementRelationshipIs(schema.Associative) {
+			return true, nil
+		}
+		if t.ElementRelationship != schema.Atomic {
+			return false, ValidationErrors{{ErrorMessage: "markers are only allowed on atomic maps and associative list entries"}}.WithPath(v.path.String())
+		}
+	case *schema.List:
+		if t.ElementRelationship != schema.Atomic {
+			return false, ValidationErrors{{ErrorMessage: "markers are only allowed on atomic lists"}}.WithPath(v.path.String())
+		}
+	case *schema.Scalar:
+		// No additional checks needed since we already checked for atomic above
+	default:
+		return false, ValidationErrors{{ErrorMessage: fmt.Sprintf("markers are only allowed on unrecognized type: %T", t)}}.WithPath(v.path.String())
+	}
+	return true, nil
+}
+
+func (v *markerExtractorWalker) doScalar(t *schema.Scalar) ValidationErrors {
+	isMarker, errs := v.validateMarkerLocation(t)
+	if errs != nil {
+		return errs
+	}
+	if isMarker {
+		v.unsetMarkers.Insert(v.path)
+	}
+	return nil
+}
+
+func (v *markerExtractorWalker) visitListItems(t *schema.List, list value.List) (errs ValidationErrors) {
+	if list.Length() == 0 {
+		return nil
+	}
+
+	markerCount := 0
+	for i := 0; i < list.Length(); i++ {
+		child := list.At(i)
+		pe, _ := listItemToPathElement(v.allocator, v.schema, t, child)
+
+		v2 := v.prepareDescent(pe, t.ElementType)
+		v2.value = child
+		errs = append(errs, v2.extractMarkers()...)
+		v.finishDescent(v2)
+
+		if v2.unsetMarkers.Has(v2.path) {
+			markerCount++
+		}
+	}
+	if markerCount == list.Length() {
+		v.orphanedFields.Insert(v.path)
+	}
+	return errs
+}
+
+func (v *markerExtractorWalker) validateUnsetMarker() (bool, ValidationErrors) {
+	marker, ok := getMarker(v.value)
+	if !ok {
+		return false, nil
+	}
+	if marker != unsetMarkerValue {
+		// Should never happen since validation already checks for allowed marker values.
+		return false, ValidationErrors{{ErrorMessage: fmt.Sprintf("Invalid marker: %v", marker)}}.WithPath(v.path.String())
+	}
+	return true, nil
+}
+
+func isUnsetMarker(v value.Value) bool {
+	marker, ok := getMarker(v)
+	if !ok {
+		return false
+	}
+	return marker == unsetMarkerValue
+}
+
+func getMarker(v value.Value) (string, bool) {
+	if v.IsMap() {
+		m := v.AsMap()
+		if val, ok := m.Get(markerKey); ok && val.IsString() {
+			return val.AsString(), true
+		}
+	}
+	return "", false
+}
+
+func (v *markerExtractorWalker) doList(t *schema.List) (errs ValidationErrors) {
+	list, _ := listValue(v.allocator, v.value)
+	if list != nil {
+		defer v.allocator.Free(list)
+	}
+
+	isMarker, errs := v.validateMarkerLocation(t)
+	if errs != nil {
+		return errs
+	}
+	if isMarker {
+		v.unsetMarkers.Insert(v.path)
+		return nil
+	}
+
+	if list == nil {
+		return nil
+	}
+
+	errs = v.visitListItems(t, list)
+	return errs
+}
+
+func (v *markerExtractorWalker) visitMapItems(t *schema.Map, m value.Map) (errs ValidationErrors) {
+	size := m.Length()
+	if size == 0 {
+		return nil
+	}
+	markerCount := 0
+	m.Iterate(func(key string, val value.Value) bool {
+		pe := fieldpath.PathElement{FieldName: &key}
+
+		tr := t.ElementType
+		if sf, ok := t.FindField(key); ok {
+			tr = sf.Type
+		}
+		v2 := v.prepareDescent(pe, tr)
+		v2.value = val
+		errs = append(errs, v2.extractMarkers()...)
+		v.finishDescent(v2)
+
+		if v2.unsetMarkers.Has(v2.path) {
+			markerCount++
+		}
+
+		return true
+	})
+	if markerCount == m.Length() {
+		v.orphanedFields.Insert(v.path)
+	}
+	return errs
+}
+
+func (v *markerExtractorWalker) doMap(t *schema.Map) (errs ValidationErrors) {
+	isMarker, errs := v.validateMarkerLocation(t)
+	if errs != nil {
+		return errs
+	}
+	if isMarker {
+		v.unsetMarkers.Insert(v.path)
+		return nil
+	}
+
+	m, _ := mapValue(v.allocator, v.value)
+	if m != nil {
+		defer v.allocator.Free(m)
+	}
+
+	if m == nil {
+		return nil
+	}
+
+	if t.ElementRelationship == schema.Atomic {
+		// If the map is atomic, we need to check for unset markers before we descend further.
+		m.Iterate(func(key string, val value.Value) bool {
+			if isUnsetMarker(val) {
+				errs = append(errs, ValidationErrors{{ErrorMessage: "markers are not allowed in the contents of atomics"}}.WithPath(v.path.String())...)
+			}
+			return true
+		})
+		return errs
+	}
+
+	errs = v.visitMapItems(t, m)
+	return errs
+}

--- a/typed/markers_test.go
+++ b/typed/markers_test.go
@@ -1,0 +1,274 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package typed_test
+
+import (
+	"strings"
+	"testing"
+
+	"sigs.k8s.io/structured-merge-diff/v4/fieldpath"
+	"sigs.k8s.io/structured-merge-diff/v4/typed"
+)
+
+func TestExtractItems(t *testing.T) {
+	tests := []struct {
+		name           string
+		schema         typed.YAMLObject
+		value          typed.YAMLObject
+		expectedUnset  *fieldpath.Set
+		expectedValue  typed.YAMLObject
+		expectedErrors typed.ValidationErrors
+	}{
+		{
+			name: "scalar on marker",
+			schema: `
+              types:
+              - name: TestType
+                map:
+                  fields:
+                    - name: field
+                      type:
+                        scalar: string`,
+			value:         `{"field": {"k8s_io__value": "unset"}}`,
+			expectedUnset: _NS(_P("field")),
+			expectedValue: `{}`,
+		},
+		{
+			name: "marker on atomic list",
+			schema: `
+              types:
+              - name: TestType
+                map:
+                  fields:
+                  - name: atomicList
+                    type:
+                      list:
+                        elementType:
+                          scalar: string
+                        elementRelationship: atomic`,
+			value:         `{"atomicList": {"k8s_io__value": "unset"}}`,
+			expectedUnset: _NS(_P("atomicList")),
+			expectedValue: `{}`,
+		},
+		{
+			name: "invalid marker in atomic list element",
+			schema: `
+              types:
+              - name: TestType
+                map:
+                  fields:
+                  - name: atomicList
+                    type:
+                      list:
+                        elementType:
+                          scalar: string
+                        elementRelationship: atomic`,
+			value: `{"atomicList": ["foo", {"k8s_io__value": "unset"}]}`,
+			expectedErrors: typed.ValidationErrors{{
+				ErrorMessage: "failed to extract markers: .atomicList: markers are not allowed in the contents of atomics",
+			}},
+		},
+		{
+			name: "marker on atomic map",
+			schema: `
+              types:
+              - name: TestType
+                map:
+                  fields:
+                  - name: atomicMap
+                    type:
+                      map:
+                        elementType:
+                          scalar: string
+                        elementRelationship: atomic`,
+			value:         `{"atomicMap": {"k8s_io__value": "unset"}}`,
+			expectedUnset: _NS(_P("atomicMap")),
+			expectedValue: `{}`,
+		},
+		{
+			name: "invalid marker in atomic map value",
+			schema: `
+              types:
+              - name: TestType
+                map:
+                  fields:
+                  - name: atomicMap
+                    type:
+                      map:
+                        elementType:
+                          scalar: string
+                        elementRelationship: atomic`,
+			value: `{"atomicMap": {"key": {"k8s_io__value": "unset"}}}`,
+			expectedErrors: typed.ValidationErrors{{
+				ErrorMessage: "failed to extract markers: .atomicMap: markers are not allowed in the contents of atomics",
+			}},
+		},
+		{
+			name: "marker in atomic struct",
+			schema: `
+              types:
+              - name: TestType
+                map:
+                  fields:
+                  - name: atomicMap
+                    type:
+                      map:
+                        fields:
+                        - name: field1
+                          type:
+                            scalar: string
+                        - name: field2
+                          type:
+                            scalar: string
+                        elementRelationship: atomic`,
+			value:         `{"atomicMap": {"k8s_io__value": "unset"}}`,
+			expectedUnset: _NS(_P("atomicMap")),
+			expectedValue: `{}`,
+		},
+		{
+			name: "invalid marker in atomic struct field",
+			schema: `
+              types:
+              - name: TestType
+                map:
+                  fields:
+                  - name: atomicMap
+                    type:
+                      map:
+                        fields:
+                        - name: field1
+                          type:
+                            scalar: string
+                        - name: field2
+                          type:
+                            scalar: string
+                        elementRelationship: atomic`,
+			value: `{"atomicMap": {"field1": {"k8s_io__value": "unset"}, "field2": "value"}}`,
+			expectedErrors: typed.ValidationErrors{{
+				ErrorMessage: "failed to extract markers: .atomicMap: markers are not allowed in the contents of atomics",
+			}},
+		},
+		{
+			name: "marker in separable map",
+			schema: `
+              types:
+              - name: TestType
+                map:
+                  elementType:
+                    scalar: string
+                  elementRelationship: separable`,
+			value:         `{"key": {"k8s_io__value": "unset"}}`,
+			expectedUnset: _NS(_P("key")),
+			expectedValue: `{}`,
+		},
+		{
+			name: "marker in associative list",
+			schema: `
+              types:
+              - name: TestType
+                map:
+                  fields:
+                  - name: items
+                    type:
+                      list:
+                        elementType:
+                          map:
+                            fields:
+                            - name: key
+                              type:
+                                scalar: string
+                            - name: value
+                              type:
+                                scalar: string
+                        elementRelationship: associative
+                        keys: ["key"]`,
+			value:         `{"items": [{"key": "k1", "value": {"k8s_io__value": "unset"}}]}`,
+			expectedUnset: _NS(_P("items", _KBF("key", "k1"), "value")),
+			expectedValue: `{"items": [{"key": "k1"}]}`,
+		},
+		{
+			name: "map is orphaned after extracting markers", // The orphaned map should be removed
+			schema: `
+              types:
+              - name: TestType
+                map:
+                  fields:
+                  - name: nested
+                    type:
+                      map:
+                        fields:
+                        - name: field1
+                          type:
+                            scalar: string
+                        - name: field2
+                          type:
+                            scalar: string`,
+			value:         `{"nested": {"field1": {"k8s_io__value": "unset"}, "field2": {"k8s_io__value": "unset"}}}`,
+			expectedUnset: _NS(_P("nested", "field1"), _P("nested", "field2")),
+			expectedValue: `{}`,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			parser, err := typed.NewParser(tc.schema)
+			if err != nil {
+				t.Fatalf("failed to create schema: %v", err)
+			}
+			tv, err := parser.Type("TestType").FromYAML(tc.value, typed.AllowDuplicates, typed.AllowMarkers)
+			if err != nil {
+				t.Fatalf("Failed to parse value: %v", err)
+			}
+
+			objectNoMarkers, markers, err := tv.ExtractMarkers()
+
+			if tc.expectedErrors != nil {
+				for _, expectedErr := range tc.expectedErrors {
+					if err == nil {
+						t.Errorf("Expected errors '%v' but got none", tc.expectedErrors)
+					} else if !strings.Contains(err.Error(), expectedErr.ErrorMessage) {
+						t.Errorf("Expected errors %v but got %v", tc.expectedErrors, err)
+					}
+				}
+				return
+			}
+
+			if err != nil {
+				t.Fatalf("Expected no errors but got %v", err)
+			}
+
+			if tc.expectedUnset != nil {
+				if !tc.expectedUnset.Equals(markers.Unset) {
+					t.Errorf("Expected unset markers %v but got %v", tc.expectedUnset, markers.Unset)
+				}
+			}
+
+			expectedValue, err := parser.Type("TestType").FromYAML(tc.expectedValue, typed.AllowDuplicates)
+			if err != nil {
+				t.Fatalf("Failed to parse value: %v", err)
+			}
+
+			compare, err := objectNoMarkers.Compare(expectedValue)
+			if err != nil {
+				t.Fatalf("Failed to compare values: %v", err)
+			}
+			if !compare.IsSame() {
+				t.Errorf("Expected value %v but got %v", tc.expectedValue, objectNoMarkers.AsValue())
+			}
+		})
+	}
+}


### PR DESCRIPTION
This implements the SMD bits of https://github.com/kubernetes/enhancements/pull/5052.

All the new functionality is opt-in. No default behavior is changed. This is extensively tested.

Benchmark data suggests negligible performance impact: https://gist.github.com/jpbetz/df3806a5605a174597a3d0d6459125c5
