### PR TITLE
Add Frozen() to fieldpath.Set

### DIFF
--- a/fieldpath/element.go
+++ b/fieldpath/element.go
@@ -227,6 +227,14 @@ func KeyByFields(nameValues ...interface{}) *value.FieldList {
 // TODO: serialize as a list.
 type PathElementSet struct {
 	members sortedPathElements
+
+	// frozen marks the PathElementSet as read-only.
+	frozen bool
+}
+
+// freeze marks the set read-only.
+func (s *PathElementSet) freeze() {
+	s.frozen = true
 }
 
 func MakePathElementSet(size int) PathElementSet {
@@ -254,7 +262,11 @@ func (s PathElementSet) Copy() PathElementSet {
 }
 
 // Insert adds pe to the set.
+// Insert panics if the set has been frozen.
 func (s *PathElementSet) Insert(pe PathElement) {
+	if s.frozen {
+		panic("fieldpath: Insert called on a frozen Set")
+	}
 	loc, found := slices.BinarySearchFunc(s.members, pe, func(a, b PathElement) int {
 		return a.Compare(b)
 	})

--- a/fieldpath/serialize.go
+++ b/fieldpath/serialize.go
@@ -165,7 +165,11 @@ func (s *Set) emitContentsV1(includeSelf bool, stream *jsoniter.Stream, r *reusa
 }
 
 // FromJSON clears s and reads a JSON formatted set structure.
+// FromJSON panics if the Set has been frozen.
 func (s *Set) FromJSON(r io.Reader) error {
+	if s.frozen {
+		panic("fieldpath: FromJSON called on a frozen Set")
+	}
 	// The iterator pool is completely useless for memory management, grrr.
 	iter := jsoniter.Parse(jsoniter.ConfigCompatibleWithStandardLibrary, r, 4096)
 

--- a/fieldpath/set.go
+++ b/fieldpath/set.go
@@ -38,6 +38,9 @@ type Set struct {
 	// members of the set. Appearance in this list does not imply membership.
 	// Note: this is a tree, not an arbitrary graph.
 	Children SetNodeMap
+
+	// frozen marks this Set as read-only.
+	frozen bool
 }
 
 // NewSet makes a set from a list of paths.
@@ -51,6 +54,7 @@ func NewSet(paths ...Path) *Set {
 
 // Copy returns a copy of the Set.
 // This is not a full deep copy as any contained value.Value is not copied.
+// The returned Set is not frozen.
 func (s *Set) Copy() *Set {
 	return &Set{
 		Members:  s.Members.Copy(),
@@ -58,9 +62,30 @@ func (s *Set) Copy() *Set {
 	}
 }
 
+// Freeze marks the Set as read-only. Calling functions that mutate state
+// results in a panic. The Members and Children are also frozen.
+//
+// Freeze only guards the set's structure. It does not deep-copy the contained
+// PathElements and Values as these types are expected to be treated as
+// immutable across structured-merge-diff.
+//
+// Freeze is not airtight. It is designed to ensure well-behaved consumers of
+// this API do not accidentally mutate Sets that are intended to be read-only
+// but it does not prevent all possible forms of mutation.
+func (s *Set) Freeze() *Set {
+	s.frozen = true
+	s.Members.freeze()
+	s.Children.freeze()
+	return s
+}
+
 // Insert adds the field identified by `p` to the set. Important: parent fields
 // are NOT added to the set; if that is desired, they must be added separately.
+// Insert panics if the Set has been frozen.
 func (s *Set) Insert(p Path) {
+	if s.frozen {
+		panic("fieldpath: Insert called on a frozen Set")
+	}
 	if len(p) == 0 {
 		// Zero-length path identifies the entire object; we don't
 		// track top-level ownership.
@@ -465,6 +490,17 @@ type setNode struct {
 // SetNodeMap is a map of PathElement to subset.
 type SetNodeMap struct {
 	members sortedSetNode
+
+	// frozen marks the SetNodeMap as read-ohnly.
+	frozen bool
+}
+
+// freeze marks the map read-only and freezes every child Set.
+func (s *SetNodeMap) freeze() {
+	s.frozen = true
+	for i := range s.members {
+		s.members[i].set.Freeze()
+	}
 }
 
 type sortedSetNode []setNode
@@ -486,7 +522,11 @@ func (s *SetNodeMap) Copy() SetNodeMap {
 }
 
 // Descend adds pe to the set if necessary, returning the associated subset.
+// Descend panics if the set has been frozen.
 func (s *SetNodeMap) Descend(pe PathElement) *Set {
+	if s.frozen {
+		panic("fieldpath: Descend called on a frozen Set")
+	}
 	loc, found := slices.BinarySearchFunc(s.members, pe, func(a setNode, b PathElement) int {
 		return a.pathElement.Compare(b)
 	})

--- a/fieldpath/set_test.go
+++ b/fieldpath/set_test.go
@@ -20,6 +20,7 @@ import (
 	"bytes"
 	"fmt"
 	"math/rand"
+	"strings"
 	"testing"
 
 	"sigs.k8s.io/structured-merge-diff/v6/schema"
@@ -1202,4 +1203,219 @@ func TestFilterByPattern(t *testing.T) {
 			}
 		})
 	}
+}
+
+func mustPanic(t *testing.T, wantSubstr string, fn func()) {
+	t.Helper()
+	defer func() {
+		r := recover()
+		if r == nil {
+			t.Fatalf("expected panic containing %q, got none", wantSubstr)
+		}
+		if msg, ok := r.(string); !ok || !strings.Contains(msg, wantSubstr) {
+			t.Fatalf("expected panic containing %q, got %v", wantSubstr, r)
+		}
+	}()
+	fn()
+}
+
+func TestFreezeReturnsSelf(t *testing.T) {
+	s := NewSet(MakePathOrDie("spec", "replicas"))
+	if got := s.Freeze(); got != s {
+		t.Errorf("Freeze should return the same Set")
+	}
+	if got := s.Freeze(); got != s {
+		t.Errorf("Freeze should be idempotent and return the same Set")
+	}
+}
+
+func TestFrozenSetInsertPanics(t *testing.T) {
+	s := NewSet(MakePathOrDie("spec", "replicas"))
+	s.Freeze()
+	mustPanic(t, "frozen Set", func() {
+		s.Insert(MakePathOrDie("spec", "paused"))
+	})
+}
+
+func TestFreezeRecursesToChildren(t *testing.T) {
+	s := NewSet(MakePathOrDie("spec", "replicas"))
+	s.Freeze()
+	child, ok := s.Children.Get(MakePathOrDie("spec")[0])
+	if !ok {
+		t.Fatal("expected a child set for \"spec\"")
+	}
+	mustPanic(t, "frozen Set", func() {
+		child.Insert(MakePathOrDie("paused"))
+	})
+}
+
+func TestFrozenSetReadsDoNotPanic(t *testing.T) {
+	s := NewSet(
+		MakePathOrDie("spec", "replicas"),
+		MakePathOrDie("spec", "paused"),
+	)
+	s.Freeze()
+	other := NewSet(MakePathOrDie("spec", "replicas"))
+
+	// Reads and non-mutating set algebra must not panic on a frozen Set.
+	_ = s.Has(MakePathOrDie("spec", "replicas"))
+	_ = s.Size()
+	_ = s.Empty()
+	_ = s.Leaves()
+	_ = s.Union(other)
+	_ = s.Intersection(other)
+	_ = s.Difference(other)
+	s.Iterate(func(Path) {})
+	if !s.Equals(s.Copy()) {
+		t.Errorf("frozen set should equal its copy")
+	}
+}
+
+func TestCopyOfFrozenSetIsMutable(t *testing.T) {
+	s := NewSet(MakePathOrDie("spec", "replicas"))
+	s.Freeze()
+	c := s.Copy()
+	// Must not panic: a copy is never frozen.
+	c.Insert(MakePathOrDie("spec", "paused"))
+	if !c.Has(MakePathOrDie("spec", "paused")) {
+		t.Errorf("expected inserted path in mutable copy")
+	}
+	if s.Has(MakePathOrDie("spec", "paused")) {
+		t.Errorf("mutating the copy must not affect the frozen original")
+	}
+}
+
+// pe is a small helper to extract a single PathElement.
+func pe(parts ...interface{}) PathElement {
+	p := MakePathOrDie(parts...)
+	return p[len(p)-1]
+}
+
+func TestFrozenMembersInsertPanics(t *testing.T) {
+	s := NewSet(MakePathOrDie("a")).Freeze()
+	mustPanic(t, "frozen Set", func() {
+		s.Members.Insert(pe("evil"))
+	})
+	if s.Has(MakePathOrDie("evil")) {
+		t.Errorf("frozen set was mutated despite the guard")
+	}
+}
+
+func TestFrozenChildrenDescendPanics(t *testing.T) {
+	s := NewSet(MakePathOrDie("a", "b")).Freeze()
+	mustPanic(t, "frozen Set", func() {
+		s.Children.Descend(pe("evil"))
+	})
+	if s.Has(MakePathOrDie("evil")) {
+		t.Errorf("frozen set was mutated despite the guard")
+	}
+}
+
+func TestFrozenSetFromJSONPanics(t *testing.T) {
+	s := NewSet(MakePathOrDie("a", "b")).Freeze()
+	other, err := NewSet(MakePathOrDie("x")).ToJSON()
+	if err != nil {
+		t.Fatal(err)
+	}
+	mustPanic(t, "frozen Set", func() {
+		_ = s.FromJSON(bytes.NewReader(other))
+	})
+	if !s.Has(MakePathOrDie("a", "b")) || s.Has(MakePathOrDie("x")) {
+		t.Errorf("frozen set was overwritten despite the guard")
+	}
+}
+
+func TestFrozenChildFromWithPrefixIsFrozen(t *testing.T) {
+	s := NewSet(MakePathOrDie("a", "b")).Freeze()
+	child := s.WithPrefix(pe("a"))
+	mustPanic(t, "frozen Set", func() { child.Members.Insert(pe("evil")) })
+	mustPanic(t, "frozen Set", func() { child.Children.Descend(pe("evil")) })
+	mustPanic(t, "frozen Set", func() { child.Insert(MakePathOrDie("evil")) })
+	if s.Has(MakePathOrDie("a", "evil")) {
+		t.Errorf("frozen subtree was mutated via WithPrefix escape")
+	}
+}
+
+func TestFrozenChildFromChildrenGetIsFrozen(t *testing.T) {
+	s := NewSet(MakePathOrDie("a", "b")).Freeze()
+	child, ok := s.Children.Get(pe("a"))
+	if !ok {
+		t.Fatal("expected child for \"a\"")
+	}
+	mustPanic(t, "frozen Set", func() { child.Members.Insert(pe("evil")) })
+}
+
+func TestFrozenSetAlgebraSharesFrozenChildren(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		op   func(s *Set) *Set
+	}{
+		{"Union", func(s *Set) *Set { return s.Union(NewSet()) }},
+		{"Difference", func(s *Set) *Set { return s.Difference(NewSet()) }},
+		{"RecursiveDifference", func(s *Set) *Set { return s.RecursiveDifference(NewSet()) }},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			s := NewSet(MakePathOrDie("a", "b")).Freeze()
+			r := tc.op(s)
+			shared, ok := r.Children.Get(pe("a"))
+			if !ok {
+				t.Fatalf("%s result lost child \"a\"", tc.name)
+			}
+			mustPanic(t, "frozen Set", func() { shared.Members.Insert(pe("evil")) })
+			if s.Has(MakePathOrDie("a", "evil")) {
+				t.Errorf("%s let the frozen original be mutated via a shared child", tc.name)
+			}
+		})
+	}
+}
+
+func TestFrozenFilterWildcardIdentityIsFrozen(t *testing.T) {
+	s := NewSet(MakePathOrDie("a", "b")).Freeze()
+	r := s.FilterIncludeMatches(MakePrefixMatcherOrDie()) // wildcard -> returns s by identity
+	mustPanic(t, "frozen Set", func() { r.Members.Insert(pe("evil")) })
+	if s.Has(MakePathOrDie("evil")) {
+		t.Errorf("frozen set mutated via FilterIncludeMatches identity return")
+	}
+}
+
+func TestFreezeRecursesToArbitraryDepth(t *testing.T) {
+	s := NewSet(MakePathOrDie("a", "b", "c", "d")).Freeze()
+	deep := s.WithPrefix(pe("a")).WithPrefix(pe("b")).WithPrefix(pe("c"))
+	mustPanic(t, "frozen Set", func() { deep.Members.Insert(pe("evil")) })
+	mustPanic(t, "frozen Set", func() { deep.Children.Descend(pe("evil")) })
+}
+
+func TestCopyOfFrozenSetIsDeeplyMutable(t *testing.T) {
+	s := NewSet(MakePathOrDie("a", "b")).Freeze()
+	c := s.Copy()
+	ca := c.Children.Descend(pe("a")) // must not panic
+	ca.Insert(MakePathOrDie("new"))
+	if !c.Has(MakePathOrDie("a", "new")) {
+		t.Errorf("expected deep mutation of copy to take effect")
+	}
+	if s.Has(MakePathOrDie("a", "new")) {
+		t.Errorf("deep mutation of copy leaked into the frozen original")
+	}
+}
+
+func TestFrozenSetReadAlgebraDoesNotPanic(t *testing.T) {
+	s := NewSet(
+		MakePathOrDie("spec", "replicas"),
+		MakePathOrDie("spec", "paused"),
+		MakePathOrDie("meta", "name"),
+	).Freeze()
+	other := NewSet(MakePathOrDie("spec", "replicas"))
+	// None of these may panic
+	_ = s.Union(other)
+	_ = s.Intersection(other)
+	_ = s.Difference(other)
+	_ = s.RecursiveDifference(other)
+	_ = s.Leaves()
+	_ = s.WithPrefix(pe("spec"))
+	_ = s.FilterIncludeMatches(MakePrefixMatcherOrDie())
+	s.Iterate(func(Path) {})
+	_ = s.Has(MakePathOrDie("spec", "replicas"))
+	_ = s.Size()
+	_ = s.Empty()
+	_ = s.String()
 }


### PR DESCRIPTION
`fieldpath.Set` is almost exclusively used as a copy-on-write structure throughout the SSA codebase.

This another layer of protection against accidental in-place mutations. It is not airtight, but when combined with the existing conventions in this repo to treat `PathElement` or `Value` as read-only values, and to only modify `fieldpath.Set` through receiver functions, it offers good protection accidental mutation, particularly by well behaved consumers.

This is being added for https://github.com/kubernetes/kubernetes/pull/139835 which relies on `VersionedSet` being frozen for correctness.