### PR TITLE
support optional map keys

### DIFF
--- a/merge/default_keys_test.go
+++ b/merge/default_keys_test.go
@@ -163,6 +163,36 @@ func TestDefaultKeysFlat(t *testing.T) {
 				),
 			},
 		},
+		"apply_missing_undefaulted_defaulted_key": {
+			Ops: []Operation{
+				Apply{
+					Manager:    "default",
+					APIVersion: "v1",
+					Object: `
+						containerPorts:
+						- protocol: TCP
+						  name: A
+					`,
+				},
+			},
+			APIVersion: "v1",
+			Object: `
+				containerPorts:
+				- protocol: TCP
+				  name: A
+			`,
+			Managed: fieldpath.ManagedFields{
+				"default": fieldpath.NewVersionedSet(
+					_NS(
+						_P("containerPorts", _KBF("protocol", "TCP")),
+						_P("containerPorts", _KBF("protocol", "TCP"), "name"),
+						_P("containerPorts", _KBF("protocol", "TCP"), "protocol"),
+					),
+					"v1",
+					true,
+				),
+			},
+		},
 	}
 
 	for name, test := range tests {
@@ -176,18 +206,6 @@ func TestDefaultKeysFlat(t *testing.T) {
 
 func TestDefaultKeysFlatErrors(t *testing.T) {
 	tests := map[string]TestCase{
-		"apply_missing_undefaulted_defaulted_key": {
-			Ops: []Operation{
-				Apply{
-					Manager:    "default",
-					APIVersion: "v1",
-					Object: `
-						containerPorts:
-						- protocol: TCP
-					`,
-				},
-			},
-		},
 		"apply_missing_defaulted_key_ambiguous_A": {
 			Ops: []Operation{
 				Apply{

--- a/typed/helpers.go
+++ b/typed/helpers.go
@@ -217,9 +217,16 @@ func keyedAssociativeListItemToPathElement(a value.Allocator, s *schema.Schema, 
 		} else if def != nil {
 			keyMap = append(keyMap, value.Field{Name: fieldName, Value: value.NewValueInterface(def)})
 		} else {
-			return pe, fmt.Errorf("associative list with keys has an element that omits key field %q (and doesn't have default value)", fieldName)
+			// Don't add the key to the key field list.
+			// A key field list where it is set then represents a different entry
+			// in the associate list.
 		}
 	}
+
+	if len(list.Keys) > 0 && len(keyMap) == 0 {
+		return pe, fmt.Errorf("associative list with keys has an element that omits all key fields %q (and doesn't have default values for any key fields)", list.Keys)
+	}
+
 	keyMap.Sort()
 	pe.Key = &keyMap
 	return pe, nil

--- a/typed/validate_test.go
+++ b/typed/validate_test.go
@@ -213,6 +213,7 @@ var validationCases = []validationTestCase{{
 		`{"list":[{"key":"a","id":1,"value":{"a":"a"}}]}`,
 		`{"list":[{"key":"a","id":1},{"key":"a","id":2},{"key":"b","id":1}]}`,
 		`{"atomicList":["a","a","a"]}`,
+		`{"list":[{"key":"x","value":{"a":"a"},"bv":true,"nv":3.14}]}`,
 	},
 	invalidObjects: []typed.YAMLObject{
 		`{"key":true,"value":1}`,


### PR DESCRIPTION
Optional keys of a list map (= associative lists) keys are simply left out of the set of keys, which is different from a key with an empty value like "" for a string and obviously also different from a non-empty value. The comparison of values already supported that and the comparison of list values supported lists with different number of entries.

Completely empty key field lists continue to trigger an error ("associative list with keys has an element that omits all key fields <quoted list of fields> (and doesn't have default values for any key fields)".
    
Downgrading from a version which has support for a new optional key to a version which doesn't works as long as the optional key is not used, because the ManagedFields don't mention the new key and field and there are no list entries which have it set. It does not work when the new field and key are used because the older version doesn't know that it needs to consider the new key, as the key is not listed in the older version's OpenAPI spec.
    
This is considered acceptable because new fields will be alpha initially and downgrades with an alpha feature enabled are not required to work. It is worth calling out in release notes, though.
