### PR TITLE
Code cleanup: remove sorted... type aliases

### DIFF
--- a/fieldpath/element.go
+++ b/fieldpath/element.go
@@ -226,27 +226,19 @@ func KeyByFields(nameValues ...interface{}) *value.FieldList {
 // PathElementSet is a set of path elements.
 // TODO: serialize as a list.
 type PathElementSet struct {
-	members sortedPathElements
+	members []PathElement // sorted, with no duplicates
 }
 
 func MakePathElementSet(size int) PathElementSet {
 	return PathElementSet{
-		members: make(sortedPathElements, 0, size),
+		members: make([]PathElement, 0, size),
 	}
 }
-
-type sortedPathElements []PathElement
-
-// Implement the sort interface; this would permit bulk creation, which would
-// be faster than doing it one at a time via Insert.
-func (spe sortedPathElements) Len() int           { return len(spe) }
-func (spe sortedPathElements) Less(i, j int) bool { return spe[i].Less(spe[j]) }
-func (spe sortedPathElements) Swap(i, j int)      { spe[i], spe[j] = spe[j], spe[i] }
 
 // Copy returns a copy of the PathElementSet.
 // This is not a full deep copy as any contained value.Value is not copied.
 func (s PathElementSet) Copy() PathElementSet {
-	out := make(sortedPathElements, len(s.members))
+	out := make([]PathElement, len(s.members))
 	for i := range s.members {
 		out[i] = s.members[i].Copy()
 	}

--- a/fieldpath/pathelementmap.go
+++ b/fieldpath/pathelementmap.go
@@ -37,16 +37,6 @@ func MakePathElementValueMap(size int) PathElementValueMap {
 	}
 }
 
-type sortedPathElementValues []pathElementValue
-
-// Implement the sort interface; this would permit bulk creation, which would
-// be faster than doing it one at a time via Insert.
-func (spev sortedPathElementValues) Len() int { return len(spev) }
-func (spev sortedPathElementValues) Less(i, j int) bool {
-	return spev[i].PathElement.Less(spev[j].PathElement)
-}
-func (spev sortedPathElementValues) Swap(i, j int) { spev[i], spev[j] = spev[j], spev[i] }
-
 // Insert adds the pathelement and associated value in the map.
 // If insert is called twice with the same PathElement, the value is replaced.
 func (s *PathElementValueMap) Insert(pe PathElement, v value.Value) {
@@ -65,7 +55,7 @@ func (s *PathElementValueMap) Get(pe PathElement) (value.Value, bool) {
 
 // PathElementValueMap is a map from PathElement to interface{}.
 type PathElementMap struct {
-	members sortedPathElementValues
+	members []pathElementValue // sorted, with no duplicates
 }
 
 type pathElementValue struct {
@@ -75,7 +65,7 @@ type pathElementValue struct {
 
 func MakePathElementMap(size int) PathElementMap {
 	return PathElementMap{
-		members: make(sortedPathElementValues, 0, size),
+		members: make([]pathElementValue, 0, size),
 	}
 }
 


### PR DESCRIPTION
We are using `slices.SortFunc` now instead, these aliases are no longer used.