### PR TITLE
bump go version to 1.19+

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,9 +3,13 @@ module sigs.k8s.io/structured-merge-diff/v4
 require (
 	github.com/google/go-cmp v0.5.9
 	github.com/json-iterator/go v1.1.12
-	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	sigs.k8s.io/randfill v0.0.0-20250304075658-069ef1bbf016
 	sigs.k8s.io/yaml v1.4.0
 )
 
-go 1.13
+require (
+	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
+	github.com/modern-go/reflect2 v1.0.2 // indirect
+)
+
+go 1.19


### PR DESCRIPTION
go is currently on 1.24 / 1.23, 1.19 is old enough to still support back to Kubernetes release-1.23 branch (10 releases behind the upcoming 1.33)

switching to a newer go version gives us improvements to module management

this is `go mod tidy` after bumping the `go` statement to 1.19