### PR TITLE
Jsontagutil: Ignore unexported fields without json tags

### DIFF
--- a/value/jsontagutil.go
+++ b/value/jsontagutil.go
@@ -76,6 +76,10 @@ func OmitZeroFunc(t reflect.Type) func(reflect.Value) bool {
 // but is based on the highly efficient approach from https://golang.org/src/encoding/json/encode.go
 
 func lookupJsonTags(f reflect.StructField) (name string, omit bool, inline bool, omitempty bool, omitzero func(reflect.Value) bool) {
+	// Skip unexported non-embedded fields, matching encoding/json behavior.
+	if f.PkgPath != "" && !f.Anonymous {
+		return "", true, false, false, nil
+	}
 	tag := f.Tag.Get("json")
 	if tag == "-" {
 		return "", true, false, false, nil

--- a/value/reflectcache_test.go
+++ b/value/reflectcache_test.go
@@ -262,6 +262,30 @@ func TestTypeReflectEntryOf(t *testing.T) {
 				orderedStructFields: []*FieldCacheEntry{},
 			},
 		},
+		"StructWithUnexportedField": {
+			arg: struct {
+				Exported   string `json:"exported"`
+				unexported string
+			}{},
+			want: &TypeReflectCacheEntry{
+				structFields: map[string]*FieldCacheEntry{
+					"exported": {
+						JsonName:  "exported",
+						fieldPath: [][]int{{0}},
+						fieldType: reflect.TypeOf(testString),
+						TypeEntry: &TypeReflectCacheEntry{},
+					},
+				},
+				orderedStructFields: []*FieldCacheEntry{
+					{
+						JsonName:  "exported",
+						fieldPath: [][]int{{0}},
+						fieldType: reflect.TypeOf(testString),
+						TypeEntry: &TypeReflectCacheEntry{},
+					},
+				},
+			},
+		},
 	}
 	for name, tt := range tests {
 		t.Run(name, func(t *testing.T) {


### PR DESCRIPTION
Without this, the `Extract` function generated by applyconfig-gen will error for a type that has an unexported field without a json tag:

```
error converting obj to typed: .spec.unexportedField: field not declared in schema
{
    msg: "error converting obj to typed: .spec.unexportedField: field not declared in schema",
    err: <typed.ValidationErrors | len:1, cap:1>[
        {
            Path: ".spec.unexportedField",
            ErrorMessage: "field not declared in schema",
        },
    ],
}
```