### PR TITLE
Revert #306 and #332 but keep Nullable schema field

### DIFF
--- a/merge/multiple_appliers_test.go
+++ b/merge/multiple_appliers_test.go
@@ -1061,14 +1061,14 @@ func TestMultipleAppliersNestedType(t *testing.T) {
 				},
 			},
 			Object: `
-			mapOfMapsRecursive:
-			  a: {}
-			  c:
-			    d:
-			      e:
-			        f:
-			          g:
-		`,
+				mapOfMapsRecursive:
+				  a:
+				  c:
+				    d:
+				      e:
+				        f:
+				          g:
+			`,
 			APIVersion: "v1",
 			Managed: fieldpath.ManagedFields{
 				"apply-one": fieldpath.NewVersionedSet(
@@ -1187,13 +1187,13 @@ func TestMultipleAppliersDeducedType(t *testing.T) {
 				},
 			},
 			Object: `
-			a: {}
-			c:
-			  d:
-			    e:
-			      f:
-			        g:
-		`,
+				a:
+				c:
+				  d:
+				    e:
+				      f:
+				        g:
+			`,
 			APIVersion: "v1",
 			Managed: fieldpath.ManagedFields{
 				"apply-two": fieldpath.NewVersionedSet(

--- a/merge/nested_test.go
+++ b/merge/nested_test.go
@@ -47,10 +47,6 @@ var nestedTypeParser = func() Parser {
       - name: struct
         type:
           namedType: struct
-      - name: nullableStruct
-        type:
-          namedType: struct
-          nullable: true
 - name: struct
   map:
     fields:
@@ -558,47 +554,13 @@ func TestUpdateNestedType(t *testing.T) {
 				},
 			},
 			Object: `
-			struct: {}
-		`,
-			APIVersion: "v1",
-			Managed: fieldpath.ManagedFields{
-				"default": fieldpath.NewVersionedSet(
-					_NS(
-						_P("struct"),
-					),
-					"v1",
-					true,
-				),
-			},
-		},
-		"nullableStruct_apply_remove_dangling": {
-			Ops: []Operation{
-				Apply{
-					Manager: "default",
-					Object: `
-						nullableStruct:
-						  name: a
-					`,
-					APIVersion: "v1",
-				},
-				Apply{
-					Manager: "default",
-					Object: `
-						nullableStruct:
-					`,
-					APIVersion: "v1",
-				},
-			},
-			// Unlike the non-nullable "struct" case (which is preserved as {}),
-			// a nullable field emptied by removal collapses back to null.
-			Object: `
-				nullableStruct: null
+				struct:
 			`,
 			APIVersion: "v1",
 			Managed: fieldpath.ManagedFields{
 				"default": fieldpath.NewVersionedSet(
 					_NS(
-						_P("nullableStruct"),
+						_P("struct"),
 					),
 					"v1",
 					true,

--- a/schema/elements.go
+++ b/schema/elements.go
@@ -64,10 +64,7 @@ type TypeRef struct {
 	ElementRelationship *ElementRelationship `yaml:"elementRelationship,omitempty"`
 
 	// Nullable indicates that an explicit null is a valid value,
-	// corresponding to OpenAPI's `nullable: true`. During removal,
-	// empty map/list values are handled differently if this is true.
-	// When true, an empty map or slice becomes null.
-	// When false, an empty map or slice is preserved as an empty container (`{}`/`[]`).
+	// corresponding to OpenAPI's `nullable: true`.
 	Nullable bool `yaml:"nullable,omitempty"`
 }
 

--- a/typed/remove.go
+++ b/typed/remove.go
@@ -26,7 +26,6 @@ type removingWalker struct {
 	toRemove      *fieldpath.Set
 	allocator     value.Allocator
 	shouldExtract bool
-	nullable      bool
 }
 
 // removeItemsWithSchema will walk the given value and look for items from the toRemove set.
@@ -41,7 +40,6 @@ func removeItemsWithSchema(val value.Value, toRemove *fieldpath.Set, schema *sch
 		toRemove:      toRemove,
 		allocator:     value.NewFreelistAllocator(),
 		shouldExtract: shouldExtract,
-		nullable:      typeRef.Nullable,
 	}
 	resolveSchema(schema, typeRef, val, w)
 	return value.NewValueInterface(w.out)
@@ -77,7 +75,6 @@ func (w *removingWalker) doList(t *schema.List) (errs ValidationErrors) {
 	}
 
 	var newItems []interface{}
-	hadMatches := false
 	iter := l.RangeUsing(w.allocator)
 	defer w.allocator.Free(iter)
 	for iter.Next() {
@@ -101,27 +98,12 @@ func (w *removingWalker) doList(t *schema.List) (errs ValidationErrors) {
 				continue
 			}
 			if isPrefixMatch {
-				// Removing nested items within this list item and preserve if it becomes empty
-				hadMatches = true
-				wasMap := item.IsMap()
-				wasList := item.IsList()
 				item = removeItemsWithSchema(item, w.toRemove.WithPrefix(pe), w.schema, t.ElementType, w.shouldExtract)
-				// If item returned null but we're removing items within the structure(not the item itself),
-				// preserve the empty container structure unless the type is nullable.
-				if item.IsNull() && !w.shouldExtract && !t.ElementType.Nullable {
-					if wasMap {
-						item = value.NewValueInterface(map[string]interface{}{})
-					} else if wasList {
-						item = value.NewValueInterface([]interface{}{})
-					}
-				}
 			}
 			newItems = append(newItems, item.Unstructured())
 		}
 	}
-	// Preserve empty lists (non-nil) instead of converting to null when items were matched and removed,
-	// unless the type is nullable.
-	if len(newItems) > 0 || (hadMatches && !w.shouldExtract && !w.nullable) {
+	if len(newItems) > 0 {
 		w.out = newItems
 	}
 	return nil
@@ -159,7 +141,6 @@ func (w *removingWalker) doMap(t *schema.Map) ValidationErrors {
 	}
 
 	newMap := map[string]interface{}{}
-	hadMatches := false
 	m.Iterate(func(k string, val value.Value) bool {
 		pe := fieldpath.PathElement{FieldName: &k}
 		path, _ := fieldpath.MakePath(pe)
@@ -177,19 +158,7 @@ func (w *removingWalker) doMap(t *schema.Map) ValidationErrors {
 			return true
 		}
 		if subset := w.toRemove.WithPrefix(pe); !subset.Empty() {
-			hadMatches = true
-			wasMap := val.IsMap()
-			wasList := val.IsList()
 			val = removeItemsWithSchema(val, subset, w.schema, fieldType, w.shouldExtract)
-			// If val returned null but we're removing items within the structure (not the field itself),
-			// preserve the empty container structure unless the type is nullable.
-			if val.IsNull() && !w.shouldExtract && !fieldType.Nullable {
-				if wasMap {
-					val = value.NewValueInterface(map[string]interface{}{})
-				} else if wasList {
-					val = value.NewValueInterface([]interface{}{})
-				}
-			}
 		} else {
 			// don't save values not on the path when we shouldExtract.
 			if w.shouldExtract {
@@ -199,9 +168,7 @@ func (w *removingWalker) doMap(t *schema.Map) ValidationErrors {
 		newMap[k] = val.Unstructured()
 		return true
 	})
-	// Preserve empty maps (non-nil) instead of converting to null when items were matched and removed,
-	// unless the type is nullable.
-	if len(newMap) > 0 || (hadMatches && !w.shouldExtract && !w.nullable) {
+	if len(newMap) > 0 {
 		w.out = newMap
 	}
 	return nil

--- a/typed/remove_test.go
+++ b/typed/remove_test.go
@@ -185,36 +185,6 @@ var nestedTypesSchema = `types:
       - name: struct
         type:
           namedType: struct
-      - name: nullableStruct
-        type:
-          namedType: struct
-          nullable: true
-      - name: nullableMapOfMapsRecursive
-        type:
-          namedType: mapOfMapsRecursive
-          nullable: true
-      - name: list
-        type:
-          namedType: list
-      - name: nullableList
-        type:
-          namedType: list
-          nullable: true
-      - name: mapOfNullableLists
-        type:
-          namedType: mapOfNullableLists
-      - name: listOfNullableMaps
-        type:
-          namedType: listOfNullableMaps
-      - name: listOfNullableLists
-        type:
-          namedType: listOfNullableLists
-      - name: listOfMapsWithDefault
-        type:
-          namedType: listOfMapsWithDefault
-      - name: listOfNullableMapsWithDefault
-        type:
-          namedType: listOfNullableMapsWithDefault
 - name: struct
   map:
     fields:
@@ -267,12 +237,6 @@ var nestedTypesSchema = `types:
     elementType:
       namedType: list
     elementRelationship: associative
-- name: mapOfNullableLists
-  map:
-    elementType:
-      namedType: list
-      nullable: true
-    elementRelationship: associative
 - name: mapOfMaps
   map:
     elementType:
@@ -283,72 +247,6 @@ var nestedTypesSchema = `types:
     elementType:
       namedType: mapOfMapsRecursive
     elementRelationship: associative
-- name: nullableList
-  list:
-    elementType:
-      scalar: string
-    elementRelationship: associative
-- name: listOfNullableMaps
-  list:
-    elementType:
-      map:
-        fields:
-        - name: name
-          type:
-            scalar: string
-        - name: value
-          type:
-            namedType: map
-            nullable: true
-    elementRelationship: associative
-    keys:
-    - name
-- name: listOfNullableLists
-  list:
-    elementType:
-      map:
-        fields:
-        - name: name
-          type:
-            scalar: string
-        - name: value
-          type:
-            namedType: list
-            nullable: true
-    elementRelationship: associative
-    keys:
-    - name
-- name: listOfMapsWithDefault
-  list:
-    elementType:
-      map:
-        fields:
-        - name: name
-          type:
-            scalar: string
-          default: "default"
-        - name: value
-          type:
-            scalar: string
-    elementRelationship: associative
-    keys:
-    - name
-- name: listOfNullableMapsWithDefault
-  list:
-    elementType:
-      map:
-        fields:
-        - name: name
-          type:
-            scalar: string
-          default: "default"
-        - name: value
-          type:
-            scalar: string
-      nullable: true
-    elementRelationship: associative
-    keys:
-    - name
 `
 
 var removeCases = []removeTestCase{{
@@ -383,7 +281,7 @@ var removeCases = []removeTestCase{{
 	quadruplets: []removeQuadruplet{{
 		`{"setBool":[false]}`,
 		_NS(_P("setBool", _V(false))),
-		`{"setBool":[]}`,
+		`{"setBool":null}`,
 		`{"setBool":[false]}`,
 	}, {
 		`{"setBool":[false]}`,
@@ -773,7 +671,7 @@ var removeCases = []removeTestCase{{
 		_NS(
 			_P("mapOfMapsRecursive", "a"),
 		),
-		`{"mapOfMapsRecursive":{}}`,
+		`{"mapOfMapsRecursive"}`,
 		`{"mapOfMapsRecursive": {"a":null}}`,
 	}, {
 		// second-level map
@@ -781,7 +679,7 @@ var removeCases = []removeTestCase{{
 		_NS(
 			_P("mapOfMapsRecursive", "a", "b"),
 		),
-		`{"mapOfMapsRecursive":{"a":{}}}`,
+		`{"mapOfMapsRecursive":{"a":null}}`,
 		`{"mapOfMapsRecursive": {"a":{"b":null}}}`,
 	}, {
 		// third-level map
@@ -789,7 +687,7 @@ var removeCases = []removeTestCase{{
 		_NS(
 			_P("mapOfMapsRecursive", "a", "b", "c"),
 		),
-		`{"mapOfMapsRecursive":{"a":{"b":{}}}}`,
+		`{"mapOfMapsRecursive":{"a":{"b":null}}}`,
 		`{"mapOfMapsRecursive": {"a":{"b":{"c":null}}}}`,
 	}, {
 		// empty list
@@ -823,110 +721,6 @@ var removeCases = []removeTestCase{{
 		),
 		``,
 		`{"mapOfMaps": null}`,
-	}, {
-		// non-nullable struct emptied by removal is preserved as an empty map
-		`{"struct": {"name": "a"}}`,
-		_NS(
-			_P("struct", "name"),
-		),
-		`{"struct": {}}`,
-		`{"struct": {"name": "a"}}`,
-	}, {
-		// nullable struct emptied by removal collapses to null instead of {}
-		`{"nullableStruct": {"name": "a"}}`,
-		_NS(
-			_P("nullableStruct", "name"),
-		),
-		`{"nullableStruct": null}`,
-		`{"nullableStruct": {"name": "a"}}`,
-	}, {
-		// nullable map emptied by removal of its only key collapses to null
-		`{"nullableMapOfMapsRecursive": {"a": {"b": {"c": null}}}}`,
-		_NS(
-			_P("nullableMapOfMapsRecursive", "a"),
-		),
-		`{"nullableMapOfMapsRecursive": null}`,
-		`{"nullableMapOfMapsRecursive": {"a": null}}`,
-	}, {
-		// non-nullable list emptied by removal is preserved as an empty list
-		`{"list": ["a"]}`,
-		_NS(
-			_P("list", _V("a")),
-		),
-		`{"list": []}`,
-		`{"list": ["a"]}`,
-	}, {
-		// nullable list emptied by removal collapses to null instead of []
-		`{"nullableList": ["a"]}`,
-		_NS(
-			_P("nullableList", _V("a")),
-		),
-		`{"nullableList": null}`,
-		`{"nullableList": ["a"]}`,
-	}, {
-		// non-nullable list inside a map emptied by removal is preserved as []
-		`{"mapOfLists": {"a": ["b"]}}`,
-		_NS(
-			_P("mapOfLists", "a", _V("b")),
-		),
-		`{"mapOfLists": {"a": []}}`,
-		`{"mapOfLists": {"a": ["b"]}}`,
-	}, {
-		// nullable list inside a map emptied by removal collapses to null instead of []
-		`{"mapOfNullableLists": {"a": ["b"]}}`,
-		_NS(
-			_P("mapOfNullableLists", "a", _V("b")),
-		),
-		`{"mapOfNullableLists": {"a": null}}`,
-		`{"mapOfNullableLists": {"a": ["b"]}}`,
-	}, {
-		// non-nullable list of maps with element emptied by removal
-		`{"listOfMaps": [{"name": "a", "value": {"b": "c"}}]}`,
-		_NS(
-			_P("listOfMaps", _KBF("name", "a"), "value", "b"),
-		),
-		`{"listOfMaps": [{"name": "a", "value": {}}]}`,
-		`unparseable`,
-	}, {
-		// non-nullable list of lists with element emptied by removal
-		`{"listOfLists": [{"name": "a", "value": ["b"]}]}`,
-		_NS(
-			_P("listOfLists", _KBF("name", "a"), "value", _V("b")),
-		),
-		`{"listOfLists": [{"name": "a", "value": []}]}`,
-		`unparseable`,
-	}, {
-		// list element with nullable map value emptied by removal collapses to null
-		`{"listOfNullableMaps": [{"name": "a", "value": {"b": "c"}}]}`,
-		_NS(
-			_P("listOfNullableMaps", _KBF("name", "a"), "value", "b"),
-		),
-		`{"listOfNullableMaps": [{"name": "a", "value": null}]}`,
-		`unparseable`,
-	}, {
-		// list element with nullable list value emptied by removal collapses to null
-		`{"listOfNullableLists": [{"name": "a", "value": ["b"]}]}`,
-		_NS(
-			_P("listOfNullableLists", _KBF("name", "a"), "value", _V("b")),
-		),
-		`{"listOfNullableLists": [{"name": "a", "value": null}]}`,
-		`unparseable`,
-	}, {
-		// non-nullable map element in list emptied by removal preserves {}
-		`{"listOfMapsWithDefault": [{}]}`,
-		_NS(
-			_P("listOfMapsWithDefault", _KBF("name", "default"), "value"),
-		),
-		`{"listOfMapsWithDefault": [{}]}`,
-		`unparseable`,
-	}, {
-		// nullable map element in list emptied by removal collapses to null, making associative list invalid
-		`{"listOfNullableMapsWithDefault": [{}]}`,
-		_NS(
-			_P("listOfNullableMapsWithDefault", _KBF("name", "default"), "value"),
-		),
-		`unparseable`, // unparseable because associative list with keys may not have a null element
-		`unparseable`,
 	}},
 }}
 


### PR DESCRIPTION
This is the first step in plan to fix the regression described in https://github.com/kubernetes-sigs/structured-merge-diff/issues/331

This reverts #306 and most of #332 but keeps the nullable field since that is consumed by kube-openapi today.