### PR TITLE
fix: handle nil values in field path and update tests

### DIFF
--- a/value/reflectcache.go
+++ b/value/reflectcache.go
@@ -84,6 +84,10 @@ func (f *FieldCacheEntry) CanOmit(fieldVal reflect.Value) bool {
 func (f *FieldCacheEntry) GetFrom(structVal reflect.Value) reflect.Value {
 	// field might be nested within 'inline' structs
 	for _, elem := range f.fieldPath {
+		if safeIsNil(structVal) {
+			// if any part of the path is nil, return the zero value for the field type
+			return reflect.Zero(f.fieldType)
+		}
 		structVal = dereference(structVal).FieldByIndex(elem)
 	}
 	return structVal

--- a/value/valuereflect_test.go
+++ b/value/valuereflect_test.go
@@ -290,6 +290,12 @@ func TestReflectStruct(t *testing.T) {
 			expectedMap:          map[string]interface{}{"int": int64(10), "S": "string"},
 			expectedUnstructured: map[string]interface{}{"int": int64(10), "S": "string"},
 		},
+		{
+			name:                 "embeddedIsNil",
+			val:                  testEmbeddedStruct{},
+			expectedMap:          map[string]interface{}{"int": int64(0), "S": ""},
+			expectedUnstructured: map[string]interface{}{"int": int64(0), "S": ""},
+		},
 	}
 
 	for _, tc := range cases {


### PR DESCRIPTION
## Summary
Fixes a nil pointer dereference panic that occurs when `GetFrom` attempts to access fields from embedded structs that are nil pointers. This adds defensive nil checking when traversing field paths to safely return zero values instead of panicking.

## Problem
The `FieldCacheEntry.GetFrom` method in `value/reflectcache.go` traverses field paths using `FieldByIndex` without checking if intermediate struct values are nil. When dealing with embedded pointer structs (e.g., `*testBasicStruct` embedded with `,inline` tag), if the pointer is nil, calling `FieldByIndex` causes a panic.

**Example scenario:**
```go
type testEmbeddedStruct struct {
    *testBasicStruct `json:",inline"`
}

// When testBasicStruct is nil, accessing its fields would panic
val := testEmbeddedStruct{} // embedded pointer is nil
```

## Impact
- **No breaking changes**: Existing behavior preserved for non-nil paths
- **Bug fix**: Prevents panic when accessing fields through nil embedded struct pointers
- **Graceful degradation**: Returns appropriate zero values instead of crashing