### PR TITLE
fix: RemoveItems should preserve empty list and map

### DIFF
--- a/merge/multiple_appliers_test.go
+++ b/merge/multiple_appliers_test.go
@@ -1061,14 +1061,14 @@ func TestMultipleAppliersNestedType(t *testing.T) {
 				},
 			},
 			Object: `
-				mapOfMapsRecursive:
-				  a:
-				  c:
-				    d:
-				      e:
-				        f:
-				          g:
-			`,
+			mapOfMapsRecursive:
+			  a: {}
+			  c:
+			    d:
+			      e:
+			        f:
+			          g:
+		`,
 			APIVersion: "v1",
 			Managed: fieldpath.ManagedFields{
 				"apply-one": fieldpath.NewVersionedSet(
@@ -1187,13 +1187,13 @@ func TestMultipleAppliersDeducedType(t *testing.T) {
 				},
 			},
 			Object: `
-				a:
-				c:
-				  d:
-				    e:
-				      f:
-				        g:
-			`,
+			a: {}
+			c:
+			  d:
+			    e:
+			      f:
+			        g:
+		`,
 			APIVersion: "v1",
 			Managed: fieldpath.ManagedFields{
 				"apply-two": fieldpath.NewVersionedSet(

--- a/merge/nested_test.go
+++ b/merge/nested_test.go
@@ -554,8 +554,8 @@ func TestUpdateNestedType(t *testing.T) {
 				},
 			},
 			Object: `
-				struct:
-			`,
+			struct: {}
+		`,
 			APIVersion: "v1",
 			Managed: fieldpath.ManagedFields{
 				"default": fieldpath.NewVersionedSet(

--- a/typed/remove.go
+++ b/typed/remove.go
@@ -99,12 +99,12 @@ func (w *removingWalker) doList(t *schema.List) (errs ValidationErrors) {
 				continue
 			}
 			if isPrefixMatch {
-				// Removing nested items WITHIN this list item - preserve if it becomes empty
+				// Removing nested items within this list item and preserve if it becomes empty
 				hadMatches = true
 				wasMap := item.IsMap()
 				wasList := item.IsList()
 				item = removeItemsWithSchema(item, w.toRemove.WithPrefix(pe), w.schema, t.ElementType, w.shouldExtract)
-				// If recursive call returned null but we're removing items within (not the item itself),
+				// If item returned null but we're removing items within the structure(not the item itself),
 				// preserve the empty container structure
 				if item.IsNull() && !w.shouldExtract {
 					if wasMap {
@@ -167,7 +167,6 @@ func (w *removingWalker) doMap(t *schema.Map) ValidationErrors {
 		// save values on the path when we shouldExtract
 		// but ignore them when we are removing (i.e. !w.shouldExtract)
 		if w.toRemove.Has(path) {
-			// Exact match: removing this field itself, not items within it
 			if w.shouldExtract {
 				newMap[k] = removeItemsWithSchema(val, w.toRemove, w.schema, fieldType, w.shouldExtract).Unstructured()
 
@@ -179,7 +178,7 @@ func (w *removingWalker) doMap(t *schema.Map) ValidationErrors {
 			wasMap := val.IsMap()
 			wasList := val.IsList()
 			val = removeItemsWithSchema(val, subset, w.schema, fieldType, w.shouldExtract)
-			// If recursive call returned null but we're removing items within (not the field itself),
+			// If val returned null but we're removing items within the structure (not the field itself),
 			// preserve the empty container structure
 			if val.IsNull() && !w.shouldExtract {
 				if wasMap {

--- a/typed/remove_test.go
+++ b/typed/remove_test.go
@@ -281,7 +281,7 @@ var removeCases = []removeTestCase{{
 	quadruplets: []removeQuadruplet{{
 		`{"setBool":[false]}`,
 		_NS(_P("setBool", _V(false))),
-		`{"setBool":null}`,
+		`{"setBool":[]}`,
 		`{"setBool":[false]}`,
 	}, {
 		`{"setBool":[false]}`,
@@ -671,7 +671,7 @@ var removeCases = []removeTestCase{{
 		_NS(
 			_P("mapOfMapsRecursive", "a"),
 		),
-		`{"mapOfMapsRecursive"}`,
+		`{"mapOfMapsRecursive":{}}`,
 		`{"mapOfMapsRecursive": {"a":null}}`,
 	}, {
 		// second-level map
@@ -679,7 +679,7 @@ var removeCases = []removeTestCase{{
 		_NS(
 			_P("mapOfMapsRecursive", "a", "b"),
 		),
-		`{"mapOfMapsRecursive":{"a":null}}`,
+		`{"mapOfMapsRecursive":{"a":{}}}`,
 		`{"mapOfMapsRecursive": {"a":{"b":null}}}`,
 	}, {
 		// third-level map
@@ -687,7 +687,7 @@ var removeCases = []removeTestCase{{
 		_NS(
 			_P("mapOfMapsRecursive", "a", "b", "c"),
 		),
-		`{"mapOfMapsRecursive":{"a":{"b":null}}}`,
+		`{"mapOfMapsRecursive":{"a":{"b":{}}}}`,
 		`{"mapOfMapsRecursive": {"a":{"b":{"c":null}}}}`,
 	}, {
 		// empty list


### PR DESCRIPTION
fixes https://github.com/kubernetes-sigs/structured-merge-diff/issues/305

Modify tests for new behavior:
RemoveItems will maintain [] or {} instead of changing to null