### PR TITLE
fix(value): detect inline fields structurally instead of matching ",inline" tag

### DIFF
--- a/value/jsontagutil.go
+++ b/value/jsontagutil.go
@@ -85,6 +85,7 @@ func lookupJsonTags(f reflect.StructField) (name string, omit bool, inline bool,
 		return "", true, false, false, nil
 	}
 	name, opts := parseTag(tag)
+	inline = f.Anonymous && name == ""
 	if name == "" {
 		name = f.Name
 	}
@@ -93,7 +94,7 @@ func lookupJsonTags(f reflect.StructField) (name string, omit bool, inline bool,
 		omitzero = OmitZeroFunc(f.Type)
 	}
 
-	return name, false, opts.Contains("inline"), opts.Contains("omitempty"), omitzero
+	return name, false, inline, opts.Contains("omitempty"), omitzero
 }
 
 func isEmpty(v reflect.Value) bool {

--- a/value/jsontagutil_test.go
+++ b/value/jsontagutil_test.go
@@ -1,0 +1,76 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package value
+
+import (
+	"reflect"
+	"testing"
+)
+
+type innerType struct {
+	X string `json:"x"`
+}
+
+type testEmbeddedEmptyTag struct {
+	innerType `json:""`
+}
+
+type testEmbeddedInlineTag struct {
+	innerType `json:",inline"`
+}
+
+type testNonEmbeddedInlineTag struct {
+	Field string `json:",inline"`
+}
+
+func TestLookupJsonTagsInline(t *testing.T) {
+	tests := []struct {
+		name           string
+		structType     reflect.Type
+		fieldIndex     int
+		expectedInline bool
+	}{
+		{
+			name:           "embedded with empty json tag",
+			structType:     reflect.TypeOf(testEmbeddedEmptyTag{}),
+			fieldIndex:     0,
+			expectedInline: true,
+		},
+		{
+			name:           "embedded with ,inline tag",
+			structType:     reflect.TypeOf(testEmbeddedInlineTag{}),
+			fieldIndex:     0,
+			expectedInline: true,
+		},
+		{
+			name:           "non-embedded with ,inline tag",
+			structType:     reflect.TypeOf(testNonEmbeddedInlineTag{}),
+			fieldIndex:     0,
+			expectedInline: false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			f := tc.structType.Field(tc.fieldIndex)
+			_, _, inline, _, _ := lookupJsonTags(f)
+			if inline != tc.expectedInline {
+				t.Errorf("lookupJsonTags(%v) inline = %v, want %v", f.Name, inline, tc.expectedInline)
+			}
+		})
+	}
+}

--- a/value/reflectcache_test.go
+++ b/value/reflectcache_test.go
@@ -253,13 +253,96 @@ func TestTypeReflectEntryOf(t *testing.T) {
 				},
 			},
 		},
-		"StructWithInlinedField": {
+		"StructWithNonEmbeddedInlineTag": {
 			arg: struct {
 				F1 string `json:",inline"`
 			}{},
 			want: &TypeReflectCacheEntry{
-				structFields:        map[string]*FieldCacheEntry{},
-				orderedStructFields: []*FieldCacheEntry{},
+				structFields: map[string]*FieldCacheEntry{
+					"F1": {
+						JsonName:  "F1",
+						fieldPath: [][]int{{0}},
+						fieldType: reflect.TypeOf(testString),
+						TypeEntry: &TypeReflectCacheEntry{},
+					},
+				},
+				orderedStructFields: []*FieldCacheEntry{
+					{
+						JsonName:  "F1",
+						fieldPath: [][]int{{0}},
+						fieldType: reflect.TypeOf(testString),
+						TypeEntry: &TypeReflectCacheEntry{},
+					},
+				},
+			},
+		},
+		"EmbeddedWithInlineTag": {
+			arg: struct {
+				Inlined `json:",inline"`
+			}{},
+			want: &TypeReflectCacheEntry{
+				structFields: map[string]*FieldCacheEntry{
+					"f1": {
+						JsonName:  "f1",
+						fieldPath: [][]int{{0}, {0}},
+						fieldType: reflect.TypeOf(testString),
+						TypeEntry: &TypeReflectCacheEntry{},
+					},
+				},
+				orderedStructFields: []*FieldCacheEntry{
+					{
+						JsonName:  "f1",
+						fieldPath: [][]int{{0}, {0}},
+						fieldType: reflect.TypeOf(testString),
+						TypeEntry: &TypeReflectCacheEntry{},
+					},
+				},
+			},
+		},
+		"EmbeddedWithEmptyJSONTag": {
+			arg: struct {
+				Inlined `json:""`
+			}{},
+			want: &TypeReflectCacheEntry{
+				structFields: map[string]*FieldCacheEntry{
+					"f1": {
+						JsonName:  "f1",
+						fieldPath: [][]int{{0}, {0}},
+						fieldType: reflect.TypeOf(testString),
+						TypeEntry: &TypeReflectCacheEntry{},
+					},
+				},
+				orderedStructFields: []*FieldCacheEntry{
+					{
+						JsonName:  "f1",
+						fieldPath: [][]int{{0}, {0}},
+						fieldType: reflect.TypeOf(testString),
+						TypeEntry: &TypeReflectCacheEntry{},
+					},
+				},
+			},
+		},
+		"EmbeddedWithNoTag": {
+			arg: struct {
+				Inlined
+			}{},
+			want: &TypeReflectCacheEntry{
+				structFields: map[string]*FieldCacheEntry{
+					"f1": {
+						JsonName:  "f1",
+						fieldPath: [][]int{{0}, {0}},
+						fieldType: reflect.TypeOf(testString),
+						TypeEntry: &TypeReflectCacheEntry{},
+					},
+				},
+				orderedStructFields: []*FieldCacheEntry{
+					{
+						JsonName:  "f1",
+						fieldPath: [][]int{{0}, {0}},
+						fieldType: reflect.TypeOf(testString),
+						TypeEntry: &TypeReflectCacheEntry{},
+					},
+				},
 			},
 		},
 		"StructWithUnexportedField": {
@@ -315,6 +398,10 @@ func TestTypeReflectEntryOf(t *testing.T) {
 			}
 		})
 	}
+}
+
+type Inlined struct {
+	F1 string `json:"f1"`
 }
 
 type customOmitZeroType struct {

--- a/value/valuereflect_test.go
+++ b/value/valuereflect_test.go
@@ -230,8 +230,8 @@ type testOmitStruct struct {
 	S string
 }
 type testInlineStruct struct {
-	Inline T `json:",inline"`
-	S      string
+	T `json:""`
+	S string
 }
 type testOmitemptyStruct struct {
 	Noomit *string `json:"noomit"`
@@ -274,7 +274,7 @@ func TestReflectStruct(t *testing.T) {
 		},
 		{
 			name:                 "inline",
-			val:                  &testInlineStruct{Inline: T{I: 10}, S: "string"},
+			val:                  &testInlineStruct{T: T{I: 10}, S: "string"},
 			expectedMap:          map[string]interface{}{"int": int64(10), "S": "string"},
 			expectedUnstructured: map[string]interface{}{"int": int64(10), "S": "string"},
 		},


### PR DESCRIPTION
xref: https://github.com/kubernetes/kubernetes/pull/138260