### PR TITLE
Valuereflect: Add support for arrays

### DIFF
--- a/value/valuereflect.go
+++ b/value/valuereflect.go
@@ -173,6 +173,12 @@ func kind(v reflect.Value) reflectType {
 		return stringType
 	case reflect.Bool:
 		return boolType
+	case reflect.Array:
+		elemKind := typ.Elem().Kind()
+		if elemKind == reflect.Uint8 {
+			return byteStringType
+		}
+		return listType
 	case reflect.Slice:
 		if v.IsNil() {
 			return nullType

--- a/value/valuereflect_test.go
+++ b/value/valuereflect_test.go
@@ -627,6 +627,13 @@ func TestReflectList(t *testing.T) {
 			expectedUnstructured: []interface{}{"converted1", "converted2"},
 			length:               2,
 		},
+		{
+			name:                 "stringArray",
+			val:                  [2]string{"value1", "value2"},
+			expectedIterate:      []interface{}{"value1", "value2"},
+			expectedUnstructured: []interface{}{"value1", "value2"},
+			length:               2,
+		},
 	}
 
 	for _, tc := range cases {


### PR DESCRIPTION
Without this, the Extract function generated by applyconfig-gen panics:
```
unsupported type: [3]int
```

Fixes https://github.com/kubernetes-sigs/structured-merge-diff/issues/311