### PR TITLE
Add PathElement struct comparison to TestPathElementRoundTrip

### DIFF
--- a/fieldpath/serialize-pe_test.go
+++ b/fieldpath/serialize-pe_test.go
@@ -17,50 +17,61 @@ limitations under the License.
 package fieldpath
 
 import (
+	"reflect"
 	"testing"
+
+	"sigs.k8s.io/structured-merge-diff/v6/value"
 )
 
 func TestPathElementRoundTrip(t *testing.T) {
-	tests := []string{
-		`i:0`,
-		`i:1234`,
-		`f:`,
-		`f:spec`,
-		`f:more-complicated-string`,
-		`f: string-with-spaces   `,
-		`f:abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789`,
-		`k:{"name":"my-container"}`,
-		`k:{"name":"   name with spaces   "}`,
-		`k:{"port":"8080","protocol":"TCP"}`,
-		`k:{"optionalField":null}`,
-		`k:{"jsonField":{"A":1,"B":null,"C":"D","E":{"F":"G"}}}`,
-		`k:{"listField":["1","2","3"]}`,
-		`v:null`,
-		`v:"some-string"`,
-		`v:1234`,
-		`v:{"some":"json"}`,
-		`v:{"some":" some  with spaces  "}`,
-		`k:{"name":"app-🚀"}`,
-		`k:{"name":"app-💻"}`,
-		`k:{"name":"app with-unicøde"}`,
-		`k:{"name":"你好世界"}`,
-		`k:{"name":"Привет, мир"}`,
-		`k:{"name":"नमस्ते दुनिया"}`,
-		`k:{"name":"👋"}`,
+	type testCase struct {
+		stringValue string
+		pathElement PathElement
+	}
+
+	tests := []testCase{
+		{`i:0`, IndexElement(0)},
+		{`i:1234`, IndexElement(1234)},
+		{`f:`, FieldNameElement("")},
+		{`f:spec`, FieldNameElement("spec")},
+		{`f:more-complicated-string`, FieldNameElement("more-complicated-string")},
+		{`f: string-with-spaces   `, FieldNameElement(" string-with-spaces   ")},
+		{`f:abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789`, FieldNameElement("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789")},
+		{`k:{"name":"my-container"}`, KeyElement(value.Field{Name: "name", Value: value.NewValueInterface("my-container")})},
+		{`k:{"name":"   name with spaces   "}`, KeyElement(value.Field{Name: "name", Value: value.NewValueInterface("   name with spaces   ")})},
+		{`k:{"port":"8080","protocol":"TCP"}`, KeyElement(value.Field{Name: "port", Value: value.NewValueInterface("8080")}, value.Field{Name: "protocol", Value: value.NewValueInterface("TCP")})},
+		{`k:{"optionalField":null}`, KeyElement(value.Field{Name: "optionalField", Value: value.NewValueInterface(nil)})},
+		{`k:{"jsonField":{"A":1,"B":null,"C":"D","E":{"F":"G"}}}`, KeyElement(value.Field{Name: "jsonField", Value: value.NewValueInterface(map[string]interface{}{"A": float64(1), "B": nil, "C": "D", "E": map[string]interface{}{"F": "G"}})})},
+		{`k:{"listField":["1","2","3"]}`, KeyElement(value.Field{Name: "listField", Value: value.NewValueInterface([]interface{}{"1", "2", "3"})})},
+		{`v:null`, ValueElement(value.NewValueInterface(nil))},
+		{`v:"some-string"`, ValueElement(value.NewValueInterface("some-string"))},
+		{`v:1234`, ValueElement(value.NewValueInterface(float64(1234)))},
+		{`v:{"some":"json"}`, ValueElement(value.NewValueInterface(map[string]interface{}{"some": "json"}))},
+		{`v:{"some":" some  with spaces  "}`, ValueElement(value.NewValueInterface(map[string]interface{}{"some": " some  with spaces  "}))},
+		{`k:{"name":"app-🚀"}`, KeyElement(value.Field{Name: "name", Value: value.NewValueInterface("app-🚀")})},
+		{`k:{"name":"app-💻"}`, KeyElement(value.Field{Name: "name", Value: value.NewValueInterface("app-💻")})},
+		{`k:{"name":"app with-unicøde"}`, KeyElement(value.Field{Name: "name", Value: value.NewValueInterface("app with-unicøde")})},
+		{`k:{"name":"你好世界"}`, KeyElement(value.Field{Name: "name", Value: value.NewValueInterface("你好世界")})},
+		{`k:{"name":"Привет, мир"}`, KeyElement(value.Field{Name: "name", Value: value.NewValueInterface("Привет, мир")})},
+		{`k:{"name":"नमस्ते दुनिया"}`, KeyElement(value.Field{Name: "name", Value: value.NewValueInterface("नमस्ते दुनिया")})},
+		{`k:{"name":"👋"}`, KeyElement(value.Field{Name: "name", Value: value.NewValueInterface("👋")})},
 	}
 
 	for _, test := range tests {
-		t.Run(test, func(t *testing.T) {
-			pe, err := DeserializePathElement(test)
+		t.Run(test.stringValue, func(t *testing.T) {
+			pe, err := DeserializePathElement(test.stringValue)
 			if err != nil {
 				t.Fatalf("Failed to create path element: %v", err)
+			}
+			if !reflect.DeepEqual(pe, test.pathElement) {
+				t.Fatalf("Expected round-trip:\ninput: %#v\noutput: %#v", test.pathElement, pe)
 			}
 			output, err := SerializePathElement(pe)
 			if err != nil {
 				t.Fatalf("Failed to create string from path element (%#v): %v", pe, err)
 			}
-			if test != output {
-				t.Fatalf("Expected round-trip:\ninput: %v\noutput: %v", test, output)
+			if test.stringValue != output {
+				t.Fatalf("Expected round-trip:\ninput: %v\noutput: %v", test.stringValue, output)
 			}
 		})
 	}


### PR DESCRIPTION
"The existing unit tests for DeserializePathElement (e.g., TestPathElementRoundTrip) only verify that the deserialized element can be round-tripped back into a string. The tests need to be updated to assert the actual in-memory state of the PathElement object returned by the DeserializePathElement function. This ensures that the function correctly populates the internal structure of the PathElement, not just its string representation." - SMD #292 Action items

This PR adds these struct comparisions to the TestPathElementRoundTrip test.