### PR TITLE
Fix 32-bit int overflow in fieldpath set_test.go

### DIFF
--- a/fieldpath/set_test.go
+++ b/fieldpath/set_test.go
@@ -19,6 +19,7 @@ package fieldpath_test
 import (
 	"bytes"
 	"fmt"
+	"math"
 	"math/rand"
 	"testing"
 
@@ -99,7 +100,7 @@ var randomPathMaker = randomPathAlphabet(MakePathOrDie(
 	_V(`\`),
 	_V(`\\`),
 	// Indices
-	1, 2, 3, 4, 0, 5, 100, 2147483648,
+	1, 2, 3, 4, 0, 5, 100, math.MaxInt,
 ))
 
 func BenchmarkFieldSet(b *testing.B) {


### PR DESCRIPTION
How to reproduce:

```shell
GOARCH=386 go vet ./fieldpath/
```

The random path alphabet in `TestFieldSet` used the untyped constant `2147483648` (2^31) as a list index argument to MakePathOrDie.

On 32-bit platforms (GOARCH=386, arm) Go's int is 32-bit, so 2^31 overflows int and the fieldpath test package fails to compile.

Use `math.MaxInt` instead. On 64-bit platforms this exceeds **2^31**, so it still exercises an index beyond the 32-bit range (the original intent); on 32-bit platforms it is the largest representable int, so the package compiles on every architecture.