### PR TITLE
Fix ExtractItems to preserve empty maps and lists

### DIFF
--- a/typed/remove.go
+++ b/typed/remove.go
@@ -58,6 +58,10 @@ func (w *removingWalker) doList(t *schema.List) (errs ValidationErrors) {
 	defer w.allocator.Free(l)
 	// If list is null or empty just return
 	if l == nil || l.Length() == 0 {
+		// When extracting, preserve empty lists
+		if w.shouldExtract && l != nil && l.Length() == 0 {
+			w.out = []interface{}{}
+		}
 		return nil
 	}
 
@@ -113,6 +117,10 @@ func (w *removingWalker) doMap(t *schema.Map) ValidationErrors {
 	}
 	// If map is null or empty just return
 	if m == nil || m.Empty() {
+		// When extracting, preserve empty maps
+		if w.shouldExtract && m != nil && m.Empty() {
+			w.out = map[string]interface{}{}
+		}
 		return nil
 	}
 


### PR DESCRIPTION
### What

`ExtractItems` now preserves empty collections (`{}` and `[]`) instead of converting them to `null`.

### Why

In our workflow, we extract apply configurations to compare with desired state before making API calls. When empty collections are converted to null, this comparison incorrectly shows
differences, causing unnecessary API requests.

This affects resources like emptyDir volumes and container resources specifications:
  ```go
// Resource has: {"emptyDir": {}} or {"resources": {}}
extracted := resource.ExtractItems(fieldSet.Leaves())
// Before: {"emptyDir": null}
// After:  {"emptyDir": {}}
```

### Changes

- Modified typed/remove.go to preserve empty maps and lists during extraction
- Added test cases for empty struct, list, and nested collection preservation
- Maintains distinction between null and empty values

Fixes issue reported in #259 regarding consistent empty collection handling.

### Additional

<details>
  <summary>V4(that's what my codebase imports) vs PR Compare example</summary>

```
package internal

import (
	"encoding/json"
	"testing"

	corev1apply "k8s.io/client-go/applyconfigurations/core/v1"
	typedv4 "sigs.k8s.io/structured-merge-diff/v4/typed"
	typedv6 "sigs.k8s.io/structured-merge-diff/v6/typed"
)

var (
	podSpecApplyConfig = corev1apply.PodSpec().
		WithContainers(
			corev1apply.Container().
				WithName("main").
				WithImage("nginx:latest").
				WithVolumeMounts(
					corev1apply.VolumeMount().
						WithName("data").
						WithMountPath("/data"),
				),
		).
		WithVolumes(
			corev1apply.Volume().
				WithName("data").
				WithEmptyDir(corev1apply.EmptyDirVolumeSource()),
		)
)

func TestStructuredMergeDiffExtraction_Pod_v6_PATCHED(t *testing.T) {
	parser, _ := typedv6.NewParser(schemaYAML)

	specType := parser.Type("io.k8s.api.core.v1.PodSpec")
	specTypeValue, _ := specType.FromStructured(podSpecApplyConfig)

	originalJSON, _ := json.Marshal(podSpecApplyConfig)
	t.Logf("Original JSON: \n%s", string(originalJSON))

	specTypeValueFields, _ := specTypeValue.ToFieldSet()
	t.Logf("FieldSet Leaves: \n%v", specTypeValueFields.Leaves())

	extractedSpecTypeValue := specTypeValue.ExtractItems(specTypeValueFields.Leaves())
	extractedJSON, _ := json.Marshal(extractedSpecTypeValue.AsValue().Unstructured())
	t.Logf("Extracted JSON: \n%s", string(extractedJSON))

	diff, _ := specTypeValue.Compare(extractedSpecTypeValue)

	if !diff.IsSame() {
		t.Logf("Diff: \n%s", diff.String())
		t.Errorf("The extracted TypedValue differs from the original.")
	}
}

func TestStructuredMergeDiffExtraction_Pod_v4(t *testing.T) {
	schemaYAMLv4 := typedv4.YAMLObject(schemaYAML)
	parser, _ := typedv4.NewParser(schemaYAMLv4)

	specType := parser.Type("io.k8s.api.core.v1.PodSpec")
	specTypeValue, _ := specType.FromStructured(podSpecApplyConfig)

	originalJSON, _ := json.Marshal(podSpecApplyConfig)
	t.Logf("Original JSON: \n%s", string(originalJSON))

	specTypeValueFields, _ := specTypeValue.ToFieldSet()
	t.Logf("FieldSet Leaves: \n%v", specTypeValueFields.Leaves())

	extractedSpecTypeValue := specTypeValue.ExtractItems(specTypeValueFields.Leaves())
	extractedJSON, _ := json.Marshal(extractedSpecTypeValue.AsValue().Unstructured())
	t.Logf("Extracted JSON: \n%s", string(extractedJSON))

	diff, _ := specTypeValue.Compare(extractedSpecTypeValue)

	if !diff.IsSame() {
		t.Logf("Diff: \n%s", diff.String())
		t.Errorf("The extracted TypedValue differs from the original.")
	}
}
```

The test output:
```
=== RUN   TestStructuredMergeDiffExtraction_Pod_v6_PATCHED
    ssa_test.go:38: Original JSON: 
        {"volumes":[{"name":"data","emptyDir":{}}],"containers":[{"name":"main","image":"nginx:latest","volumeMounts":[{"name":"data","mountPath":"/data"}]}]}
    ssa_test.go:41: FieldSet Leaves: 
        .containers[name="main"].image
        .containers[name="main"].name
        .containers[name="main"].volumeMounts[mountPath="/data"].mountPath
        .containers[name="main"].volumeMounts[mountPath="/data"].name
        .volumes[name="data"].emptyDir
        .volumes[name="data"].name
    ssa_test.go:45: Extracted JSON: 
        {"containers":[{"image":"nginx:latest","name":"main","volumeMounts":[{"mountPath":"/data","name":"data"}]}],"volumes":[{"emptyDir":{},"name":"data"}]}
--- PASS: TestStructuredMergeDiffExtraction_Pod_v6_PATCHED (0.01s)
=== RUN   TestStructuredMergeDiffExtraction_Pod_v4
    ssa_test.go:63: Original JSON: 
        {"volumes":[{"name":"data","emptyDir":{}}],"containers":[{"name":"main","image":"nginx:latest","volumeMounts":[{"name":"data","mountPath":"/data"}]}]}
    ssa_test.go:66: FieldSet Leaves: 
        .containers[name="main"].image
        .containers[name="main"].name
        .containers[name="main"].volumeMounts[mountPath="/data"].mountPath
        .containers[name="main"].volumeMounts[mountPath="/data"].name
        .volumes[name="data"].emptyDir
        .volumes[name="data"].name
    ssa_test.go:70: Extracted JSON: 
        {"containers":[{"image":"nginx:latest","name":"main","volumeMounts":[{"mountPath":"/data","name":"data"}]}],"volumes":[{"emptyDir":null,"name":"data"}]}
    ssa_test.go:75: Diff: 
        - Modified Fields:
        .volumes[name="data"].emptyDir
    ssa_test.go:76: The extracted TypedValue differs from the original.
--- FAIL: TestStructuredMergeDiffExtraction_Pod_v4 (0.01s)
FAIL
FAIL    github.com/niledatabase/operator/pkg/client/applyconfigurations/internal        0.024s
FAIL

```

</details>