### PR TITLE
fieldpath: convert to blackbox testing

### DIFF
--- a/fieldpath/fieldpath_test.go
+++ b/fieldpath/fieldpath_test.go
@@ -1,0 +1,46 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package fieldpath_test
+
+import (
+	"sigs.k8s.io/structured-merge-diff/v6/fieldpath"
+	"sigs.k8s.io/structured-merge-diff/v6/value"
+)
+
+// Type and function aliases to avoid typing...
+
+type (
+	Filter      = fieldpath.Filter
+	Path        = fieldpath.Path
+	PathElement = fieldpath.PathElement
+	Set         = fieldpath.Set
+	SetNodeMap  = fieldpath.SetNodeMap
+)
+
+var (
+	KeyByFields             = fieldpath.KeyByFields
+	MakePathOrDie           = fieldpath.MakePathOrDie
+	MakePrefixMatcherOrDie  = fieldpath.MakePrefixMatcherOrDie
+	MatchAnyPathElement     = fieldpath.MatchAnyPathElement
+	NewIncludeMatcherFilter = fieldpath.NewIncludeMatcherFilter
+	NewSet                  = fieldpath.NewSet
+
+	// Short names for readable test cases.
+	_V  = value.NewValueInterface
+	_NS = fieldpath.NewSet
+	_P  = fieldpath.MakePathOrDie
+)

--- a/fieldpath/managers_test.go
+++ b/fieldpath/managers_test.go
@@ -23,12 +23,6 @@ import (
 	"sigs.k8s.io/structured-merge-diff/v6/fieldpath"
 )
 
