### PR TITLE
Drop usage of forked copies of goyaml.v2

### DIFF
--- a/fieldpath/fromvalue_test.go
+++ b/fieldpath/fromvalue_test.go
@@ -19,8 +19,8 @@ package fieldpath
 import (
 	"testing"
 
+	yaml "go.yaml.in/yaml/v2"
 	"sigs.k8s.io/structured-merge-diff/v6/value"
-	yaml "sigs.k8s.io/yaml/goyaml.v2"
 )
 
 func TestFromValue(t *testing.T) {

--- a/fieldpath/set_test.go
+++ b/fieldpath/set_test.go
@@ -24,8 +24,8 @@ import (
 
 	"sigs.k8s.io/structured-merge-diff/v6/value"
 
+	yaml "go.yaml.in/yaml/v2"
 	"sigs.k8s.io/structured-merge-diff/v6/schema"
-	yaml "sigs.k8s.io/yaml/goyaml.v2"
 )
 
 type randomPathAlphabet []PathElement

--- a/go.mod
+++ b/go.mod
@@ -3,8 +3,8 @@ module sigs.k8s.io/structured-merge-diff/v6
 require (
 	github.com/google/go-cmp v0.5.9
 	github.com/json-iterator/go v1.1.12
+	go.yaml.in/yaml/v2 v2.4.2
 	sigs.k8s.io/randfill v0.0.0-20250304075658-069ef1bbf016
-	sigs.k8s.io/yaml v1.4.0
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -16,9 +16,9 @@ github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZN
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.3.0 h1:TivCn/peBQ7UY8ooIcPgZFpTNSz0Q2U6UrFlUfqbe0Q=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
+go.yaml.in/yaml/v2 v2.4.2 h1:DzmwEr2rDGHl7lsFgAHxmNz/1NlQ7xLIrlN2h5d1eGI=
+go.yaml.in/yaml/v2 v2.4.2/go.mod h1:081UH+NErpNdqlCXm3TtEran0rJZGxAYx9hb/ELlsPU=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 sigs.k8s.io/randfill v0.0.0-20250304075658-069ef1bbf016 h1:kXv6kKdoEtedwuqMmkqhbkgvYKeycVbC8+iPCP9j5kQ=
 sigs.k8s.io/randfill v0.0.0-20250304075658-069ef1bbf016/go.mod h1:XeLlZ/jmk4i1HRopwe7/aU3H5n1zNUcX6TM94b3QxOY=
-sigs.k8s.io/yaml v1.4.0 h1:Mk1wCc2gy/F0THH0TAp1QYyJNzRm2KCLy3o5ASXVI5E=
-sigs.k8s.io/yaml v1.4.0/go.mod h1:Ejl7/uTz7PSA4eKMyQCUTnhZYNmLIl+5c2lQPGR2BPY=

--- a/merge/multiple_appliers_test.go
+++ b/merge/multiple_appliers_test.go
@@ -22,12 +22,12 @@ import (
 	"strings"
 	"testing"
 
+	yaml "go.yaml.in/yaml/v2"
 	"sigs.k8s.io/structured-merge-diff/v6/fieldpath"
 	. "sigs.k8s.io/structured-merge-diff/v6/internal/fixture"
 	"sigs.k8s.io/structured-merge-diff/v6/merge"
 	"sigs.k8s.io/structured-merge-diff/v6/typed"
 	"sigs.k8s.io/structured-merge-diff/v6/value"
-	yaml "sigs.k8s.io/yaml/goyaml.v2"
 )
 
 func TestMultipleAppliersSet(t *testing.T) {

--- a/typed/parser.go
+++ b/typed/parser.go
@@ -19,9 +19,9 @@ package typed
 import (
 	"fmt"
 
+	yaml "go.yaml.in/yaml/v2"
 	"sigs.k8s.io/structured-merge-diff/v6/schema"
 	"sigs.k8s.io/structured-merge-diff/v6/value"
-	yaml "sigs.k8s.io/yaml/goyaml.v2"
 )
 
 // YAMLObject is an object encoded in YAML.

--- a/typed/parser_test.go
+++ b/typed/parser_test.go
@@ -22,8 +22,8 @@ import (
 	"strings"
 	"testing"
 
+	yaml "go.yaml.in/yaml/v2"
 	"sigs.k8s.io/structured-merge-diff/v6/typed"
-	yaml "sigs.k8s.io/yaml/goyaml.v2"
 )
 
 func testdata(file string) string {

--- a/value/equals_test.go
+++ b/value/equals_test.go
@@ -21,8 +21,8 @@ import (
 	"path/filepath"
 	"testing"
 
+	yaml "go.yaml.in/yaml/v2"
 	"sigs.k8s.io/structured-merge-diff/v6/value"
-	yaml "sigs.k8s.io/yaml/goyaml.v2"
 )
 
 func testdata(file string) string {

--- a/value/value.go
+++ b/value/value.go
@@ -24,7 +24,7 @@ import (
 
 	jsoniter "github.com/json-iterator/go"
 
-	yaml "sigs.k8s.io/yaml/goyaml.v2"
+	yaml "go.yaml.in/yaml/v2"
 )
 
 var (


### PR DESCRIPTION
Please see the following for context:
- https://github.com/kubernetes/kubernetes/issues/132056
- https://github.com/kubernetes/kubernetes/pull/132357

`"sigs.k8s.io/yaml/goyaml.v2"` is forked code and now there is a supported alternative in the larger community.

So essentially, we have to switch to using `go.yaml.in/yaml/v2`