### PR TITLE
Add a direct unstructured conversion interface that can return errors.

### DIFF
--- a/value/reflectcache.go
+++ b/value/reflectcache.go
@@ -93,9 +93,9 @@ func (f *FieldCacheEntry) GetFrom(structVal reflect.Value) reflect.Value {
 	return structVal
 }
 
-var marshalerType = reflect.TypeOf(new(json.Marshaler)).Elem()
-var unmarshalerType = reflect.TypeOf(new(json.Unmarshaler)).Elem()
-var unstructuredConvertableType = reflect.TypeOf(new(UnstructuredConverter)).Elem()
+var marshalerType = reflect.TypeFor[json.Marshaler]()
+var unmarshalerType = reflect.TypeFor[json.Unmarshaler]()
+var unstructuredConvertableType = reflect.TypeFor[UnstructuredConverter]()
 var defaultReflectCache = newReflectCache()
 
 // TypeReflectEntryOf returns the TypeReflectCacheEntry of the provided reflect.Type.
@@ -123,10 +123,10 @@ func typeReflectEntryOf(cm reflectCacheMap, t reflect.Type, updates reflectCache
 	}
 	typeEntry := &TypeReflectCacheEntry{
 		isJsonMarshaler:        t.Implements(marshalerType),
-		ptrIsJsonMarshaler:     reflect.PtrTo(t).Implements(marshalerType),
-		isJsonUnmarshaler:      reflect.PtrTo(t).Implements(unmarshalerType),
+		ptrIsJsonMarshaler:     reflect.PointerTo(t).Implements(marshalerType),
+		isJsonUnmarshaler:      reflect.PointerTo(t).Implements(unmarshalerType),
 		isStringConvertable:    t.Implements(unstructuredConvertableType),
-		ptrIsStringConvertable: reflect.PtrTo(t).Implements(unstructuredConvertableType),
+		ptrIsStringConvertable: reflect.PointerTo(t).Implements(unstructuredConvertableType),
 	}
 	if t.Kind() == reflect.Struct {
 		fieldEntries := map[string]*FieldCacheEntry{}

--- a/value/reflectcache.go
+++ b/value/reflectcache.go
@@ -39,14 +39,28 @@ type UnstructuredConverter interface {
 	ToUnstructured() interface{}
 }
 
+// UnstructuredConverterWithError is implemented instead of UnstructuredConverter by types for which
+// some, but not all, values can be converted directly to unstructured. If a type implements both
+// UnstructuredConverter and UnstructuredConverterWithError, its UnstructuredConverterWithError
+// implementation takes precedence during conversion.
+type UnstructuredConverterWithError interface {
+	json.Marshaler // require that json.Marshaler is implemented
+
+	// ToUnstructured returns the unstructured representation, or a non-nil error if the value
+	// cannot be converted to unstructured.
+	ToUnstructuredWithError() (any, error)
+}
+
 // TypeReflectCacheEntry keeps data gathered using reflection about how a type is converted to/from unstructured.
 type TypeReflectCacheEntry struct {
-	isJsonMarshaler        bool
-	ptrIsJsonMarshaler     bool
-	isJsonUnmarshaler      bool
-	ptrIsJsonUnmarshaler   bool
-	isStringConvertable    bool
-	ptrIsStringConvertable bool
+	isJsonMarshaler                     bool
+	ptrIsJsonMarshaler                  bool
+	isJsonUnmarshaler                   bool
+	ptrIsJsonUnmarshaler                bool
+	isUnstructuredConverter             bool
+	ptrIsUnstructuredConverter          bool
+	isUnstructuredConverterWithError    bool
+	ptrIsUnstructuredConverterWithError bool
 
 	structFields        map[string]*FieldCacheEntry
 	orderedStructFields []*FieldCacheEntry
@@ -95,7 +109,8 @@ func (f *FieldCacheEntry) GetFrom(structVal reflect.Value) reflect.Value {
 
 var marshalerType = reflect.TypeFor[json.Marshaler]()
 var unmarshalerType = reflect.TypeFor[json.Unmarshaler]()
-var unstructuredConvertableType = reflect.TypeFor[UnstructuredConverter]()
+var unstructuredConverterType = reflect.TypeFor[UnstructuredConverter]()
+var unstructuredConverterWithErrorType = reflect.TypeFor[UnstructuredConverterWithError]()
 var defaultReflectCache = newReflectCache()
 
 // TypeReflectEntryOf returns the TypeReflectCacheEntry of the provided reflect.Type.
@@ -122,11 +137,13 @@ func typeReflectEntryOf(cm reflectCacheMap, t reflect.Type, updates reflectCache
 		return record
 	}
 	typeEntry := &TypeReflectCacheEntry{
-		isJsonMarshaler:        t.Implements(marshalerType),
-		ptrIsJsonMarshaler:     reflect.PointerTo(t).Implements(marshalerType),
-		isJsonUnmarshaler:      reflect.PointerTo(t).Implements(unmarshalerType),
-		isStringConvertable:    t.Implements(unstructuredConvertableType),
-		ptrIsStringConvertable: reflect.PointerTo(t).Implements(unstructuredConvertableType),
+		isJsonMarshaler:                     t.Implements(marshalerType),
+		ptrIsJsonMarshaler:                  reflect.PointerTo(t).Implements(marshalerType),
+		isJsonUnmarshaler:                   reflect.PointerTo(t).Implements(unmarshalerType),
+		isUnstructuredConverter:             t.Implements(unstructuredConverterType),
+		ptrIsUnstructuredConverter:          reflect.PointerTo(t).Implements(unstructuredConverterType),
+		isUnstructuredConverterWithError:    t.Implements(unstructuredConverterWithErrorType),
+		ptrIsUnstructuredConverterWithError: reflect.PointerTo(t).Implements(unstructuredConverterWithErrorType),
 	}
 	if t.Kind() == reflect.Struct {
 		fieldEntries := map[string]*FieldCacheEntry{}
@@ -190,7 +207,7 @@ func (e TypeReflectCacheEntry) OrderedFields() []*FieldCacheEntry {
 
 // CanConvertToUnstructured returns true if this TypeReflectCacheEntry can convert values of its type to unstructured.
 func (e TypeReflectCacheEntry) CanConvertToUnstructured() bool {
-	return e.isJsonMarshaler || e.ptrIsJsonMarshaler || e.isStringConvertable || e.ptrIsStringConvertable
+	return e.isJsonMarshaler || e.ptrIsJsonMarshaler || e.isUnstructuredConverter || e.ptrIsUnstructuredConverter || e.isUnstructuredConverterWithError || e.ptrIsUnstructuredConverterWithError
 }
 
 // ToUnstructured converts the provided value to unstructured and returns it.
@@ -206,7 +223,7 @@ func (e TypeReflectCacheEntry) ToUnstructured(sv reflect.Value) (interface{}, er
 	// Check if the object has a custom string converter and use it if available, since it is much more efficient
 	// than round tripping through json.
 	if converter, ok := e.getUnstructuredConverter(sv); ok {
-		return converter.ToUnstructured(), nil
+		return converter.ToUnstructuredWithError()
 	}
 	// Check if the object has a custom JSON marshaller/unmarshaller.
 	if marshaler, ok := e.getJsonMarshaler(sv); ok {
@@ -318,16 +335,26 @@ func (e TypeReflectCacheEntry) getJsonUnmarshaler(v reflect.Value) (json.Unmarsh
 	return v.Addr().Interface().(json.Unmarshaler), true
 }
 
-func (e TypeReflectCacheEntry) getUnstructuredConverter(v reflect.Value) (UnstructuredConverter, bool) {
-	if e.isStringConvertable {
-		return v.Interface().(UnstructuredConverter), true
-	}
-	if e.ptrIsStringConvertable {
+type unstructuredConverterWithNilError struct {
+	UnstructuredConverter
+}
+
+func (c unstructuredConverterWithNilError) ToUnstructuredWithError() (any, error) {
+	return c.UnstructuredConverter.ToUnstructured(), nil
+}
+
+func (e TypeReflectCacheEntry) getUnstructuredConverter(v reflect.Value) (UnstructuredConverterWithError, bool) {
+	switch {
+	case e.isUnstructuredConverterWithError:
+		return v.Interface().(UnstructuredConverterWithError), true
+	case e.ptrIsUnstructuredConverterWithError && v.CanAddr():
 		// Check pointer receivers if v is not a pointer
-		if v.CanAddr() {
-			v = v.Addr()
-			return v.Interface().(UnstructuredConverter), true
-		}
+		return v.Addr().Interface().(UnstructuredConverterWithError), true
+	case e.isUnstructuredConverter:
+		return unstructuredConverterWithNilError{v.Interface().(UnstructuredConverter)}, true
+	case e.ptrIsUnstructuredConverter && v.CanAddr():
+		// Check pointer receivers if v is not a pointer
+		return unstructuredConverterWithNilError{v.Addr().Interface().(UnstructuredConverter)}, true
 	}
 	return nil, false
 }

--- a/value/reflectcache_test.go
+++ b/value/reflectcache_test.go
@@ -18,6 +18,7 @@ package value
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"reflect"
 	"testing"
@@ -55,6 +56,149 @@ func (t Time) ToUnstructured() interface{} {
 	buf := make([]byte, 0, len(time.RFC3339))
 	buf = t.UTC().AppendFormat(buf, time.RFC3339)
 	return string(buf)
+}
+
+// PointerUnstructuredConverter implements UnstructuredConverter with a pointer receiver.
+type PointerUnstructuredConverter struct {
+	val any
+}
+
+func (c *PointerUnstructuredConverter) MarshalJSON() ([]byte, error) {
+	return []byte(`"MarshalJSON"`), nil
+}
+
+func (c *PointerUnstructuredConverter) ToUnstructured() any {
+	return c.val
+}
+
+// ValueUnstructuredConverterWithError implements UnstructuredConverterWithError with a value
+// receiver.
+type ValueUnstructuredConverterWithError struct {
+	val any
+	err error
+}
+
+func (c ValueUnstructuredConverterWithError) MarshalJSON() ([]byte, error) {
+	return []byte(`"MarshalJSON"`), nil
+}
+
+func (c ValueUnstructuredConverterWithError) ToUnstructuredWithError() (any, error) {
+	return c.val, c.err
+}
+
+// PointerUnstructuredConverterWithError implements UnstructuredConverterWithError with a pointer
+// receiver.
+type PointerUnstructuredConverterWithError struct {
+	val any
+	err error
+}
+
+func (c *PointerUnstructuredConverterWithError) MarshalJSON() ([]byte, error) {
+	return []byte(`"MarshalJSON"`), nil
+}
+
+func (c *PointerUnstructuredConverterWithError) ToUnstructuredWithError() (any, error) {
+	return c.val, c.err
+}
+
+// ValueUnstructuredConverterWithAndWithoutError implements both UnstructuredConverter and
+// UnstructuredConverterWithError.
+type ValueUnstructuredConverterWithAndWithoutError struct{}
+
+func (c ValueUnstructuredConverterWithAndWithoutError) MarshalJSON() ([]byte, error) {
+	return []byte(`"MarshalJSON"`), nil
+}
+
+func (c ValueUnstructuredConverterWithAndWithoutError) ToUnstructured() any {
+	return "ToUnstructured"
+}
+
+func (c ValueUnstructuredConverterWithAndWithoutError) ToUnstructuredWithError() (any, error) {
+	return "ToUnstructuredWithError", nil
+}
+
+func TestUnstructuredConverterWithError(t *testing.T) {
+	t.Run("value receiver", func(t *testing.T) {
+		c := ValueUnstructuredConverterWithError{val: "hello"}
+		rv := reflect.ValueOf(c)
+		entry := TypeReflectEntryOf(rv.Type())
+		if !entry.CanConvertToUnstructured() {
+			t.Fatal("expected CanConvertToUnstructured to be true")
+		}
+		result, err := entry.ToUnstructured(rv)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if result != "hello" {
+			t.Errorf("expected %q but got %#v", "hello", result)
+		}
+	})
+
+	t.Run("pointer receiver", func(t *testing.T) {
+		c := PointerUnstructuredConverterWithError{val: int64(42)}
+		rv := reflect.ValueOf(&c).Elem()
+		entry := TypeReflectEntryOf(rv.Type())
+		if !entry.CanConvertToUnstructured() {
+			t.Fatal("expected CanConvertToUnstructured to be true")
+		}
+		result, err := entry.ToUnstructured(rv)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if result != int64(42) {
+			t.Errorf("expected %v but got %#v", int64(42), result)
+		}
+	})
+
+	t.Run("error with value receiver", func(t *testing.T) {
+		convertErr := errors.New("cannot convert")
+		c := ValueUnstructuredConverterWithError{err: convertErr}
+		rv := reflect.ValueOf(c)
+		_, err := TypeReflectEntryOf(rv.Type()).ToUnstructured(rv)
+		if err == nil {
+			t.Fatal("expected error but got nil")
+		}
+		if err != convertErr {
+			t.Fatalf("expected error %q but got %q", convertErr, err)
+		}
+	})
+
+	t.Run("error with pointer receiver", func(t *testing.T) {
+		convertErr := errors.New("cannot convert")
+		c := PointerUnstructuredConverterWithError{err: convertErr}
+		rv := reflect.ValueOf(&c).Elem()
+		_, err := TypeReflectEntryOf(rv.Type()).ToUnstructured(rv)
+		if err == nil {
+			t.Fatal("expected error but got nil")
+		}
+		if err != convertErr {
+			t.Fatalf("expected error %q but got %q", convertErr, err)
+		}
+	})
+
+	t.Run("precedence over UnstructuredConverter", func(t *testing.T) {
+		c := ValueUnstructuredConverterWithAndWithoutError{}
+		rv := reflect.ValueOf(c)
+		result, err := TypeReflectEntryOf(rv.Type()).ToUnstructured(rv)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if result != "ToUnstructuredWithError" {
+			t.Errorf("expected %q but got %#v", "from-fallible", result)
+		}
+	})
+
+	t.Run("nil-valued pointer receiver returns nil", func(t *testing.T) {
+		var c *PointerUnstructuredConverterWithError
+		rv := reflect.ValueOf(c)
+		result, err := TypeReflectEntryOf(rv.Type()).ToUnstructured(rv)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if result != nil {
+			t.Errorf("expected nil but got %#v", result)
+		}
+	})
 }
 
 func TestToUnstructured(t *testing.T) {
@@ -139,6 +283,22 @@ func TestTimeToUnstructured(t *testing.T) {
 				t.Errorf("expected %#v but got %#v", tc.Expected, result)
 			}
 		})
+	}
+}
+
+func TestPointerUnstructuredConverterToUnstructured(t *testing.T) {
+	c := PointerUnstructuredConverter{val: "hello"}
+	rv := reflect.ValueOf(&c).Elem()
+	entry := TypeReflectEntryOf(rv.Type())
+	if !entry.CanConvertToUnstructured() {
+		t.Fatal("expected CanConvertToUnstructured to be true")
+	}
+	result, err := entry.ToUnstructured(rv)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result != "hello" {
+		t.Errorf("expected %q but got %#v", "hello", result)
 	}
 }
 


### PR DESCRIPTION
The existing UnstructuredConverter interface method signature `ToUnstructured() any` can only be
implemented by types that are unconditionally convertible to unstructured. However, types that
implement json.Marshaler (`MarshalJSON() ([]byte, error)`) are _conditionally_ convertible to
unstructured via JSON. For example, a value of k8s.io/apimachinery/pkg/util/intstr.IntOrString only
has a JSON representation when its Type fields is one of "Int" or "String".
