### PR TITLE
Fix ExtractItems to preserve empty maps and lists

### DIFF
--- a/typed/remove.go
+++ b/typed/remove.go
@@ -58,6 +58,10 @@ func (w *removingWalker) doList(t *schema.List) (errs ValidationErrors) {
 	defer w.allocator.Free(l)
 	// If list is null or empty just return
 	if l == nil || l.Length() == 0 {
+		// For extraction, we just return the value as is (which is nil or empty). For extraction the difference matters.
+		if w.shouldExtract {
+			w.out = w.value.Unstructured()
+		}
 		return nil
 	}
 
@@ -113,6 +117,10 @@ func (w *removingWalker) doMap(t *schema.Map) ValidationErrors {
 	}
 	// If map is null or empty just return
 	if m == nil || m.Empty() {
+		// For extraction, we just return the value as is (which is nil or empty). For extraction the difference matters.
+		if w.shouldExtract {
+			w.out = w.value.Unstructured()
+		}
 		return nil
 	}
 

--- a/typed/remove_test.go
+++ b/typed/remove_test.go
@@ -675,6 +675,38 @@ var removeCases = []removeTestCase{{
 		),
 		`{"mapOfMapsRecursive":{"a":{"b":null}}}`,
 		`{"mapOfMapsRecursive": {"a":{"b":{"c":null}}}}`,
+	}, {
+		// empty list
+		`{"listOfLists": []}`,
+		_NS(
+			_P("listOfLists"),
+		),
+		``,
+		`{"listOfLists": []}`,
+	}, {
+		// null list
+		`{"listOfLists": null}`,
+		_NS(
+			_P("listOfLists"),
+		),
+		``,
+		`{"listOfLists": null}`,
+	}, {
+		// empty map
+		`{"mapOfMaps": {}}`,
+		_NS(
+			_P("mapOfMaps"),
+		),
+		``,
+		`{"mapOfMaps": {}}`,
+	}, {
+		// nil map
+		`{"mapOfMaps": null}`,
+		_NS(
+			_P("mapOfMaps"),
+		),
+		``,
+		`{"mapOfMaps": null}`,
 	}},
 }}
 


### PR DESCRIPTION
### What

`ExtractItems` now preserves empty maps and lists (`{}` and `[]`) instead of converting them to `null`.

### Why

The apply config that gets applied should be the same that gets later extracted. Today this isn't the case for empty, non-nil, fields (like `volumes[].emptyDir`).

### Changes

- Modified typed/remove.go to preserve empty maps and lists during extraction
- Added test cases for empty maps and lists (nil and non-nil)

### Additional

<details>
  <summary>Attached a test case that uses the Pod apply config as a more specific example</summary>

```
package pdb

import (
	"encoding/json"
	"testing"

	"github.com/stretchr/testify/require"
	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
	corev1apply "k8s.io/client-go/applyconfigurations/core/v1"
	"k8s.io/client-go/kubernetes/fake"
)

var (
	desiredApplyConf = corev1apply.Pod("test", "default").WithSpec(corev1apply.PodSpec().
		WithContainers(
			corev1apply.Container().
				WithName("main").
				WithImage("nginx:latest").
				WithVolumeMounts(
					corev1apply.VolumeMount().
						WithName("data").
						WithMountPath("/data"),
				),
		).
		WithVolumes(
			corev1apply.Volume().
				WithName("data").
				WithEmptyDir(corev1apply.EmptyDirVolumeSource()),
		))
)

func Test_ExtractPod(t *testing.T) {
	client := fake.NewClientset()
	pod, err := client.CoreV1().Pods("default").Apply(t.Context(), desiredApplyConf, v1.ApplyOptions{FieldManager: "test"})
	require.NoError(t, err)

	extractedApplyConf, err := corev1apply.ExtractPod(pod, "test")
	require.NoError(t, err)

	extractedJSON, err := json.Marshal(extractedApplyConf)
	require.NoError(t, err)
	t.Logf("Extracted Pod Apply Config: \n%s", string(extractedJSON))
	desiredJSON, err := json.Marshal(desiredApplyConf)
	require.NoError(t, err)
	t.Logf("Desired Pod Apply Config: \n%s", string(desiredJSON))

	require.JSONEq(t, string(desiredJSON), string(extractedJSON), "extracted apply config does not match the desired one")
}
```

</details>