### PR TITLE
stop exporting jsoniter based apis

### DIFF
--- a/fieldpath/element.go
+++ b/fieldpath/element.go
@@ -21,7 +21,7 @@ import (
 	"sort"
 	"strings"
 
-	"sigs.k8s.io/structured-merge-diff/v4/value"
+	"sigs.k8s.io/structured-merge-diff/v6/value"
 )
 
 // PathElement describes how to select a child field given a containing object.

--- a/fieldpath/element_test.go
+++ b/fieldpath/element_test.go
@@ -19,7 +19,7 @@ package fieldpath
 import (
 	"testing"
 
-	"sigs.k8s.io/structured-merge-diff/v4/value"
+	"sigs.k8s.io/structured-merge-diff/v6/value"
 )
 
 func TestPathElementSet(t *testing.T) {

--- a/fieldpath/fromvalue.go
+++ b/fieldpath/fromvalue.go
@@ -17,7 +17,7 @@ limitations under the License.
 package fieldpath
 
 import (
-	"sigs.k8s.io/structured-merge-diff/v4/value"
+	"sigs.k8s.io/structured-merge-diff/v6/value"
 )
 
 // SetFromValue creates a set containing every leaf field mentioned in v.

--- a/fieldpath/fromvalue_test.go
+++ b/fieldpath/fromvalue_test.go
@@ -19,7 +19,7 @@ package fieldpath
 import (
 	"testing"
 
-	"sigs.k8s.io/structured-merge-diff/v4/value"
+	"sigs.k8s.io/structured-merge-diff/v6/value"
 	yaml "sigs.k8s.io/yaml/goyaml.v2"
 )
 

--- a/fieldpath/managers_test.go
+++ b/fieldpath/managers_test.go
@@ -20,7 +20,7 @@ import (
 	"reflect"
 	"testing"
 
-	"sigs.k8s.io/structured-merge-diff/v4/fieldpath"
+	"sigs.k8s.io/structured-merge-diff/v6/fieldpath"
 )
 
 var (

--- a/fieldpath/path.go
+++ b/fieldpath/path.go
@@ -20,7 +20,7 @@ import (
 	"fmt"
 	"strings"
 
-	"sigs.k8s.io/structured-merge-diff/v4/value"
+	"sigs.k8s.io/structured-merge-diff/v6/value"
 )
 
 // Path describes how to select a potentially deeply-nested child field given a

--- a/fieldpath/path_test.go
+++ b/fieldpath/path_test.go
@@ -19,7 +19,7 @@ package fieldpath
 import (
 	"testing"
 
-	"sigs.k8s.io/structured-merge-diff/v4/value"
+	"sigs.k8s.io/structured-merge-diff/v6/value"
 )
 
 var (

--- a/fieldpath/pathelementmap.go
+++ b/fieldpath/pathelementmap.go
@@ -19,7 +19,7 @@ package fieldpath
 import (
 	"sort"
 
-	"sigs.k8s.io/structured-merge-diff/v4/value"
+	"sigs.k8s.io/structured-merge-diff/v6/value"
 )
 
 // PathElementValueMap is a map from PathElement to value.Value.

--- a/fieldpath/pathelementmap_test.go
+++ b/fieldpath/pathelementmap_test.go
@@ -19,7 +19,7 @@ package fieldpath
 import (
 	"testing"
 
-	"sigs.k8s.io/structured-merge-diff/v4/value"
+	"sigs.k8s.io/structured-merge-diff/v6/value"
 )
 
 func TestPathElementValueMap(t *testing.T) {

--- a/fieldpath/serialize-pe.go
+++ b/fieldpath/serialize-pe.go
@@ -54,6 +54,24 @@ var (
 	peSepBytes      = []byte(peSeparator)
 )
 
+// readJSONIter reads a Value from a JSON iterator.
+// DO NOT EXPORT
+// TODO: eliminate this https://github.com/kubernetes-sigs/structured-merge-diff/issues/202
+func readJSONIter(iter *jsoniter.Iterator) (value.Value, error) {
+	v := iter.Read()
+	if iter.Error != nil && iter.Error != io.EOF {
+		return nil, iter.Error
+	}
+	return value.NewValueInterface(v), nil
+}
+
+// writeJSONStream writes a value into a JSON stream.
+// DO NOT EXPORT
+// TODO: eliminate this https://github.com/kubernetes-sigs/structured-merge-diff/issues/202
+func writeJSONStream(v value.Value, stream *jsoniter.Stream) {
+	stream.WriteVal(v.Unstructured())
+}
+
 // DeserializePathElement parses a serialized path element
 func DeserializePathElement(s string) (PathElement, error) {
 	b := []byte(s)
@@ -75,7 +93,7 @@ func DeserializePathElement(s string) (PathElement, error) {
 	case peValueSepBytes[0]:
 		iter := readPool.BorrowIterator(b)
 		defer readPool.ReturnIterator(iter)
-		v, err := value.ReadJSONIter(iter)
+		v, err := readJSONIter(iter)
 		if err != nil {
 			return PathElement{}, err
 		}
@@ -86,7 +104,7 @@ func DeserializePathElement(s string) (PathElement, error) {
 		fields := value.FieldList{}
 
 		iter.ReadObjectCB(func(iter *jsoniter.Iterator, key string) bool {
-			v, err := value.ReadJSONIter(iter)
+			v, err := readJSONIter(iter)
 			if err != nil {
 				iter.Error = err
 				return false
@@ -141,14 +159,14 @@ func serializePathElementToWriter(w io.Writer, pe PathElement) error {
 				stream.WriteMore()
 			}
 			stream.WriteObjectField(field.Name)
-			value.WriteJSONStream(field.Value, stream)
+			writeJSONStream(field.Value, stream)
 		}
 		stream.WriteObjectEnd()
 	case pe.Value != nil:
 		if _, err := stream.Write(peValueSepBytes); err != nil {
 			return err
 		}
-		value.WriteJSONStream(*pe.Value, stream)
+		writeJSONStream(*pe.Value, stream)
 	case pe.Index != nil:
 		if _, err := stream.Write(peIndexSepBytes); err != nil {
 			return err

--- a/fieldpath/serialize-pe.go
+++ b/fieldpath/serialize-pe.go
@@ -24,7 +24,7 @@ import (
 	"strings"
 
 	jsoniter "github.com/json-iterator/go"
-	"sigs.k8s.io/structured-merge-diff/v4/value"
+	"sigs.k8s.io/structured-merge-diff/v6/value"
 )
 
 var ErrUnknownPathElementType = errors.New("unknown path element type")

--- a/fieldpath/set.go
+++ b/fieldpath/set.go
@@ -18,11 +18,12 @@ package fieldpath
 
 import (
 	"fmt"
-	"sigs.k8s.io/structured-merge-diff/v4/value"
 	"sort"
 	"strings"
 
-	"sigs.k8s.io/structured-merge-diff/v4/schema"
+	"sigs.k8s.io/structured-merge-diff/v6/value"
+
+	"sigs.k8s.io/structured-merge-diff/v6/schema"
 )
 
 // Set identifies a set of fields.

--- a/fieldpath/set_test.go
+++ b/fieldpath/set_test.go
@@ -20,10 +20,11 @@ import (
 	"bytes"
 	"fmt"
 	"math/rand"
-	"sigs.k8s.io/structured-merge-diff/v4/value"
 	"testing"
 
-	"sigs.k8s.io/structured-merge-diff/v4/schema"
+	"sigs.k8s.io/structured-merge-diff/v6/value"
+
+	"sigs.k8s.io/structured-merge-diff/v6/schema"
 	yaml "sigs.k8s.io/yaml/goyaml.v2"
 )
 

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module sigs.k8s.io/structured-merge-diff/v4
+module sigs.k8s.io/structured-merge-diff/v6
 
 require (
 	github.com/google/go-cmp v0.5.9

--- a/internal/cli/operation.go
+++ b/internal/cli/operation.go
@@ -21,8 +21,8 @@ import (
 	"io"
 	"io/ioutil"
 
-	"sigs.k8s.io/structured-merge-diff/v4/typed"
-	"sigs.k8s.io/structured-merge-diff/v4/value"
+	"sigs.k8s.io/structured-merge-diff/v6/typed"
+	"sigs.k8s.io/structured-merge-diff/v6/value"
 )
 
 type Operation interface {

--- a/internal/cli/options.go
+++ b/internal/cli/options.go
@@ -24,7 +24,7 @@ import (
 	"io/ioutil"
 	"os"
 
-	"sigs.k8s.io/structured-merge-diff/v4/typed"
+	"sigs.k8s.io/structured-merge-diff/v6/typed"
 )
 
 var (

--- a/internal/fixture/state.go
+++ b/internal/fixture/state.go
@@ -22,9 +22,9 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 
-	"sigs.k8s.io/structured-merge-diff/v4/fieldpath"
-	"sigs.k8s.io/structured-merge-diff/v4/merge"
-	"sigs.k8s.io/structured-merge-diff/v4/typed"
+	"sigs.k8s.io/structured-merge-diff/v6/fieldpath"
+	"sigs.k8s.io/structured-merge-diff/v6/merge"
+	"sigs.k8s.io/structured-merge-diff/v6/typed"
 )
 
 // For the sake of tests, a parser is something that can retrieve a

--- a/internal/fixture/state_test.go
+++ b/internal/fixture/state_test.go
@@ -20,7 +20,7 @@ import (
 	"fmt"
 	"testing"
 
-	"sigs.k8s.io/structured-merge-diff/v4/typed"
+	"sigs.k8s.io/structured-merge-diff/v6/typed"
 )
 
 func TestFixTabs(t *testing.T) {

--- a/merge/conflict.go
+++ b/merge/conflict.go
@@ -21,7 +21,7 @@ import (
 	"sort"
 	"strings"
 
-	"sigs.k8s.io/structured-merge-diff/v4/fieldpath"
+	"sigs.k8s.io/structured-merge-diff/v6/fieldpath"
 )
 
 // Conflict is a conflict on a specific field with the current manager of

--- a/merge/conflict_test.go
+++ b/merge/conflict_test.go
@@ -19,9 +19,9 @@ package merge_test
 import (
 	"testing"
 
-	"sigs.k8s.io/structured-merge-diff/v4/fieldpath"
-	"sigs.k8s.io/structured-merge-diff/v4/merge"
-	"sigs.k8s.io/structured-merge-diff/v4/value"
+	"sigs.k8s.io/structured-merge-diff/v6/fieldpath"
+	"sigs.k8s.io/structured-merge-diff/v6/merge"
+	"sigs.k8s.io/structured-merge-diff/v6/value"
 )
 
 var (

--- a/merge/deduced_test.go
+++ b/merge/deduced_test.go
@@ -19,9 +19,9 @@ package merge_test
 import (
 	"testing"
 
-	"sigs.k8s.io/structured-merge-diff/v4/fieldpath"
-	. "sigs.k8s.io/structured-merge-diff/v4/internal/fixture"
-	"sigs.k8s.io/structured-merge-diff/v4/merge"
+	"sigs.k8s.io/structured-merge-diff/v6/fieldpath"
+	. "sigs.k8s.io/structured-merge-diff/v6/internal/fixture"
+	"sigs.k8s.io/structured-merge-diff/v6/merge"
 )
 
 func TestDeduced(t *testing.T) {

--- a/merge/default_keys_test.go
+++ b/merge/default_keys_test.go
@@ -16,10 +16,10 @@ package merge_test
 import (
 	"testing"
 
-	"sigs.k8s.io/structured-merge-diff/v4/fieldpath"
-	. "sigs.k8s.io/structured-merge-diff/v4/internal/fixture"
-	"sigs.k8s.io/structured-merge-diff/v4/merge"
-	"sigs.k8s.io/structured-merge-diff/v4/typed"
+	"sigs.k8s.io/structured-merge-diff/v6/fieldpath"
+	. "sigs.k8s.io/structured-merge-diff/v6/internal/fixture"
+	"sigs.k8s.io/structured-merge-diff/v6/merge"
+	"sigs.k8s.io/structured-merge-diff/v6/typed"
 )
 
 // portListParser sets the default value of key "protocol" to "TCP"

--- a/merge/duplicates_test.go
+++ b/merge/duplicates_test.go
@@ -19,10 +19,10 @@ package merge_test
 import (
 	"testing"
 
-	"sigs.k8s.io/structured-merge-diff/v4/fieldpath"
-	. "sigs.k8s.io/structured-merge-diff/v4/internal/fixture"
-	"sigs.k8s.io/structured-merge-diff/v4/merge"
-	"sigs.k8s.io/structured-merge-diff/v4/typed"
+	"sigs.k8s.io/structured-merge-diff/v6/fieldpath"
+	. "sigs.k8s.io/structured-merge-diff/v6/internal/fixture"
+	"sigs.k8s.io/structured-merge-diff/v6/merge"
+	"sigs.k8s.io/structured-merge-diff/v6/typed"
 )
 
 var duplicatesParser = func() Parser {

--- a/merge/extract_apply_test.go
+++ b/merge/extract_apply_test.go
@@ -19,9 +19,9 @@ package merge_test
 import (
 	"testing"
 
-	"sigs.k8s.io/structured-merge-diff/v4/fieldpath"
-	. "sigs.k8s.io/structured-merge-diff/v4/internal/fixture"
-	"sigs.k8s.io/structured-merge-diff/v4/typed"
+	"sigs.k8s.io/structured-merge-diff/v6/fieldpath"
+	. "sigs.k8s.io/structured-merge-diff/v6/internal/fixture"
+	"sigs.k8s.io/structured-merge-diff/v6/typed"
 )
 
 var extractParser = func() Parser {

--- a/merge/field_level_overrides_test.go
+++ b/merge/field_level_overrides_test.go
@@ -3,10 +3,10 @@ package merge_test
 import (
 	"testing"
 
-	"sigs.k8s.io/structured-merge-diff/v4/fieldpath"
-	"sigs.k8s.io/structured-merge-diff/v4/internal/fixture"
-	"sigs.k8s.io/structured-merge-diff/v4/merge"
-	"sigs.k8s.io/structured-merge-diff/v4/typed"
+	"sigs.k8s.io/structured-merge-diff/v6/fieldpath"
+	"sigs.k8s.io/structured-merge-diff/v6/internal/fixture"
+	"sigs.k8s.io/structured-merge-diff/v6/merge"
+	"sigs.k8s.io/structured-merge-diff/v6/typed"
 )
 
 func TestFieldLevelOverrides(t *testing.T) {

--- a/merge/ignore_test.go
+++ b/merge/ignore_test.go
@@ -19,8 +19,8 @@ package merge_test
 import (
 	"testing"
 
-	"sigs.k8s.io/structured-merge-diff/v4/fieldpath"
-	. "sigs.k8s.io/structured-merge-diff/v4/internal/fixture"
+	"sigs.k8s.io/structured-merge-diff/v6/fieldpath"
+	. "sigs.k8s.io/structured-merge-diff/v6/internal/fixture"
 )
 
 func TestIgnoreFilter(t *testing.T) {

--- a/merge/key_test.go
+++ b/merge/key_test.go
@@ -19,9 +19,9 @@ package merge_test
 import (
 	"testing"
 
-	"sigs.k8s.io/structured-merge-diff/v4/fieldpath"
-	. "sigs.k8s.io/structured-merge-diff/v4/internal/fixture"
-	"sigs.k8s.io/structured-merge-diff/v4/typed"
+	"sigs.k8s.io/structured-merge-diff/v6/fieldpath"
+	. "sigs.k8s.io/structured-merge-diff/v6/internal/fixture"
+	"sigs.k8s.io/structured-merge-diff/v6/typed"
 )
 
 var associativeListParser = func() Parser {

--- a/merge/leaf_test.go
+++ b/merge/leaf_test.go
@@ -19,10 +19,10 @@ package merge_test
 import (
 	"testing"
 
-	"sigs.k8s.io/structured-merge-diff/v4/fieldpath"
-	. "sigs.k8s.io/structured-merge-diff/v4/internal/fixture"
-	"sigs.k8s.io/structured-merge-diff/v4/merge"
-	"sigs.k8s.io/structured-merge-diff/v4/typed"
+	"sigs.k8s.io/structured-merge-diff/v6/fieldpath"
+	. "sigs.k8s.io/structured-merge-diff/v6/internal/fixture"
+	"sigs.k8s.io/structured-merge-diff/v6/merge"
+	"sigs.k8s.io/structured-merge-diff/v6/typed"
 )
 
 var leafFieldsParser = func() Parser {

--- a/merge/multiple_appliers_test.go
+++ b/merge/multiple_appliers_test.go
@@ -22,11 +22,11 @@ import (
 	"strings"
 	"testing"
 
-	"sigs.k8s.io/structured-merge-diff/v4/fieldpath"
-	. "sigs.k8s.io/structured-merge-diff/v4/internal/fixture"
-	"sigs.k8s.io/structured-merge-diff/v4/merge"
-	"sigs.k8s.io/structured-merge-diff/v4/typed"
-	"sigs.k8s.io/structured-merge-diff/v4/value"
+	"sigs.k8s.io/structured-merge-diff/v6/fieldpath"
+	. "sigs.k8s.io/structured-merge-diff/v6/internal/fixture"
+	"sigs.k8s.io/structured-merge-diff/v6/merge"
+	"sigs.k8s.io/structured-merge-diff/v6/typed"
+	"sigs.k8s.io/structured-merge-diff/v6/value"
 	yaml "sigs.k8s.io/yaml/goyaml.v2"
 )
 

--- a/merge/nested_test.go
+++ b/merge/nested_test.go
@@ -19,9 +19,9 @@ package merge_test
 import (
 	"testing"
 
-	"sigs.k8s.io/structured-merge-diff/v4/fieldpath"
-	. "sigs.k8s.io/structured-merge-diff/v4/internal/fixture"
-	"sigs.k8s.io/structured-merge-diff/v4/typed"
+	"sigs.k8s.io/structured-merge-diff/v6/fieldpath"
+	. "sigs.k8s.io/structured-merge-diff/v6/internal/fixture"
+	"sigs.k8s.io/structured-merge-diff/v6/typed"
 )
 
 var nestedTypeParser = func() Parser {

--- a/merge/obsolete_versions_test.go
+++ b/merge/obsolete_versions_test.go
@@ -20,10 +20,10 @@ import (
 	"fmt"
 	"testing"
 
-	"sigs.k8s.io/structured-merge-diff/v4/fieldpath"
-	. "sigs.k8s.io/structured-merge-diff/v4/internal/fixture"
-	"sigs.k8s.io/structured-merge-diff/v4/merge"
-	"sigs.k8s.io/structured-merge-diff/v4/typed"
+	"sigs.k8s.io/structured-merge-diff/v6/fieldpath"
+	. "sigs.k8s.io/structured-merge-diff/v6/internal/fixture"
+	"sigs.k8s.io/structured-merge-diff/v6/merge"
+	"sigs.k8s.io/structured-merge-diff/v6/typed"
 )
 
 // specificVersionConverter doesn't convert and return the exact same

--- a/merge/preserve_unknown_test.go
+++ b/merge/preserve_unknown_test.go
@@ -19,9 +19,9 @@ package merge_test
 import (
 	"testing"
 
-	"sigs.k8s.io/structured-merge-diff/v4/fieldpath"
-	. "sigs.k8s.io/structured-merge-diff/v4/internal/fixture"
-	"sigs.k8s.io/structured-merge-diff/v4/typed"
+	"sigs.k8s.io/structured-merge-diff/v6/fieldpath"
+	. "sigs.k8s.io/structured-merge-diff/v6/internal/fixture"
+	"sigs.k8s.io/structured-merge-diff/v6/typed"
 )
 
 var preserveUnknownParser = func() Parser {

--- a/merge/real_test.go
+++ b/merge/real_test.go
@@ -21,8 +21,8 @@ import (
 	"path/filepath"
 	"testing"
 
-	. "sigs.k8s.io/structured-merge-diff/v4/internal/fixture"
-	"sigs.k8s.io/structured-merge-diff/v4/typed"
+	. "sigs.k8s.io/structured-merge-diff/v6/internal/fixture"
+	"sigs.k8s.io/structured-merge-diff/v6/typed"
 )
 
 func testdata(file string) string {

--- a/merge/schema_change_test.go
+++ b/merge/schema_change_test.go
@@ -19,10 +19,10 @@ package merge_test
 import (
 	"testing"
 
-	"sigs.k8s.io/structured-merge-diff/v4/fieldpath"
-	. "sigs.k8s.io/structured-merge-diff/v4/internal/fixture"
-	"sigs.k8s.io/structured-merge-diff/v4/merge"
-	"sigs.k8s.io/structured-merge-diff/v4/typed"
+	"sigs.k8s.io/structured-merge-diff/v6/fieldpath"
+	. "sigs.k8s.io/structured-merge-diff/v6/internal/fixture"
+	"sigs.k8s.io/structured-merge-diff/v6/merge"
+	"sigs.k8s.io/structured-merge-diff/v6/typed"
 )
 
 var structParser = func() *typed.Parser {

--- a/merge/set_test.go
+++ b/merge/set_test.go
@@ -19,9 +19,9 @@ package merge_test
 import (
 	"testing"
 
-	"sigs.k8s.io/structured-merge-diff/v4/fieldpath"
-	. "sigs.k8s.io/structured-merge-diff/v4/internal/fixture"
-	"sigs.k8s.io/structured-merge-diff/v4/typed"
+	"sigs.k8s.io/structured-merge-diff/v6/fieldpath"
+	. "sigs.k8s.io/structured-merge-diff/v6/internal/fixture"
+	"sigs.k8s.io/structured-merge-diff/v6/typed"
 )
 
 var setFieldsParser = func() Parser {

--- a/merge/update.go
+++ b/merge/update.go
@@ -15,9 +15,10 @@ package merge
 
 import (
 	"fmt"
-	"sigs.k8s.io/structured-merge-diff/v4/fieldpath"
-	"sigs.k8s.io/structured-merge-diff/v4/typed"
-	"sigs.k8s.io/structured-merge-diff/v4/value"
+
+	"sigs.k8s.io/structured-merge-diff/v6/fieldpath"
+	"sigs.k8s.io/structured-merge-diff/v6/typed"
+	"sigs.k8s.io/structured-merge-diff/v6/value"
 )
 
 // Converter is an interface to the conversion logic. The converter

--- a/smd/main.go
+++ b/smd/main.go
@@ -22,7 +22,7 @@ import (
 	"flag"
 	"log"
 
-	"sigs.k8s.io/structured-merge-diff/v4/internal/cli"
+	"sigs.k8s.io/structured-merge-diff/v6/internal/cli"
 )
 
 func main() {

--- a/typed/compare.go
+++ b/typed/compare.go
@@ -20,9 +20,9 @@ import (
 	"fmt"
 	"strings"
 
-	"sigs.k8s.io/structured-merge-diff/v4/fieldpath"
-	"sigs.k8s.io/structured-merge-diff/v4/schema"
-	"sigs.k8s.io/structured-merge-diff/v4/value"
+	"sigs.k8s.io/structured-merge-diff/v6/fieldpath"
+	"sigs.k8s.io/structured-merge-diff/v6/schema"
+	"sigs.k8s.io/structured-merge-diff/v6/value"
 )
 
 // Comparison is the return value of a TypedValue.Compare() operation.

--- a/typed/comparison_test.go
+++ b/typed/comparison_test.go
@@ -3,8 +3,8 @@ package typed_test
 import (
 	"testing"
 
-	"sigs.k8s.io/structured-merge-diff/v4/fieldpath"
-	"sigs.k8s.io/structured-merge-diff/v4/typed"
+	"sigs.k8s.io/structured-merge-diff/v6/fieldpath"
+	"sigs.k8s.io/structured-merge-diff/v6/typed"
 )
 
 func TestComparisonExcludeFields(t *testing.T) {

--- a/typed/deduced_test.go
+++ b/typed/deduced_test.go
@@ -20,8 +20,8 @@ import (
 	"fmt"
 	"testing"
 
-	"sigs.k8s.io/structured-merge-diff/v4/typed"
-	"sigs.k8s.io/structured-merge-diff/v4/value"
+	"sigs.k8s.io/structured-merge-diff/v6/typed"
+	"sigs.k8s.io/structured-merge-diff/v6/value"
 )
 
 func TestValidateDeducedType(t *testing.T) {

--- a/typed/helpers.go
+++ b/typed/helpers.go
@@ -21,9 +21,9 @@ import (
 	"fmt"
 	"strings"
 
-	"sigs.k8s.io/structured-merge-diff/v4/fieldpath"
-	"sigs.k8s.io/structured-merge-diff/v4/schema"
-	"sigs.k8s.io/structured-merge-diff/v4/value"
+	"sigs.k8s.io/structured-merge-diff/v6/fieldpath"
+	"sigs.k8s.io/structured-merge-diff/v6/schema"
+	"sigs.k8s.io/structured-merge-diff/v6/value"
 )
 
 // ValidationError reports an error about a particular field

--- a/typed/helpers_test.go
+++ b/typed/helpers_test.go
@@ -4,8 +4,8 @@ import (
 	"strings"
 	"testing"
 
-	"sigs.k8s.io/structured-merge-diff/v4/internal/fixture"
-	"sigs.k8s.io/structured-merge-diff/v4/typed"
+	"sigs.k8s.io/structured-merge-diff/v6/internal/fixture"
+	"sigs.k8s.io/structured-merge-diff/v6/typed"
 )
 
 func TestInvalidOverride(t *testing.T) {

--- a/typed/merge.go
+++ b/typed/merge.go
@@ -17,9 +17,9 @@ limitations under the License.
 package typed
 
 import (
-	"sigs.k8s.io/structured-merge-diff/v4/fieldpath"
-	"sigs.k8s.io/structured-merge-diff/v4/schema"
-	"sigs.k8s.io/structured-merge-diff/v4/value"
+	"sigs.k8s.io/structured-merge-diff/v6/fieldpath"
+	"sigs.k8s.io/structured-merge-diff/v6/schema"
+	"sigs.k8s.io/structured-merge-diff/v6/value"
 )
 
 type mergingWalker struct {

--- a/typed/merge_test.go
+++ b/typed/merge_test.go
@@ -20,8 +20,8 @@ import (
 	"fmt"
 	"testing"
 
-	"sigs.k8s.io/structured-merge-diff/v4/typed"
-	"sigs.k8s.io/structured-merge-diff/v4/value"
+	"sigs.k8s.io/structured-merge-diff/v6/typed"
+	"sigs.k8s.io/structured-merge-diff/v6/value"
 )
 
 type mergeTestCase struct {

--- a/typed/parser.go
+++ b/typed/parser.go
@@ -19,8 +19,8 @@ package typed
 import (
 	"fmt"
 
-	"sigs.k8s.io/structured-merge-diff/v4/schema"
-	"sigs.k8s.io/structured-merge-diff/v4/value"
+	"sigs.k8s.io/structured-merge-diff/v6/schema"
+	"sigs.k8s.io/structured-merge-diff/v6/value"
 	yaml "sigs.k8s.io/yaml/goyaml.v2"
 )
 

--- a/typed/parser_test.go
+++ b/typed/parser_test.go
@@ -22,7 +22,7 @@ import (
 	"strings"
 	"testing"
 
-	"sigs.k8s.io/structured-merge-diff/v4/typed"
+	"sigs.k8s.io/structured-merge-diff/v6/typed"
 	yaml "sigs.k8s.io/yaml/goyaml.v2"
 )
 

--- a/typed/reconcile_schema.go
+++ b/typed/reconcile_schema.go
@@ -20,8 +20,8 @@ import (
 	"fmt"
 	"sync"
 
-	"sigs.k8s.io/structured-merge-diff/v4/fieldpath"
-	"sigs.k8s.io/structured-merge-diff/v4/schema"
+	"sigs.k8s.io/structured-merge-diff/v6/fieldpath"
+	"sigs.k8s.io/structured-merge-diff/v6/schema"
 )
 
 var fmPool = sync.Pool{

--- a/typed/reconcile_schema_test.go
+++ b/typed/reconcile_schema_test.go
@@ -20,8 +20,8 @@ import (
 	"fmt"
 	"testing"
 
-	"sigs.k8s.io/structured-merge-diff/v4/fieldpath"
-	"sigs.k8s.io/structured-merge-diff/v4/typed"
+	"sigs.k8s.io/structured-merge-diff/v6/fieldpath"
+	"sigs.k8s.io/structured-merge-diff/v6/typed"
 )
 
 type reconcileTestCase struct {

--- a/typed/remove.go
+++ b/typed/remove.go
@@ -14,9 +14,9 @@ limitations under the License.
 package typed
 
 import (
-	"sigs.k8s.io/structured-merge-diff/v4/fieldpath"
-	"sigs.k8s.io/structured-merge-diff/v4/schema"
-	"sigs.k8s.io/structured-merge-diff/v4/value"
+	"sigs.k8s.io/structured-merge-diff/v6/fieldpath"
+	"sigs.k8s.io/structured-merge-diff/v6/schema"
+	"sigs.k8s.io/structured-merge-diff/v6/value"
 )
 
 type removingWalker struct {

--- a/typed/remove_test.go
+++ b/typed/remove_test.go
@@ -20,9 +20,9 @@ import (
 	"fmt"
 	"testing"
 
-	"sigs.k8s.io/structured-merge-diff/v4/fieldpath"
-	"sigs.k8s.io/structured-merge-diff/v4/typed"
-	"sigs.k8s.io/structured-merge-diff/v4/value"
+	"sigs.k8s.io/structured-merge-diff/v6/fieldpath"
+	"sigs.k8s.io/structured-merge-diff/v6/typed"
+	"sigs.k8s.io/structured-merge-diff/v6/value"
 )
 
 type removeTestCase struct {

--- a/typed/symdiff_test.go
+++ b/typed/symdiff_test.go
@@ -20,8 +20,8 @@ import (
 	"fmt"
 	"testing"
 
-	"sigs.k8s.io/structured-merge-diff/v4/fieldpath"
-	"sigs.k8s.io/structured-merge-diff/v4/typed"
+	"sigs.k8s.io/structured-merge-diff/v6/fieldpath"
+	"sigs.k8s.io/structured-merge-diff/v6/typed"
 )
 
 type symdiffTestCase struct {

--- a/typed/tofieldset.go
+++ b/typed/tofieldset.go
@@ -19,9 +19,9 @@ package typed
 import (
 	"sync"
 
-	"sigs.k8s.io/structured-merge-diff/v4/fieldpath"
-	"sigs.k8s.io/structured-merge-diff/v4/schema"
-	"sigs.k8s.io/structured-merge-diff/v4/value"
+	"sigs.k8s.io/structured-merge-diff/v6/fieldpath"
+	"sigs.k8s.io/structured-merge-diff/v6/schema"
+	"sigs.k8s.io/structured-merge-diff/v6/value"
 )
 
 var tPool = sync.Pool{

--- a/typed/toset_test.go
+++ b/typed/toset_test.go
@@ -20,9 +20,9 @@ import (
 	"fmt"
 	"testing"
 
-	"sigs.k8s.io/structured-merge-diff/v4/fieldpath"
-	"sigs.k8s.io/structured-merge-diff/v4/typed"
-	"sigs.k8s.io/structured-merge-diff/v4/value"
+	"sigs.k8s.io/structured-merge-diff/v6/fieldpath"
+	"sigs.k8s.io/structured-merge-diff/v6/typed"
+	"sigs.k8s.io/structured-merge-diff/v6/value"
 )
 
 type objSetPair struct {

--- a/typed/typed.go
+++ b/typed/typed.go
@@ -19,9 +19,9 @@ package typed
 import (
 	"sync"
 
-	"sigs.k8s.io/structured-merge-diff/v4/fieldpath"
-	"sigs.k8s.io/structured-merge-diff/v4/schema"
-	"sigs.k8s.io/structured-merge-diff/v4/value"
+	"sigs.k8s.io/structured-merge-diff/v6/fieldpath"
+	"sigs.k8s.io/structured-merge-diff/v6/schema"
+	"sigs.k8s.io/structured-merge-diff/v6/value"
 )
 
 // ValidationOptions is the list of all the options available when running the validation.

--- a/typed/validate.go
+++ b/typed/validate.go
@@ -19,9 +19,9 @@ package typed
 import (
 	"sync"
 
-	"sigs.k8s.io/structured-merge-diff/v4/fieldpath"
-	"sigs.k8s.io/structured-merge-diff/v4/schema"
-	"sigs.k8s.io/structured-merge-diff/v4/value"
+	"sigs.k8s.io/structured-merge-diff/v6/fieldpath"
+	"sigs.k8s.io/structured-merge-diff/v6/schema"
+	"sigs.k8s.io/structured-merge-diff/v6/value"
 )
 
 var vPool = sync.Pool{

--- a/typed/validate_test.go
+++ b/typed/validate_test.go
@@ -21,8 +21,8 @@ import (
 	"strings"
 	"testing"
 
-	"sigs.k8s.io/structured-merge-diff/v4/schema"
-	"sigs.k8s.io/structured-merge-diff/v4/typed"
+	"sigs.k8s.io/structured-merge-diff/v6/schema"
+	"sigs.k8s.io/structured-merge-diff/v6/typed"
 )
 
 type validationTestCase struct {

--- a/value/equals_test.go
+++ b/value/equals_test.go
@@ -21,7 +21,7 @@ import (
 	"path/filepath"
 	"testing"
 
-	"sigs.k8s.io/structured-merge-diff/v4/value"
+	"sigs.k8s.io/structured-merge-diff/v6/value"
 	yaml "sigs.k8s.io/yaml/goyaml.v2"
 )
 

--- a/value/value.go
+++ b/value/value.go
@@ -23,6 +23,7 @@ import (
 	"strings"
 
 	jsoniter "github.com/json-iterator/go"
+
 	yaml "sigs.k8s.io/yaml/goyaml.v2"
 )
 
@@ -90,7 +91,7 @@ func FromJSON(input []byte) (Value, error) {
 func FromJSONFast(input []byte) (Value, error) {
 	iter := readPool.BorrowIterator(input)
 	defer readPool.ReturnIterator(iter)
-	return ReadJSONIter(iter)
+	return readJSONIter(iter)
 }
 
 // ToJSON is a helper function for producing a JSon document.
@@ -98,7 +99,7 @@ func ToJSON(v Value) ([]byte, error) {
 	buf := bytes.Buffer{}
 	stream := writePool.BorrowStream(&buf)
 	defer writePool.ReturnStream(stream)
-	WriteJSONStream(v, stream)
+	writeJSONStream(v, stream)
 	b := stream.Buffer()
 	err := stream.Flush()
 	// Help jsoniter manage its buffers--without this, the next
@@ -109,8 +110,10 @@ func ToJSON(v Value) ([]byte, error) {
 	return buf.Bytes(), err
 }
 
-// ReadJSONIter reads a Value from a JSON iterator.
-func ReadJSONIter(iter *jsoniter.Iterator) (Value, error) {
+// readJSONIter reads a Value from a JSON iterator.
+// DO NOT EXPORT
+// TODO: eliminate this https://github.com/kubernetes-sigs/structured-merge-diff/issues/202
+func readJSONIter(iter *jsoniter.Iterator) (Value, error) {
 	v := iter.Read()
 	if iter.Error != nil && iter.Error != io.EOF {
 		return nil, iter.Error
@@ -118,8 +121,10 @@ func ReadJSONIter(iter *jsoniter.Iterator) (Value, error) {
 	return NewValueInterface(v), nil
 }
 
-// WriteJSONStream writes a value into a JSON stream.
-func WriteJSONStream(v Value, stream *jsoniter.Stream) {
+// writeJSONStream writes a value into a JSON stream.
+// DO NOT EXPORT
+// TODO: eliminate this https://github.com/kubernetes-sigs/structured-merge-diff/issues/202
+func writeJSONStream(v Value, stream *jsoniter.Stream) {
 	stream.WriteVal(v.Unstructured())
 }
 


### PR DESCRIPTION
see: https://github.com/kubernetes-sigs/structured-merge-diff/issues/202

TODO: should we bump the module to v6 since this removes APIs?

I can't find evidence that anyone else was using these:

none in the org:
https://cs.k8s.io/?q=(ReadJSONIter)%7C(WriteJSONStream)&i=nope&literal=nope&files=&excludeFiles=vendor&repos=

only in `vendor/`:
https://grep.app/search?f.lang=Go&regexp=true&q=%28ReadJSONIter%29%7C%28WriteJSONStream%29