### PR TITLE
Add more test coverage for searialization and deserialization

### DIFF
--- a/fieldpath/serialize-pe_test.go
+++ b/fieldpath/serialize-pe_test.go
@@ -16,7 +16,9 @@ limitations under the License.
 
 package fieldpath
 
-import "testing"
+import (
+	"testing"
+)
 
 func TestPathElementRoundTrip(t *testing.T) {
 	tests := []string{
@@ -25,8 +27,10 @@ func TestPathElementRoundTrip(t *testing.T) {
 		`f:`,
 		`f:spec`,
 		`f:more-complicated-string`,
+		`f: string-with-spaces   `,
 		`f:abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789`,
 		`k:{"name":"my-container"}`,
+		`k:{"name":"   name with spaces   "}`,
 		`k:{"port":"8080","protocol":"TCP"}`,
 		`k:{"optionalField":null}`,
 		`k:{"jsonField":{"A":1,"B":null,"C":"D","E":{"F":"G"}}}`,
@@ -35,6 +39,7 @@ func TestPathElementRoundTrip(t *testing.T) {
 		`v:"some-string"`,
 		`v:1234`,
 		`v:{"some":"json"}`,
+		`v:{"some":" some  with spaces  "}`,
 		`k:{"name":"app-🚀"}`,
 		`k:{"name":"app-💻"}`,
 		`k:{"name":"app with-unicøde"}`,
@@ -79,6 +84,7 @@ func TestDeserializePathElementError(t *testing.T) {
 		`v:`,
 		`k:invalid json`,
 		`k:{"name":invalid}`,
+		`v:{"some":" \x41"}`, // This is an invalid JSON string because \x41 is not a valid escape sequence.
 	}
 
 	for _, test := range tests {

--- a/fieldpath/set_test.go
+++ b/fieldpath/set_test.go
@@ -61,7 +61,7 @@ var randomPathMaker = randomPathAlphabet(MakePathOrDie(
 	KeyByFields("name", "second"),
 	KeyByFields("port", 443, "protocol", "tcp"),
 	KeyByFields("port", 443, "protocol", "udp"),
-	KeyByFields("key", "value"),
+	KeyByFields("key", " value with spaces "),
 	KeyByFields("lang", "en-US"),
 	KeyByFields("unicode-key", "unicode-value-🔥"),
 	// Values


### PR DESCRIPTION
Add cases mentioned in  https://github.com/kubernetes-sigs/structured-merge-diff/pull/292#issuecomment-3271796972.

This pull request adds test coverage for serialization and deserialization of field paths, focusing on correctly handling spaces and invalid escape characters.

### Description

This PR addresses cases mentioned in https://github.com/kubernetes-sigs/structured-merge-diff/pull/292#issuecomment-3271796972. The test suite is expanded to include tests for:

*   **Leading and trailing spaces:** New test cases have been added to `fieldpath/serialize-pe_test.go`, `fieldpath/serialize_test.go`, and `fieldpath/set_test.go` to ensure that leading and trailing spaces in field names and key values are preserved during serialization and deserialization round-trips.
*   **Invalid escape characters:** A new test has been added to `fieldpath/serialize-pe_test.go` to verify that an error is correctly returned when deserializing a path element that contains an invalid JSON escape sequence.

These additions improve the robustness of the serialization and deserialization  logic.