-var (
-	// Short names for readable test cases.
-	_NS = fieldpath.NewSet
-	_P  = fieldpath.MakePathOrDie
-)
-
 func TestManagersEquals(t *testing.T) {
 	tests := []struct {
 		name string

--- a/fieldpath/serialize_test.go
+++ b/fieldpath/serialize_test.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package fieldpath
+package fieldpath_test
 
 import (
 	"bytes"

--- a/fieldpath/set_test.go
+++ b/fieldpath/set_test.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package fieldpath
+package fieldpath_test
 
 import (
 	"bytes"
@@ -22,10 +22,9 @@ import (
 	"math/rand"
 	"testing"
 
-	"sigs.k8s.io/structured-merge-diff/v6/value"
-
-	yaml "go.yaml.in/yaml/v2"
 	"sigs.k8s.io/structured-merge-diff/v6/schema"
+	"sigs.k8s.io/structured-merge-diff/v6/typed"
+	"sigs.k8s.io/structured-merge-diff/v6/value"
 )
 
 type randomPathAlphabet []PathElement
@@ -664,65 +663,95 @@ func TestSetDifference(t *testing.T) {
 	}
 }
 
-var nestedSchema = func() (*schema.Schema, schema.TypeRef) {
-	sc := &schema.Schema{}
+var nestedSchema = func() (*typed.Parser, string) {
 	name := "type"
-	err := yaml.Unmarshal([]byte(`types:
+	parser := mustParse(`types:
 - name: type
   map:
     elementType:
       namedType: type
     fields:
+      - name: keyAStr
+        type:
+          scalar: string
+      - name: keyBInt
+        type:
+          scalar: numeric
       - name: named
         type:
           namedType: type
       - name: list
         type:
           list:
-            elementRelationShip: associative
-            keys: ["name"]
+            elementRelationship: associative
+            keys: ["keyAStr", "keyBInt"]
             elementType:
               namedType: type
+      - name: a
+        type:
+          namedType: type
       - name: value
         type:
           scalar: numeric
-`), &sc)
+`)
+	return parser, name
+}
+
+func mustParse(schema typed.YAMLObject) *typed.Parser {
+	parser, err := typed.NewParser(schema)
 	if err != nil {
 		panic(err)
 	}
-	return sc, schema.TypeRef{NamedType: &name}
+	return parser
 }
-
-var _P = MakePathOrDie
 
 func TestEnsureNamedFieldsAreMembers(t *testing.T) {
 	table := []struct {
-		set, expected *Set
+		value          typed.YAMLObject
+		expectedBefore *Set
+		expectedAfter  *Set
 	}{
 		{
-			set: NewSet(_P("named", "named", "value")),
-			expected: NewSet(
+			value: `{"named": {"named": {"value": 0}}}`,
+			expectedBefore: NewSet(
+				_P("named", "named", "value"),
+			),
+			expectedAfter: NewSet(
 				_P("named", "named", "value"),
 				_P("named", "named"),
 				_P("named"),
 			),
 		},
 		{
-			set: NewSet(_P("named", "a", "named", "value"), _P("a", "named", "value"), _P("a", "b", "value")),
-			expected: NewSet(
+			value: `{"named": {"a": {"named": {"value": 42}}}, "a": {"named": {"value": 1}}}`,
+			expectedBefore: NewSet(
+				_P("named", "a", "named", "value"),
+				_P("a", "named", "value"),
+			),
+			expectedAfter: NewSet(
 				_P("named", "a", "named", "value"),
 				_P("named", "a", "named"),
+				_P("named", "a"),
 				_P("named"),
 				_P("a", "named", "value"),
 				_P("a", "named"),
-				_P("a", "b", "value"),
+				_P("a"),
 			),
 		},
 		{
-			set: NewSet(_P("named", "list", KeyByFields("name", "a"), "named", "a", "value")),
-			expected: NewSet(
-				_P("named", "list", KeyByFields("name", "a"), "named", "a", "value"),
-				_P("named", "list", KeyByFields("name", "a"), "named"),
+			value: `{"named": {"list": [{"keyAStr": "a", "keyBInt": 1, "named": {"value": 0}}]}}`,
+			expectedBefore: NewSet(
+				_P("named", "list", KeyByFields("keyAStr", "a", "keyBInt", 1), "keyAStr"),
+				_P("named", "list", KeyByFields("keyAStr", "a", "keyBInt", 1), "keyBInt"),
+				_P("named", "list", KeyByFields("keyAStr", "a", "keyBInt", 1), "named", "value"),
+				_P("named", "list", KeyByFields("keyAStr", "a", "keyBInt", 1)),
+			),
+			expectedAfter: NewSet(
+				_P("named", "list", KeyByFields("keyAStr", "a", "keyBInt", 1), "keyAStr"),
+				_P("named", "list", KeyByFields("keyAStr", "a", "keyBInt", 1), "keyBInt"),
+				_P("named", "list", KeyByFields("keyAStr", "a", "keyBInt", 1), "named", "value"),
+				_P("named", "list", KeyByFields("keyAStr", "a", "keyBInt", 1), "named"),
+				_P("named", "list", KeyByFields("keyAStr", "a", "keyBInt", 1)),
 				_P("named", "list"),
 				_P("named"),
 			),
@@ -730,14 +759,34 @@ func TestEnsureNamedFieldsAreMembers(t *testing.T) {
 	}
 
 	for _, test := range table {
-		t.Run(fmt.Sprintf("%v", test.set), func(t *testing.T) {
-			got := test.set.EnsureNamedFieldsAreMembers(nestedSchema())
-			if !got.Equals(test.expected) {
-				t.Errorf("expected %v, got %v (missing: %v/superfluous: %v)",
-					test.expected,
+		t.Run(string(test.value), func(t *testing.T) {
+			parser, typeName := nestedSchema()
+			typeRef := schema.TypeRef{NamedType: &typeName}
+			typedValue, err := parser.Type(typeName).FromYAML(test.value)
+			if err != nil {
+				t.Fatalf("unexpected error parsing test value: %v", err)
+			}
+			set, err := typedValue.ToFieldSet()
+			if err != nil {
+				t.Fatalf("unexpected error converting test value to set: %v", err)
+			}
+			if !set.Equals(test.expectedBefore) {
+				t.Errorf("expected before EnsureNamedFieldsAreMembers:\n%v\n\ngot:\n%v\n\nmissing:\n%v\n\nsuperfluous:\n\n%v",
+					test.expectedBefore,
+					set,
+					test.expectedAfter.Difference(set),
+					set.Difference(test.expectedAfter),
+				)
+			}
+
+			schema := &parser.Schema
+			got := set.EnsureNamedFieldsAreMembers(schema, typeRef)
+			if !got.Equals(test.expectedAfter) {
+				t.Errorf("expected after EnsureNamedFieldsAreMembers:\n%v\n\ngot:\n%v\n\nmissing:\n%v\n\nsuperfluous:\n\n%v",
+					test.expectedAfter,
 					got,
-					test.expected.Difference(got),
-					got.Difference(test.expected),
+					test.expectedAfter.Difference(got),
+					got.Difference(test.expectedAfter),
 				)
 			}
 		})


### PR DESCRIPTION
The tests were defined in the "fieldpath" package, which prevented using typed.NewParser (import cycle!). Defining them in "fieldpath_test" allows that. To avoid changing all references to the package's exported symbols, "fieldpath_test.go" defines aliases.

typed.NewParser is more strict and finds a typo in the test schema.

Also, constructing a set with `NewSet(MakePath(...))` was found to not yield the same structs as parsing a value with a schema, so now `parser.Type(typeName).FromYAML().ToFieldSet` is used instead.