### PR TITLE
fix: update error formatting and test naming

### DIFF
--- a/fieldpath/managers_test.go
+++ b/fieldpath/managers_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package fieldpath_test
 
 import (
-	"fmt"
 	"reflect"
 	"testing"
 
@@ -155,7 +154,7 @@ func TestManagersEquals(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		t.Run(fmt.Sprintf(test.name), func(t *testing.T) {
+		t.Run(test.name, func(t *testing.T) {
 			want := test.out
 			got := test.lhs.Difference(test.rhs)
 			if !reflect.DeepEqual(want, got) {
@@ -273,7 +272,7 @@ func TestManagersDifference(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		t.Run(fmt.Sprintf(test.name), func(t *testing.T) {
+		t.Run(test.name, func(t *testing.T) {
 			equal := test.lhs.Equals(test.rhs)
 			if test.equal && !equal {
 				difference := test.lhs.Difference(test.rhs)

--- a/internal/cli/operation.go
+++ b/internal/cli/operation.go
@@ -153,7 +153,7 @@ func (c compare) Execute(w io.Writer) error {
 	// TODO: I think it'd be neat if we actually emitted a machine-readable
 	// format.
 
-	_, err = fmt.Fprintf(w, got.String())
+	_, err = fmt.Fprint(w, got.String())
 
 	return err
 }

--- a/typed/validate.go
+++ b/typed/validate.go
@@ -157,7 +157,7 @@ func (v *validatingObjectWalker) visitListItems(t *schema.List, list value.List)
 func (v *validatingObjectWalker) doList(t *schema.List) (errs ValidationErrors) {
 	list, err := listValue(v.allocator, v.value)
 	if err != nil {
-		return errorf(err.Error())
+		return errorf("%v", err)
 	}
 
 	if list == nil {
@@ -193,7 +193,7 @@ func (v *validatingObjectWalker) visitMapItems(t *schema.Map, m value.Map) (errs
 func (v *validatingObjectWalker) doMap(t *schema.Map) (errs ValidationErrors) {
 	m, err := mapValue(v.allocator, v.value)
 	if err != nil {
-		return errorf(err.Error())
+		return errorf("%v", err)
 	}
 	if m == nil {
 		return nil


### PR DESCRIPTION
This is for addressing the change in go1.24
https://github.com/golang/go/issues/60529, which suppress the error on non-constant format and no args.

Fix: #281 