### PR TITLE
Test duplicate key behavior in KeyElement

### DIFF
--- a/fieldpath/serialize-pe_test.go
+++ b/fieldpath/serialize-pe_test.go
@@ -55,6 +55,7 @@ func TestPathElementRoundTrip(t *testing.T) {
 		{`k:{"name":"Привет, мир"}`, KeyElement(value.Field{Name: "name", Value: value.NewValueInterface("Привет, мир")})},
 		{`k:{"name":"नमस्ते दुनिया"}`, KeyElement(value.Field{Name: "name", Value: value.NewValueInterface("नमस्ते दुनिया")})},
 		{`k:{"name":"👋"}`, KeyElement(value.Field{Name: "name", Value: value.NewValueInterface("👋")})},
+		{`k:{"duplicateKey":"value1","duplicateKey":"value2"}`, KeyElement(value.Field{Name: "duplicateKey", Value: value.NewValueInterface("value1")}, value.Field{Name: "duplicateKey", Value: value.NewValueInterface("value2")})},
 	}
 
 	for _, test := range tests {

--- a/fieldpath/serialize-pe_test.go
+++ b/fieldpath/serialize-pe_test.go
@@ -57,6 +57,7 @@ func TestPathElementRoundTrip(t *testing.T) {
 		{`k:{"name":"👋"}`, KeyElement(value.Field{Name: "name", Value: value.NewValueInterface("👋")})},
 		{`f:spec-🚀`, FieldNameElement("spec-🚀")},
 		{`f:spec-\n`, FieldNameElement("spec-\\n")},
+		{`k:{"duplicateKey":"value1","duplicateKey":"value2"}`, KeyElement(value.Field{Name: "duplicateKey", Value: value.NewValueInterface("value1")}, value.Field{Name: "duplicateKey", Value: value.NewValueInterface("value2")})},
 	}
 
 	for _, test := range tests {


### PR DESCRIPTION
"Investigate whether the original ReadObjectCB function implicitly prevented or handled duplicate key entries in JSON objects. Based on this, create a specific test case to ensure the new json/v2 implementation behaves identically to json-iterator when encountering duplicate keys." - SMD #292 Action items

Adds test case for duplicate keys in KeyElement